### PR TITLE
Remove redundant character in attribute reference

### DIFF
--- a/docs/shared-kie-docs/src/main/asciidoc/Android/Android-chapter.adoc
+++ b/docs/shared-kie-docs/src/main/asciidoc/Android/Android-chapter.adoc
@@ -184,7 +184,7 @@ There are also some settings for merging various Drools XML files within the apk
     <plugin>
       <groupId>org.kie</groupId>
       <artifactId>kie-maven-plugin</artifactId>
-      <version>${revnumber}</version>
+      <version>{revnumber}</version>
       <executions>
         <execution>
           <id>compile-kbase</id>


### PR DESCRIPTION
AsciiDoc attributes are used like `{this}`. So the result before the fix was `<version>$8.0.0-SNAPSHOT</version>` with the extra, unwanted dollar sign.