### PR TITLE
Fix links and typos

### DIFF
--- a/docs/drools-docs/src/main/asciidoc/index.adoc
+++ b/docs/drools-docs/src/main/asciidoc/index.adoc
@@ -19,9 +19,8 @@ ifndef::backend-pdf[]
 image::shared/images/droolsExpertLogo.png[align="center"]
 endif::[]
 
-////
+[discrete]
 = Welcome
-////
 
 Welcome and Release Notes
 
@@ -29,18 +28,16 @@ include::{shared-dir}/Welcome-chapter.adoc[leveloffset=+1]
 include::ReleaseNotes-chapter.adoc[leveloffset=+1]
 include::{shared-dir}/ReleaseInformation/CompatibilityMatrix-chapter.adoc[leveloffset=+1]
 
-////
+[discrete]
 = KIE
-////
 
 KIE is the shared core for Drools and jBPM. It provides a unified methodology and programming model for
 building, deploying and utilizing resources.
 
 include::{shared-dir}/KIE/KIE-chapter.adoc[leveloffset=+1]
 
-////
+[discrete]
 = Drools Runtime and Language
-////
 
 Drools is a powerful Hybrid Reasoning System.
 
@@ -52,9 +49,8 @@ include::ComplexEventProcessing-chapter.adoc[leveloffset=+1]
 include::DMN-chapter.adoc[leveloffset=+1]
 include::ExperimentalFeatures-chapter.adoc[leveloffset=+1]
 
-////
+[discrete]
 = Drools Integration
-////
 
 Integration Documentation
 
@@ -67,9 +63,8 @@ include::{shared-dir}/Camel/Camel-chapter.adoc[leveloffset=+1]
 include::{shared-dir}/DroolsServer/DroolsServer-chapter.adoc[leveloffset=+1]
 include::{shared-dir}/RHQ/RHQ-chapter.adoc[leveloffset=+1]
 
-////
+[discrete]
 = Drools Workbench
-////
 
 The Drools workbench is built with the UberFire framework and uses the Guvnor plugin. Drools provides an
 additional rich set of plugins for rule authoring metaphors.
@@ -79,17 +74,15 @@ include::AuthoringAssets-chapter.adoc[leveloffset=+1]
 include::{shared-dir}/Workbench/WorkbenchIntegration-chapter.adoc[leveloffset=+1]
 include::{shared-dir}/Workbench/WorkbenchHighAvailability-chapter.adoc[leveloffset=+1]
 
-////
+[discrete]
 = KIE Server
-////
 
 The KIE Server is a standalone execution server for rules.
 
 include::{shared-dir}/KieServer/KieServer-chapter.adoc[leveloffset=+1]
   
-////
+[discrete]
 = Drools Examples
-////
 
 Examples to help you learn Drools
 

--- a/docs/jbpm-docs/src/main/asciidoc/ReleaseNotes/Release.7.2.0.Final-section.adoc
+++ b/docs/jbpm-docs/src/main/asciidoc/ReleaseNotes/Release.7.2.0.Final-section.adoc
@@ -6,7 +6,7 @@
 The following features were added to jBPM 7.2
 
 
-=== Improved validation in deployment descriptor editor
+== Improved validation in deployment descriptor editor
 
 Deployment descriptor editor in workbench has been improved to validate content of entered data for
 
@@ -24,7 +24,7 @@ Validation mainly focuses on checking if data entered are valid based on selecte
 - MVEL type resolver will perform compilation of the expression that was given as identifier, it can produce warning messages as it might not have access to all classes that will be available on runtime, thus it's only warning to not block the build.
 - Reflection type resolver will verify if the identifier has valid name according to Java standard (class name)
 
-=== Websocket based KIE Server communication with KIE Controller
+== Websocket based KIE Server communication with KIE Controller
 
 Default communication mechanism for KIE Server to connect to KIE Controller is HTTP/REST based. This fits well in non-restricted environments where both components can freely talk to each other. Though it requires both components to know how to access and authorize
 itself when sending requests. That does not play well in cloud based environments or environments that utilize load balancer.

--- a/docs/jbpm-docs/src/main/asciidoc/RuntimeManagement-chapter.adoc
+++ b/docs/jbpm-docs/src/main/asciidoc/RuntimeManagement-chapter.adoc
@@ -27,7 +27,7 @@ That descriptor allows to define:
 
 By default, this descriptor is empty (just kmodule root element) and is considered as marker file.
 Whenever a runtime component (such as jbpm console) is about to process kjar it looks up kmodule.xml to build its runtime representation.
