### PR TITLE
Fix bad XML tag in deployment descriptor docs.

### DIFF
--- a/docs/jbpm-docs/src/main/asciidoc/RuntimeManagement-chapter.adoc
+++ b/docs/jbpm-docs/src/main/asciidoc/RuntimeManagement-chapter.adoc
@@ -398,8 +398,8 @@ If that is not enough deployment descriptor allows to manually specify classes t
 ----
 <remoteable-classes>
    ...
-   <remotable-class>org.jbpm.test.CustomClass</remotable-class>
-   <remotable-class>org.jbpm.test.AnotherCustomClass</remotable-class>
+   <remoteable-class>org.jbpm.test.CustomClass</remoteable-class>
+   <remoteable-class>org.jbpm.test.AnotherCustomClass</remoteable-class>
    ...
 </remoteable-classes>
 ----


### PR DESCRIPTION
* As per: [XSD](https://github.com/kiegroup/jbpm/blob/master/jbpm-runtime-manager/src/main/resources/deployment-descriptor.xsd#L76)