### PR TITLE
Reviewed section-Renaming and unification of configuration files

### DIFF
--- a/docs/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.7.0.0.Final-section.adoc
+++ b/docs/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.7.0.0.Final-section.adoc
@@ -1001,8 +1001,9 @@ The KieSession option to control when timed rules have to be automatically execu
 
 == Renaming and unification of configuration files
 
-In Drools 6.x default Drools configuration properties were spread in 2 distinct files: `drools.default.rulebase.conf` which
-was in the META-INF folder of drools-core and `drools.default.packagebuilder.conf` stored in the same folder but in drools-compiler.
-These 2 files are now unified in a single one named `kie.default.properties.conf` contained in the META-INF folder of drools-core.
-If you want to override the default values of those properties or add your own you can put them in a file called `kie.properties.conf`
-placed in the META-INF folder of your project.
+In Drools 6.x, the default Drools configuration properties were configured in two distinct files:
+*  `drools.default.rulebase.conf` located in the META-INF folder of drools-core 
+*  `drools.default.packagebuilder.conf` located in the META-INF folder of of drools-compiler
+
+In Drools 7.0.0, these files are unified into a single one named `kie.default.properties.conf`, located in the META-INF folder of drools-core.
+If you want to override the default values of these properties or add your own, you can put them in a file called `kie.properties.conf` located in the META-INF folder of your project.


### PR DESCRIPTION
Peer reviewed the last section of Release Notes 7.0.0: "Renaming and unification of configuration files".
Corrected minor language and structural changes.