### PR TITLE
BXMSDOC-1807 (for upstream 7.4.x): Minor updates to chap Advanced Process Modeling in BPMS User Guide for clearer instructions

### DIFF
--- a/docs/product-user-guide/src/main/asciidoc/chap-advanced-process-modeling.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/chap-advanced-process-modeling.adoc
@@ -31,10 +31,10 @@ See the {URL_DEVELOPMENT_GUIDE}#sect_process_fluent_api[Process Fluent API] chap
 
 Workflow patterns are predefined blocks of process elements that enable you to reuse a predefined combination of process elements. Workflow patterns include multiple nodes that are connected and form a common executable pattern that can be reused in a process model.
 
-Workflow patterns are available in the Workflow Patterns section of the Object Library and can be drag-and-dropped on the canvas just like any other elements.
+Workflow patterns are available in the *Workflow Patterns* section of the *Object Library* and can be moved onto the canvas just like any other elements.
 To attach a pattern to an element on the canvas, select the element and drag-and-drop the pattern from the palette onto the canvas. The pattern automatically connects to the element.
 
-Multiple predefined workflow patterns are provided by default and you can define your own workflow patters as necessary.
+Multiple predefined workflow patterns are provided by default and you can define your own workflow patterns as necessary.
 The definitions are defined as JSON objects in the `_EAP_HOME_/standalone/deployments/business-central.war/org.kie.workbench.KIEWebapp/defaults/patterns.json` file.
 
 [[_defining_process_patterns]]
@@ -43,7 +43,8 @@ The definitions are defined as JSON objects in the `_EAP_HOME_/standalone/deploy
 
 To define custom workflow patterns:
 
-. In the *Workflow Patterns* section of the *Object Library*, locate a workflow pattern that will serve as a base for your workflow pattern.
+. Go to *Business Processes* in your *Project Explorer* and select the process.
+. Go to the *Workflow Patterns* section of the *Object Library* and locate a workflow pattern that will serve as a base for your workflow pattern.
 . Open the `_EAP_HOME_/standalone/deployments/business-central.war/org.kie.workbench.KIEWebapp/defaults/patterns.json` file in a text editor.
 . Locate the JSON object with the description property set to the base workflow pattern name (for example, ``"description" : "Sequence Pattern"``).
 . Copy the JSON object and modify its elements as needed. Note that all the JSON objects are nested in a pair of square brackets and are comma separated.


### PR DESCRIPTION
Ready to merge with upstream 7.4.x.

Cherry-picked from branch BXMSDOC-1807-master. No impact from new UI, from what I can see. I went ahead and made a couple of changes while I was there though. Very minimal.

[JIRA](https://issues.jboss.org/browse/BXMSDOC-1807)