### PR TITLE
BXMSDOC-1830 (for upstream 7.4.x): Fixed broken cross-refs in Dev Guided introduced in BXMSDOC-1646

### DIFF
--- a/docs/product-development-guide/src/main/asciidoc/chap-human-tasks-management.adoc
+++ b/docs/product-development-guide/src/main/asciidoc/chap-human-tasks-management.adoc
@@ -1,12 +1,12 @@
-[#chap_human_tasks_management]
+[#_chap_human_tasks_management]
 = Human Tasks Management
 
-[#human_tasks]
+[#_human_tasks]
 == Human Tasks
 
 Human Tasks are tasks within a process that must be carried out by human actors. BRMS Business Process Management supports a human task node inside processes for modeling the interaction with human actors. The human task node allows process designers to define the properties related to the task that the human actor needs to execute; for example, the type of task, the actor, and the data associated with the task can be defined by the human task node. A back-end human task service manages the lifecycle of the tasks at runtime. The implementation of the human task service is based on the WS-HumanTask specification, and the implementation is fully pluggable; this means users can integrate their own human task solution if necessary. Human tasks nodes must be included inside the process model and the end users must interact with a human task client to request their tasks, claim and complete tasks.
 
-[#using_user_tasks_in_processes]
+[#_using_user_tasks_in_processes]
 == Using User Tasks in Processes
 
 Red Hat JBoss BPM Suite supports the use of human tasks inside processes using a special User Task node defined by the BPMN2 Specification. A User Task node represents an atomic task that is executed by a human actor.
@@ -44,7 +44,7 @@ Apart from the above mentioned core and extra properties of user tasks, there ar
 
 To override the default values of these generic user properties, you must define a data input with the name of the property, and then set the desired value in the assignment section.
 
-[#data_mapping]
+[#_data_mapping]
 == Data Mapping
 
 Human tasks typically present some data related to the task that needs to be performed to the actor that is executing the task. Human tasks usually also request the actor to provide some result data related to the execution of the task. Task forms are typically used to present this data to the actor and request results.
@@ -53,7 +53,7 @@ You must specify the data that is used by the task when you define the user task
 
 Most of the times forms are used to display data to the end user. This allows them to generate or create new data to propagate to the process context to be used by future activities. In order to decide how the information flow from the process to a particular task and from the task to the process, you need to define which pieces of information must be automatically copied by the process engine.
 
-[#task_lifecycle]
+[#_task_lifecycle]
 == Task Lifecycle
 
 A human task is created when a user task node is encountered during the execution. The process leaves the user task node only when the associated human task is completed or aborted. The human task itself has a complete life cycle as well. The following diagram describes the human task life cycle.
@@ -73,7 +73,7 @@ While this life cycle explained above is the normal life cycle, the specificatio
 * Stopping a task in progress.
 * Skipping a task (if the task has been marked as skippable), in which case the task will not be executed.
 
-[#sect_task_permissions]
+[#_sect_task_permissions]
 == Task Permissions
 
 Only users associated with a specific task are allowed to modify or retrieve information about the task. This allows users to create a Red Hat JBoss BPM Suite workflow with multiple tasks and yet still be assured of both the confidentiality and integrity of the task status and information associated with a task.
@@ -213,17 +213,17 @@ You can use the following Java API methods from `UserTaskAdminService` to modify
 * `removeExcludedOwners()`: To remove existing excluded owners from given task.
 
 
-[#sect_task_permissions1]
+[#_sect_task_permissions1]
 == Task Service
 
-[#task_service_and_process_engine]
+[#_task_service_and_process_engine]
 === Task Service and Process Engine
 
 Human tasks are similar to any other external service that are invoked and implemented as a domain-specific service. As a human task is an example of such a domain-specific service, the process itself only contains a high-level, abstract description of the human task to be executed and a work item handler that is responsible for binding this (abstract) task to a specific implementation.
 
 You can plug in any human task service implementation, such as the one that is provided by JBoss BPM Suite, or may register your own implementation. The Red Hat JBoss BPM Suite provides a default implementation of a human task service based on the WS-HumanTask specification. If you do not need to integrate JBoss BPM Suite with another existing implementation of a human task service, you can use this service. The Red Hat JBoss BPM Suite implementation manages the life cycle of the tasks (such as creation, claiming, completion) and stores the state of all the tasks, task lists, and other associated information. It also supports features like internationalization, calendar integration, different types of assignments, delegation, escalation and deadlines. You can find the code for the implementation in the jbpm-human-task module. The Red Hat JBoss BPM Suite task service implementation is based on the WS-HumanTask (WS-HT) specification. This specification defines (in detail) the model of the tasks, the life cycle, and many other features.
 
-[#task_service_api]
+[#_task_service_api]
 === Task Service API
 
 The human task service exposes a Java API for managing the life cycle of tasks. This allows clients to integrate (at a low level) with the human task service. Note that, the end users should probably not interact with this low-level API directly, but use one of the more user-friendly task clients instead. These clients offer a graphical user interface to request task lists, claim and complete tasks, and manage tasks in general. The task clients listed below use the Java API to internally interact with the human task service. Of course, the low-level API is also available so that developers can use it in their code to interact with the human task service directly.
@@ -293,7 +293,7 @@ return content;
 For a list of Maven dependencies, see example <<_embedded_jbpm_engine_dependencies>>.
 
 
-[#interacting_with_the_task_service]
+[#_interacting_with_the_task_service]
 === Interacting with the Task Service
 
 In order to get access to the Task Service API, it is recommended to let the Runtime Manager ensure that everything is setup correctly. From the API perspective, if you use the following approach, there is no need to register the Task Service with the Process Engine:
@@ -333,7 +333,7 @@ For a list of Maven dependencies, see example <<_embedded_jbpm_engine_dependenci
 
 The Runtime Manager registers the Task Service with the Process Engine automatically. If you do not use the Runtime Manager, you have to set the `LocalHTWorkItemHandler` in the session to get the Task Service notify the Process Engine once the task completes. In Red Hat JBoss BPM Suite, the Task Service runs locally to the Process and Rule Engine. This enables you to create multiple light clients for different Process and Rule Engine's instances. All the clients can share the same database.
 
-[#task_event_listener]
+[#_task_event_listener]
 === Accessing Task Variables Using TaskEventListener
 
 Task variables can be accessed in the `TaskEventListener` for process instances.
@@ -631,8 +631,8 @@ Task comments are stored in the `task_comment` table. See a list of `task_commen
 
 For more information about task data model, see <<_sect_audit_log>>.
 
-[#people_assignments]
 [float]
+[#_people_assignments]
 === Entities and People Assignments
 
 Information about particular users and groups are stored in the `OrganizationalEntity` table. The attribute `DTYPE` determines whether it is a user or a group and `id` is the name of a user (for example `bpmsAdmin`) or a group (for example `Administrators`).
@@ -658,7 +658,7 @@ PeopleAssignments_Recipients::
 Not fully supported.
 
 
-[#reassignments]
+[#_reassignments]
 [float]
 === Reassignments
 
@@ -672,7 +672,7 @@ The `Deadline` table stores deadline information: the unique ID of a deadline (`
 
 The `Reassignment` table refers to the `Escalation` table: the `Escalation_Reassignments_Id` attribute in `Reassignments` is equivalent to the `id` attribute in `Escalation`.
 
-[#notifications]
+[#_notifications]
 [float]
 === Notifications
 
@@ -682,7 +682,7 @@ Recipients of a notification are stored in the `Notification_Recipients` table, 
 
 The `Notification_email_header` stores the ID of a notification in the `Notification_id` attribute and the ID of an email that is sent in the `emailHeader_id` attribute. The `email_header` table contains the unique ID of an email (`id`), content of an email (`body`), the _name_ of a user who is sending an email (`fromAddress`), the language of an email (`language`), the _email address_ to which it is possible to reply (`replyToAddress`), and the subject of an email (`subject`).
 
-[#attachments]
+[#_attachments]
 [float]
 === Attachments
 
@@ -724,13 +724,13 @@ You can attach an attachment with an arbitrary type and content to each task. Th
 
 The `Content` table stores the actual binary content of an attachment. The content type is defined in the `Attachment` table. The maximum size of an attachment is 2 GB.
 
-[#delegations]
+[#_delegations]
 [float]
 === Delegations
 
 Each task defines whether it can be escalated to another user or a group in the `allowedToDelegate` attribute of the `Task` table. The `Delegation_delegates` table stores the tasks that can be escalated (in the `task_id` attribute) and the users to which the tasks are escalated (`entity_id`).
 
-[#connecting_to_custom_directory_information_services]
+[#_connecting_to_custom_directory_information_services]
 === Connecting to Custom Directory Information Services
 
 
@@ -803,11 +803,11 @@ Using a custom [parameter]``UserGroupInfoProducer`` is not recommended or suppor
 ====
 . Restart your server. Your custom callback implementation should now be used by Business Central.
 
-[#sect_ldap_connection]
+[#_sect_ldap_connection]
 === LDAP Connection
 
 
-A dedicated [interface]``UserGroupCallback`` implementation for LDAP servers is provided with the product to enable the User Task service to retrieve information about users, groups, and roles directly from an LDAP service. See <<_ldap_example>> for example configuration.
+A dedicated [interface]``UserGroupCallback`` implementation for LDAP servers is provided with the product to enable the User Task service to retrieve information about users, groups, and roles directly from an LDAP service. See <<_connecting_to_ldap>> for example configuration.
 
 The LDAP `UserGroupCallback` implementation takes the following properties:
 
@@ -828,7 +828,7 @@ The LDAP `UserGroupCallback` implementation takes the following properties:
 * [property]``java.naming.provider.url``: LDAP url (by default ``ldap://localhost:389``; if the protocol is set to `ssl` then ``ldap://localhost:636``)
 
 
-[#connecting_to_ldap]
+[#_connecting_to_ldap]
 ==== Connecting to LDAP
 
 
@@ -861,7 +861,6 @@ UserGroupCallbackManager.getInstance().setCallback(ldapUserGroupCallback);
 Make sure to register the LDAP callback when starting the User Task server.
 +
 
-[#ldap_example]
 .LDAP Callback Connection Example
 [source,java]
 ----
@@ -878,7 +877,7 @@ ldap.user.roles.filter=(member\={0})
 ----
 
 
-[#task_escalation]
+[#_task_escalation]
 == Task Escalation
 
 It is possible to implement Task Escalation for your Human Tasks to set up a timer within which certain task must be finished. To learn more about Task Escalation, see {URL_USER_GUIDE}#escalation[A.3.2. Escalation] from {USER_GUIDE}. Red Hat JBoss BPM Suite also supports custom implementation of the Email Notification Events in the Task Escalation service, which requires you to do the following:
@@ -895,7 +894,7 @@ This will cause the Task Escalation Service to trigger your custom Email Notific
 * Task information, such as task ID, name, and description.
 * Process information, such as process instance ID, process ID, and deployment ID.
 
-[#task_assignment_strategies]
+[#_task_assignment_strategies]
 == Task Assignment Strategies
 
 {PRODUCT} enables you to automatically assign new tasks to a potential owner of the task, using one of the available task assignment strategies. You can enable and set this feature using system properties. For more information about system properties, see the `org.jbpm.services.task.assignment` and `org.jbpm.task.assignment` properties in the {URL_ADMIN_GUIDE}#system_properties[System Properties] section of the _{ADMIN_GUIDE}_.
@@ -985,7 +984,7 @@ end
 == Custom Task Assignment Strategy
 A custom strategy for task assignment is created by extending the `AssignmentStrategy` interface. A custom strategy allows you to assign tasks in a way you want, rather than relying on one of the provided assignment strategies.
 
-To use a custom strategy, you must include it in a KJAR and set the `org.jbpm.assignment.strategy` system property to the value of your `CustomStrategy` `IDENTIFIER`. 
+To use a custom strategy, you must include it in a KJAR and set the `org.jbpm.assignment.strategy` system property to the value of your `CustomStrategy` `IDENTIFIER`.
 
 By implementing the `apply()` method, you can define how potential owners are applied to a task.
 
@@ -1035,7 +1034,7 @@ public class CustomStrategy implements AssignmentStrategy {
 
 
 ifdef::BPMS[]
-[#retrieving_process_and_task_information]
+[#_retrieving_process_and_task_information]
 == Retrieving Process and Task Information
 
 There are two services which can be used when building list-based user interfaces: the `RuntimeDataService` and `TaskQueryService`.
@@ -1148,7 +1147,7 @@ Since the `QueryFilter` inherits all of the mentioned attributes, it provides th
 Moreover, additional filtering can be applied to the queries to provide more advanced options when searching for user tasks and processes.
 endif::BPMS[]
 
-[#advanced_queries]
+[#_advanced_queries]
 == Advanced Queries with QueryService
 
 `QueryService` provides advanced search capabilities based on JBoss BPM Suite Dashbuilder datasets. You can retrieve data from the underlying data store by means of, for example, JPA entity tables, or custom database tables.
@@ -1396,7 +1395,7 @@ QueryParam.in(COLUMN_STATUS, 1, 3));
 
 For a list of Maven dependencies, see <<_embedded_jbpm_engine_dependencies>>.
 
-[#advanced_queries_ips]
+[#_advanced_queries_ips]
 === Advanced Queries Through {KIE_SERVER}
 
 To use advanced queries, you need to deploy the {KIE_SERVER}. See the {KIE_SERVER} chapter in the {USER_GUIDE} to learn more about the {KIE_SERVER}. Also, for a list of endpoints you can use, see the Advanced Queries for the {KIE_SERVER} chapter in the _{USER_GUIDE}_.


### PR DESCRIPTION
Ready to merge with upstream 7.4.x.

Cherry-picked change from BXMSDOC-1830. In [BXMSDOC-1646](https://github.com/kiegroup/kie-docs/commit/d91763a00822e47ee56edc4512af77b62a4a54dd), the initial underscore was removed before all anchor names in chap-human-tasks-management. This is great and what we want to do going forward, but the corresponding cross-references were not likewise updated, resulting in broken links. Gemma is out and couldn't fix the cross-refs at the moment, and I don't have the time, so I instead just put back the initial underscores for now to fix the broken links.

Links:
- [BXMSDOC-1646](https://github.com/kiegroup/kie-docs/commit/d91763a00822e47ee56edc4512af77b62a4a54dd) (previous PR commit that introduced the issue)
- [JIRA for this fix](https://issues.jboss.org/browse/BXMSDOC-1830)