### PR TITLE
BXMSDOC-1806 (for upstream master): Updated chap. Data Models in BRMS and BPMS User Guide per 7.0 LA ER3 new UI

### DIFF
--- a/docs/product-user-guide/src/main/asciidoc/data-object-deployment-descriptor-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/data-object-deployment-descriptor-proc.adoc
@@ -4,7 +4,7 @@
 For advanced persistence configuration, you can modify the `kie-deployment-descriptor.xml` file. This file defines deployment in the jBPM runtime, persistence unit information, and other advanced deployment settings. Automatic configuration of the JPA Marshalling Strategies is only available in JBoss BPM Suite.
 
 .Procedure
-. Go to *Authoring* → *Project Authoring* and select your project.
+. Go to *Menu* → *Projects* and select your project.
 . In the upper-right corner, click *Settings*, and then click *Project Settings: Project General Settings* -> *Deployment descriptor* to open the `kie-deployment-descriptor.xml` editor.
 +
 

--- a/docs/product-user-guide/src/main/asciidoc/data-objects-create-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/data-objects-create-proc.adoc
@@ -4,7 +4,7 @@
 The data objects that you define can be implemented in various types of assets in your project, and are essential building blocks for your project.
 
 .Procedure
-. Go to *Authoring* → *Project Authoring* and select your project.
+. Go to *Menu* → *Projects* and select your project.
 . Click *Create New Asset* → *Data Object*.
 . Enter the name and select the package. The name must be unique across the package, but it is possible to have two data objects with the same name in two different packages.
 . To make your Data Object persistable, check the *Persistable* checkbox.

--- a/docs/product-user-guide/src/main/asciidoc/data-objects-persistable-modify-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/data-objects-persistable-modify-proc.adoc
@@ -4,7 +4,7 @@
 Business central contains a `persistence.xml` file with default persistence settings. You can modify these persistence settings for all persistable data objects.
 
 .Procedure
-. Go to *Authoring* → *Project Authoring* and select your project.
+. Go to *Menu* → *Projects* and select your project.
 . In the upper-right corner of the screen, click *Settings*, and then click *Project Settings: Project General Settings* -> *Persistence descriptor* to open the `persistence.xml` editor.
 +
 

--- a/docs/product-user-guide/src/main/asciidoc/data-objects-relationships-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/data-objects-relationships-proc.adoc
@@ -7,6 +7,9 @@ When an attribute type is defined as another persistable data object, the relati
 .Procedure
 . In the data object editor, select the data object attribute from the list.
 . Click the *Persistence* icon on the right side of the editor.
++
+image::persistenceicon.png[]
+
 . Under *Relationship Properties*, click the *Relationship Type* property editing option, and fill in the fields as needed.
 +
 


### PR DESCRIPTION
Ready to merge with upstream master.

Basically just changed "**Authoring** -> **Project Authoring**" to  "**Menu** -> **Projects**" at several points. Otherwise no impact.

Links:
- [JIRA](https://issues.jboss.org/browse/BXMSDOC-1806)
- [Output for BRMS](http://file.rdu.redhat.com/~sterobin/BXMSDOC-1806_BRMS/#assets_data_models_gloss_chap-data-models)
- [Output for BPMS](http://file.rdu.redhat.com/~sterobin/BXMSDOC-1806_BPM/#assets_data_models_gloss_chap-data-models)

@vidya-iyengar, @gsheldon, @emmurphy1, and @michelehaglund:

I'm just saying this:
- "Go to **Menu** -> **Projects** . . ."
- "Got to **Menu** -> **Deployments** . . ."
- etc.

Not this:
- "Go to **Menu** -> **Design** -> **Projects** . . ."
- Got to **Menu** -> **DevOps** -> **Deployments** . . ."
- etc.

I'm not positive that saying the heading under which the different options are found is particularly helpful, and after trying both, what I have just seems cleaner. If you disagree and think we should list the headings in the menu, I'm fine with that I guess.

Thoughts?