-In addition to kmodule.xml a deployment descriptor (that provides fine graind control over deployment) is available (since 6.1). 
+In addition to kmodule.xml a deployment descriptor (that provides fine grained control over deployment) is available (since 6.1).
 
 === Deployment descriptors
 
@@ -82,7 +82,7 @@ jBPM supports following levels of deployment descriptors:
 
 
 
-* server level - this is the main and considered default deployment descriptos that apply to all deployments on given server
+* server level - this is the main and considered default deployment descriptors that apply to all deployments on given server
 * kjar level - this is dedicated deployment descriptor to given kjar
 * deploy time level - this is deployment descriptor that is given at the time of deployment
 
@@ -355,7 +355,7 @@ In case fine grained control is required defined roles can be prefixed with one 
 * view:
 + 
 to restrict access to be able to see given process definitions/instances on UI
-* executre:
+* execute:
 + 
 to restrict access to be able to execute given process definitions
 * all:
@@ -378,8 +378,8 @@ For example to restrict access to show process from given kjar only to group 'ma
 
 *Classes used for serialization in the remote services*
 
-When processes make use of custom types (or in general non promitive types) and there is a use case to include remote api invocations (REST, SOAP, JMS) such types must be available to the remote services marshalling mechanism that is based on JAXB for XML type.
-By default all types defined in kjar will be automatically included in JAXB context and therefore will be avialble for remote interaction.
+When processes make use of custom types (or in general non primitive types) and there is a use case to include remote API invocations (REST, SOAP, JMS) such types must be available to the remote services marshalling mechanism that is based on JAXB for XML type.
+By default all types defined in kjar will be automatically included in JAXB context and therefore will be available for remote interaction.
 Though there might be more classes (like from dependent model) that shall be included there too. 
 
 Upon deployment, jBPM will scan classpath of given kjar to automatically register classes that might be needed for remote interaction.
@@ -407,9 +407,9 @@ If that is not enough deployment descriptor allows to manually specify classes t
 
 With this all classes can be added to the JAXB context to properly marshal and unmarshal data types when interacting with jBPM remotely.
 
-*Limiting classes usd for serialization in the remote services*
+*Limiting classes used for serialization in the remote services*
 
-When there are classes in the kjar project or in the dependencies of the kjar project that woudl cause problems when used for serialization, the `limit-serialization-classes` property can be used to limit which classes are used for serialization
+When there are classes in the kjar project or in the dependencies of the kjar project that would cause problems when used for serialization, the `limit-serialization-classes` property can be used to limit which classes are used for serialization.
 
 [source,xml]
 ----
@@ -467,14 +467,14 @@ image::RuntimeManagement/new-deployment.png[]
 == Jobs
 
 
-The Jobs perspective allows you to monitor and trigger Asynchronous Jobs schedulled to the jBPM Executor Service.
+The Jobs perspective allows you to monitor and trigger Asynchronous Jobs scheduled to the jBPM Executor Service.
 You can access to the Jobs List from the Deploy top level menu of the KIE Workbench. 
 
 
 image::RuntimeManagement/jobs-menu.png[]
 
 
-The Jobs List shows all the Jobs that were schedulled and their status.
+The Jobs List shows all the Jobs that were scheduled and their status.
 The Filter on top of the table  helps the administrator to monitor the Jobs execution and take corrective actions in case of Failure.
 Check the jBPM Executor section of the documentation for more information. 
 
@@ -488,11 +488,11 @@ Administrators have also the option to configure the jBPM Executor Service Setti
 image::RuntimeManagement/jobs-service-settings.png[]
 
 
-Administrators can also schedulle manually new Jobs from the User Interface via the Actions -> Settings option.
-By specifing the command class name and the parameters needed to run the command a new Job can be created.
+Administrators can also schedule manually new Jobs from the User Interface via the Actions -> Settings option.
+By specifying the command class name and the parameters needed to run the command a new Job can be created.
 This manually created jobs will not be associated with any process instance.
