### PR TITLE
Correction in the usage of possessive form

### DIFF
--- a/docs/shared-kie-docs/src/main/asciidoc/Workbench/ReleaseNotes/ReleaseNotesWorkbench.7.0.0.Final-section.adoc
+++ b/docs/shared-kie-docs/src/main/asciidoc/Workbench/ReleaseNotes/ReleaseNotesWorkbench.7.0.0.Final-section.adoc
@@ -11,7 +11,7 @@ Authoring now has a new design, with a better information organization. It's now
 
 [NOTE]
 ====
-The Library uses the Workbench's indexing. It is, therefore, *imperative* that existing index information is deleted so that the Workbench can rebuild them with the necessary information. Index information is stored in the ``.index`` folder within your application servers ``\bin`` folder (or as you may have configured otherwise with the ``org.uberfire.metadata.index.dir`` System Property).
+The Library uses the indexing of the Workbench. It is, therefore, *imperative* that existing index information is deleted so that the Workbench can rebuild them with the necessary information. Index information is stored in the ``.index`` folder within your application servers ``\bin`` folder (or as you may have configured otherwise with the ``org.uberfire.metadata.index.dir`` System Property).
 ====
 
 .Teams view


### PR DESCRIPTION
Minor correction on [PR #255 ](https://github.com/kiegroup/kie-docs/pull/255): The possessive form ('s- apostrophe 's' ) is used with only nouns referring to people.