### PR TITLE
Corrected typo in chap-deploying-projects.adoc

### DIFF
--- a/docs/product-user-guide/src/main/asciidoc/chap-deploying-projects.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/chap-deploying-projects.adoc
@@ -576,4 +576,3 @@ For example, the following expression can be used for accessing the [var]``proce
 ----
 ${task.taskData.processInstanceId}
 ----
-=======


### PR DESCRIPTION
@vidya-iyengar Corrected typo in the chap-deploying-projects.adoc file that was preventing the book from building correctly past Chapter 15. This was probably left behind from an old merge conflict.