-Notice also that the Due Date paramenter allows the execution to be derrefered  for the future.
-If the Due Date is the time of schedulling the jBPM Executor Service will execute the command as soon as there is an Executor Thread available.
+Notice also that the Due Date parameter allows the execution to be deferred for the future.
+If the Due Date is the time of scheduling the jBPM Executor Service will execute the command as soon as there is an Executor Thread available.
 The number of retries will help the command to be executed more than once if it fails.
 This can help in situations when the business logic requires an external service to be called where the runtime cannot rely on that service to be available 100% of the time. 
 

--- a/docs/jbpm-docs/src/main/asciidoc/index.adoc
+++ b/docs/jbpm-docs/src/main/asciidoc/index.adoc
@@ -1,4 +1,5 @@
 = jBPM Documentation
+The jBPM Team <https://www.jbpm.org/community/team.html>
 :doctype: book
 :imagesdir: .
 :title-logo-image: image:shared/images/jBPMLogo.png[align="center"]

--- a/docs/jbpm-docs/src/main/asciidoc/index.adoc
+++ b/docs/jbpm-docs/src/main/asciidoc/index.adoc
@@ -54,6 +54,13 @@ include::Console-chapter.adoc[leveloffset=+1]
 include::BAM-chapter.adoc[leveloffset=+1]
 
 [discrete]
+= KIE Server
+
+The KIE Server is a standalone execution server for rules.
+
+include::{shared-dir}/KieServer/KieServer-chapter.adoc[leveloffset=+1]
+
+[discrete]
 = Eclipse
 
 How to use the Eclipse-based tooling

--- a/docs/optaplanner-wb-es-docs/src/main/asciidoc/Workbench/AuthoringPlanningAssets/TerminationEditor-section.adoc
+++ b/docs/optaplanner-wb-es-docs/src/main/asciidoc/Workbench/AuthoringPlanningAssets/TerminationEditor-section.adoc
@@ -2,10 +2,12 @@
 = Termination Editor
 :imagesdir: ../..
 
