### PR TITLE
BXMSDOC-1463 (for upstream master): Add 'target' parameter to enable advanced queries in Intelligent Process Server 

### DIFF
--- a/docs/product-development-guide/src/main/asciidoc/chap-human-tasks-management.adoc
+++ b/docs/product-development-guide/src/main/asciidoc/chap-human-tasks-management.adoc
@@ -199,7 +199,7 @@ The following matrix describes the authorizations for all operations which modif
 
 === Exclude Potential Owner from a Human Task
 
-You can prevent a potential owner of a task from becoming the actual owner. When you exclude potential owners from a human task, they can not claim and act on it, nor can they view it in their task list. 
+You can prevent a potential owner of a task from becoming the actual owner. When you exclude potential owners from a human task, they can not claim and act on it, nor can they view it in their task list.
 To exclude users from a human task, set the task input variable with name `ExcludedOwnerId` to the name of the user you wish to exclude from the potential owner list. For this, ensure that the human task is assigned to a group. To exclude multiple owners from a human task, set the `ExcludedOwnerId` parameter to a comma separated list of values.
 
 The following BPMN process shows how to exclude a potential owner from a human task:
@@ -208,7 +208,7 @@ image::excludeUsers.png[]
 
 You can use the following Java API methods from `UserTaskAdminService` to modify `excludedOwners`:
 
-* `addExcludedOwners()`: To add new excluded owners to a given task. 
+* `addExcludedOwners()`: To add new excluded owners to a given task.
 
 * `removeExcludedOwners()`: To remove existing excluded owners from given task.
 
@@ -455,13 +455,13 @@ To improve performance, task variables are automatically set when they are avail
 
 * When created, a task usually has input variables, which are then set on `Task` instance. This applies to `beforeTaskAdded` and `afterTaskAdded` events handling.
 
-* When `Task` is completed, it usually has output variables, which are set on a task. 
+* When `Task` is completed, it usually has output variables, which are set on a task.
 +
 The `loadTaskVariables` method should be used to populate task variables in all other circumstances.
 +
 [NOTE]
 ====
-Calling the `loadTaskVariables` method of the listener once (such as in `beforeTask`) makes it available to both `beforeTask` and `afterTask` methods. 
+Calling the `loadTaskVariables` method of the listener once (such as in `beforeTask`) makes it available to both `beforeTask` and `afterTask` methods.
 ====
 
 . *Configuring the TaskEventListener*
@@ -916,12 +916,12 @@ The `RoundRobin` assignment strategy assigns tasks equally to all the potential 
 Load Balance::
 +
 --
-The `LoadBalance` assignment strategy uses a load calculator class to determine which user from the potential owners group should be assigned to the particular task. 
+The `LoadBalance` assignment strategy uses a load calculator class to determine which user from the potential owners group should be assigned to the particular task.
 
 The following load calculators are provided in {PRODUCT}.
 
 * `org.jbpm.services.task.assignment.impl.TaskCountLoadCalculator` (default): Assigns the tasks based on the number of tasks currently assigned to users. For example, if there are two potential owners of a specific task, the task will be automatically assigned to the user with fewer currently assigned tasks.
-* `org.jbpm.services.task.assignment.impl.TotalCompletionTimeLoadCalculator`: Assigns the tasks based on the estimated amount of time that the currently assigned tasks take. 
+* `org.jbpm.services.task.assignment.impl.TotalCompletionTimeLoadCalculator`: Assigns the tasks based on the estimated amount of time that the currently assigned tasks take.
 +
 Consider the following example.
 
@@ -940,7 +940,7 @@ The `BusinessRule` assignment strategy enables you to use business rules to dete
 
 [NOTE]
 ====
-All rules defined in the KIE Container specified by the `org.jbpm.task.assignment.rules.releaseId` property are used. 
+All rules defined in the KIE Container specified by the `org.jbpm.task.assignment.rules.releaseId` property are used.
 ====
 
 [source,java]
@@ -1389,7 +1389,7 @@ KieServicesClient kieServicesClient =  KieServicesFactory
 
 QueryServicesClient queryClient = kieServicesClient
   .getServicesClient(QueryServicesClient.class);
-  
+
 // Maven dependency list shown above
 ----
 
@@ -1421,9 +1421,25 @@ query.setExpression("select ti.*,c.country,c.productCode,c.quantity,c.price,c.sa
   "inner join ProductSale c " +
   "on (c.id = mv.map_var_id)");
 
+query.setTarget("Task");
+
 queryClient.registerQuery(query);
 
 // Maven dependency list shown above
+----
+Note that `Target` instructs `QueryService` to apply default filters.
+Alternatively, you can set filter parameters manually. `Target` has the following values:
+
+[source,java]
+----
+public enum Target {
+    PROCESS,
+    TASK,
+    BA_TASK,
+    PO_TASK,
+    JOBS,
+    CUSTOM;
+}
 ----
 
 Once registered, you can start with queries:
@@ -1613,7 +1629,7 @@ params.put("max", 20);
 List<TaskInstance> instances = queryClient.query
   ("getAllTaskInstancesWithCustomVariables", "UserTasksWithCustomVariables", "test",
   params, 0, 10, TaskInstance.class);
-  
+
 // Maven dependencies shown above
 ----
 
@@ -1677,7 +1693,7 @@ We recommend you to let active process instance finish and start new process ins
 * Data change
 * Need for node mapping
 
-The best practice is to create backward compatible processes whenever possible, such as extending process definitions. For example, removing specific nodes from the process definition breaks compatibility. In such case, you must provide new node mapping in case an active process instance is in a node that has been removed. 
+The best practice is to create backward compatible processes whenever possible, such as extending process definitions. For example, removing specific nodes from the process definition breaks compatibility. In such case, you must provide new node mapping in case an active process instance is in a node that has been removed.
 
 A node map contains source node IDs, from the old process definition, mapped to target node IDs in the new process definition. You can map nodes with the same type only, for example a user task to a user task.
 


### PR DESCRIPTION
Ready to merge with upstream master.

Added single line of code and copied one sentence and code snippet from another section of the Dev Guide.

Lines affected are 1424-1443. I have no idea what those other diffs are. Similar behavior in GitLab when I just merged the PR for 6.4-preview. Just a handful of deletions/additions of the exact same content, as if copied and pasted in place. Weird. No actual change except mine, though.

JIRA: https://issues.jboss.org/browse/BXMSDOC-1463

Didn't bother with providing rendered output. Very small change, shown sufficiently in PR diffs.

The SME review/approval was given in the above JIRA itself, and the Peer Review (approved) is a sub-task, as usual.