-By default, a time period that the planning engine is given to solve a problem instance is not limited. While this might be enforced by some scenarios (e.g. https://docs.jboss.org/optaplanner/release/latestFinal/optaplanner-docs/html/ch15.html#realTimePlanning[real-time] planning),
+By default, a time period that the planning engine is given to solve a problem instance is not limited.
+While this might be enforced by some scenarios (e.g.
+https://docs.jboss.org/optaplanner/release/latestFinal/optaplanner-docs/html_single/#realTimePlanning[real-time] planning),
 it is useful to have a mechanism to control total duration of the solving process.
 
-Refer to https://docs.jboss.org/optaplanner/release/latest/optaplanner-docs/html/ch06.html#termination[OptaPlanner documentation]
+Refer to https://docs.jboss.org/optaplanner/release/latestFinal/optaplanner-docs/html_single/#termination[OptaPlanner documentation]
 for more information on supported termination types.
 
 [NOTE]

--- a/docs/optaplanner-wb-es-docs/src/main/asciidoc/Workbench/Quickstart/Quickstart-section.adoc
+++ b/docs/optaplanner-wb-es-docs/src/main/asciidoc/Workbench/Quickstart/Quickstart-section.adoc
@@ -1,7 +1,9 @@
 = Cloud Balancing Example Setup
 :imagesdir: ../..
 
-This chapter describes the process of setting up environment to run https://docs.jboss.org/optaplanner/release/latestFinal/optaplanner-docs/html/ch02.html#cloudBalancingProblemDescription[Cloud Balancing] example using KIE Workbench and KIE Server.
+This chapter describes the process of setting up environment to run
+https://docs.jboss.org/optaplanner/release/latestFinal/optaplanner-docs/html_single/#cloudBalancingProblemDescription[Cloud Balancing]
+example using KIE Workbench and KIE Server.
 At the end of the chapter, the user will be able to submit sample planning problem to the KIE Server and query the best solution.
 
 == Environment Setup

--- a/docs/optaplanner-wb-es-docs/src/main/asciidoc/index.adoc
+++ b/docs/optaplanner-wb-es-docs/src/main/asciidoc/index.adoc
@@ -21,7 +21,7 @@ endif::[]
 
 == OptaPlanner Engine
 
-See the link:https://docs.jboss.org/optaplanner/release/latestFinal/optaplanner-docs/html/[OptaPlanner User Guide].
+See the link:https://docs.jboss.org/optaplanner/release/latestFinal/optaplanner-docs/html_single/[OptaPlanner User Guide].
 
 [discrete]
 = OptaPlanner Workbench

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -78,6 +78,8 @@
             </attributes>
           </configuration>
           <executions>
+            <!-- TODO add generate-html execution after https://github.com/asciidoctor/asciidoctor/issues/626
+            is implemented -->
             <execution>
               <id>generate-single-html</id>
               <phase>process-sources</phase>

--- a/docs/shared-kie-docs/src/main/asciidoc/KieServer/OptaplannerRestAPI-section.adoc
+++ b/docs/shared-kie-docs/src/main/asciidoc/KieServer/OptaplannerRestAPI-section.adoc
@@ -8,7 +8,7 @@ Please also note:
 
 
 
-* The base URL for these will remain as the endpoint defined earlier (for example `http://SERVER:PORT/CONTEXT/services/rest/server/` ).
+* The base URL for these will remain as the endpoint defined earlier (for example `http://SERVER:PORT/CONTEXT/services/rest/server/`).
 * All requests require basic HTTP Authentication for the role kie-server as indicated earlier.
 * To get a specific marshalling format, add the HTTP headers `Content-Type` and optional `X-KIE-ContentType` in the HTTP request. For example:
 +

--- a/docs/shared-kie-docs/src/main/asciidoc/Workbench/KeycloakSSOIntegration/KC_SSO_integ-section.adoc
+++ b/docs/shared-kie-docs/src/main/asciidoc/Workbench/KeycloakSSOIntegration/KC_SSO_integ-section.adoc
@@ -330,7 +330,7 @@ git clone ssh://admin@localhost:8001/system
 == Execution server
 
 
-The KIE Execution Server provides a https://docs.jboss.org/drools/release/latest/drools-docs/html_single/#_kie.ksrestapi[REST API] that can be consumed for any third party clients.
+The KIE Execution Server provides a <<_kie.ksrestapi,REST API>> that can be consumed for any third party clients.
 This this section is about how to integration the KIE Execution Server with the Keycloak SSO in order to delegate the third party clients identity management to the SSO server.
 
 Consider the above environment running, so consider having:

--- a/docs/shared-kie-docs/src/main/asciidoc/Workbench/KeycloakSSOIntegration/KC_SSO_integ-section.adoc
+++ b/docs/shared-kie-docs/src/main/asciidoc/Workbench/KeycloakSSOIntegration/KC_SSO_integ-section.adoc
@@ -233,7 +233,7 @@ Use your Keycloak's admin user credentials to login: __admin/password__.
 == Securing workbench remote services via Keycloak
 
 
-Both jBPM and Drools workbenches provide different remote service endpoints that can be consumed by third party clients using the https://docs.jboss.org/jbpm/v6.3/userguide/ch17.html[remote API].
+Both jBPM and Drools workbenches provide different remote service endpoints that can be consumed by third party clients using the <<_drools.workbenchremoteapi,remote API>>.
 
 In order to authenticate those services thorough Keycloak the _BasicAuthSecurityFilter_ must be disabled, apply those modifications for the the _WEB-INF/web.xml_ file (app deployment descriptor) from jBPM's WAR file:
 
@@ -330,7 +330,7 @@ git clone ssh://admin@localhost:8001/system
 == Execution server
 
 
-The KIE Execution Server provides a https://docs.jboss.org/drools/release/latest/drools-docs/html/ch22.html[REST API] that can be consumed for any third party clients.
+The KIE Execution Server provides a https://docs.jboss.org/drools/release/latest/drools-docs/html_single/#_kie.ksrestapi[REST API] that can be consumed for any third party clients.
 This this section is about how to integration the KIE Execution Server with the Keycloak SSO in order to delegate the third party clients identity management to the SSO server.
 
 Consider the above environment running, so consider having:


### PR DESCRIPTION
* Fixed broken links between different books (typically optaplanner-wb-docs -> optaplanner-docs) which used the old `html_single` format that got lost after migration to AsciiDoc.
* Added KIE Server chapter to jbpm-docs book. Now that this chapter is in all books, it can be cross referenced instead using a URL link. Besides that it's relevant for jBPM users so I don't see a reason why it shouldn't be a part of jbpm-docs.
* Fixed a few inconsistencies between `drools-docs/index.adoc` and `jbpm-docs/index.adoc`.
* Fixed a few typos.