### PR TITLE
BXMSDOC-1836 (for upstream 7.4.x): Updated new main menu nav from Menu -> Projects to Menu -> Design -> Projects, and corrected all instances of 'log/logging/logged into' (should be 'in to').

### DIFF
--- a/docs/jbpm-docs/src/main/asciidoc/Examples/Importing-section.adoc
+++ b/docs/jbpm-docs/src/main/asciidoc/Examples/Importing-section.adoc
@@ -41,7 +41,7 @@ endif::PRODUCT-ONLY[]
 + 
 This opens the login page. 
 +
-.. Log into 
+.. Log in to 
 ifdef::COMMUNITY-ONLY[Workbench] 
 ifdef::PRODUCT-ONLY[Business Central] 
 with the user credentials created during installation. 

--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-kie-server-configuration.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-kie-server-configuration.adoc
@@ -475,7 +475,7 @@ ifdef::BRMS[.JVM Properties for Managed {KIE_SERVER} Instance]
 </response>
 ----
 
-. Verify successful registration by logging into Business Central and selecting *Deploy* -> *Execution Servers*. If successful, you can see the registered server ID.
+. Verify successful registration by logging in to Business Central and selecting *Deploy* -> *Execution Servers*. If successful, you can see the registered server ID.
 
 [[_unmanaged_decision_server]]
 === Unmanaged {KIE_SERVER}

--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-localization-and-customization.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-localization-and-customization.adoc
@@ -45,7 +45,7 @@ ifdef::BPMS[]
 
 To change the user interface language in dashbuilder, do the following:
 
-. Log into the dashbuilder after the server has been successfully started by navigating to http://_localhost_:8080/dashbuilder in a web browser.
+. Log in to the dashbuilder after the server has been successfully started by navigating to http://_localhost_:8080/dashbuilder in a web browser.
 . Select the language of your choice by clicking on the available locales on the top center of the dashbuilder user interface to change the language.
 
 

--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-managing-security-for-red-hat-jboss-bpm-suite-dashbuilder.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-managing-security-for-red-hat-jboss-bpm-suite-dashbuilder.adoc
@@ -29,7 +29,7 @@ Thanks to the permissions system, you can build a workspace structure with sever
 == Workspace permissions
 
 .Procedure: Accessing Workspace Permissions
-. Log into Business Dashboards from Business Central (as described in the Accessing Red Hat JBoss BPM Suite Dashbuilder topic).
+. Log in to Business Dashboards from Business Central (as described in the Accessing Red Hat JBoss BPM Suite Dashbuilder topic).
 . Select the appropriate Dashboard from the Wokspace drop-down:
 +
 .Dashbuilder Workspace

--- a/docs/product-development-guide/src/main/asciidoc/chap-getting-started-with-rules-and-facts.adoc
+++ b/docs/product-development-guide/src/main/asciidoc/chap-getting-started-with-rules-and-facts.adoc
@@ -601,7 +601,7 @@ You are rich!
 
 NOTE: Make sure you have {PRODUCT} successfully installed before proceeding further.
 
-. Start the server and log in to Business Central. For more information how to do so, see sections {URL_INSTALLATION_GUIDE}#starting_the_server2[Starting Server] and {URL_INSTALLATION_GUIDE}#logging_on[Logging into Business Central] of _{INSTALLATION_GUIDE}_.
+. Start the server and log in to Business Central. For more information how to do so, see sections {URL_INSTALLATION_GUIDE}#starting_the_server2[Starting Server] and {URL_INSTALLATION_GUIDE}#logging_on[Logging in to Business Central] of _{INSTALLATION_GUIDE}_.
 
 . *Create a repository structure and a project.*
   .. In Business Central, click *Authoring* -> *Administration*.

--- a/docs/product-getting-started-guide/src/main/asciidoc/task_business-process.adoc
+++ b/docs/product-getting-started-guide/src/main/asciidoc/task_business-process.adoc
@@ -17,7 +17,7 @@ This model is comprised of the following business processes:
 * Increasing the down payment
 
 === Validating the mortgage
-. Log into Business Central. Click *Menu* -> *Projects*, then *process-app-start*.
+. Log in to Business Central. Click *Menu* -> *Design* -> *Projects*, then *process-app-start*.
 . Click *Create New Asset* -> *Business Process*.
 . Enter the following values:
 +

--- a/docs/product-getting-started-guide/src/main/asciidoc/task_business-rules.adoc
+++ b/docs/product-getting-started-guide/src/main/asciidoc/task_business-rules.adoc
@@ -13,7 +13,7 @@ Finished data object in {PRODUCT}. For further information, see <<_defining_a_da
 
 == Creating Guided Rules
 
- . Log into Business Central. Click *Menu* -> *Projects*, then *process-app-start*.
+ . Log in to Business Central. Click *Menu* -> *Design* -> *Projects*, then *process-app-start*.
  . Click *Create New Asset* -> *Guided Rule*, then enter:
 
  * *Name*: `Validate Down Payment`
@@ -52,7 +52,7 @@ System.out.println("Executed Rule: " + drools.getRule().getName() );
 
 == Creating Guided Decision Tables
 
-. Log into Business Central. Click *Menu* -> *Projects*, then *process-app-start*.
+. Log in to Business Central. Click *Menu* -> *Design* -> *Projects*, then *process-app-start*.
 . Click *Create New Asset* -> *Guided Decision Table*, then enter:
 +
 * *Name*: `Mortgage Decision Table`

--- a/docs/product-getting-started-guide/src/main/asciidoc/task_data-model.adoc
+++ b/docs/product-getting-started-guide/src/main/asciidoc/task_data-model.adoc
@@ -12,7 +12,7 @@ Imported starter project. For further information, see <<_importing_a_getting_st
 
 To create a data model:
 
-. Log into Business Central. Click *Menu* -> *Projects*, then *process-app-start*.
+. Log in to Business Central. Click *Menu* -> *Design* -> *Projects*, then *process-app-start*.
 . Click *Create New Asset* -> *Data Object*.
 . In the *Create new Data Object* wizard, enter the following values:
 .. *Data Object*: `Application`.

--- a/docs/product-getting-started-guide/src/main/asciidoc/task_deploying-application.adoc
+++ b/docs/product-getting-started-guide/src/main/asciidoc/task_deploying-application.adoc
@@ -16,8 +16,8 @@ The {KIE_SERVER} is deployed and connected to the Business Central.
 
 To deploy an application in {PRODUCT}:
 
-. Log into Business Central.
-. Click *Menu* -> *Projects*.
+. Log in to Business Central.
+. Click *Menu* -> *Design* -> *Projects*.
 . Click on a project you want to deploy, for example *process-app-start*.
 . Click *Build & Deploy*.
 +

--- a/docs/product-getting-started-guide/src/main/asciidoc/task_new-project.adoc
+++ b/docs/product-getting-started-guide/src/main/asciidoc/task_new-project.adoc
@@ -8,14 +8,14 @@ The following chapter instructs you how to import an incomplete business process
 
 * Installed Red Hat JBoss EAP 7.0. For further information, see https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.0/html/installation_guide/[_Red Hat JBoss EAP 7.0 Installation Guide_].
 * Installed {PRODUCT}. For further information, see the {INSTALLATION_GUIDE}.
-* {PRODUCT} is running and you can log into Business Central with the `admin` role. For further information, see the {INSTALLATION_GUIDE}.
+* {PRODUCT} is running and you can log in to Business Central with the `admin` role. For further information, see the {INSTALLATION_GUIDE}.
 
 == Importing the Starter Project
 
 To import the starter project:
 
-. Log into Business Central.
-. Click *Menu* -> *Projects*.
+. Log in to Business Central.
+. Click *Menu* -> *Design* -> *Projects*.
 . Click *Import* -> *Advanced Import*.
 . Next to the *Repository type* label, select *Custom*. Paste the following in to the *Repository URL* field: `https://github.com/ibek/bpms-getting-started.git`. Then, click *Next*.
 +

--- a/docs/product-getting-started-guide/src/main/asciidoc/task_process-forms.adoc
+++ b/docs/product-getting-started-guide/src/main/asciidoc/task_process-forms.adoc
@@ -18,7 +18,7 @@ Finished business process model of the started project. For further information,
 
 === Creating the Applicant form
 
-. Log into Business Central. Click *Menu* -> *Projects*, then *process-app-start*.
+. Log in to Business Central. Click *Menu* -> *Design* -> *Projects*, then *process-app-start*.
 Create the *Applicant* form:
 . Click *Create New Asset > Form (Preview)*.
 . From the *Create new Form (Preview)* window, select *Data Object*.
@@ -101,7 +101,7 @@ The business process uses three data objects:
 
 Follow these steps to finish the data object forms:
 
-. Log into Business Central. Click *Menu* -> *Projects*, then *process-app-start*.
+. Log in to Business Central. Click *Menu* -> *Design* -> *Projects*, then *process-app-start*.
 . Click the *Applicant* data object form and remove the following fields:
 
 * *Address*
@@ -145,7 +145,7 @@ The `MortgageApprovalProcess` business process requires the following process ta
 
 Follow these steps to finish the process task forms:
 
-. Log into Business Central. Click *Menu* -> *Projects*, then *process-app-start*.
+. Log in to Business Central. Click *Menu* -> *Design* -> *Projects*, then *process-app-start*.
 . Click the *process-app-start.MortgageApprovalProcess-taskform* form.
 .. Remove the following form fields:
 

--- a/docs/product-migration-guide/src/main/asciidoc/chap-migration-examples.adoc
+++ b/docs/product-migration-guide/src/main/asciidoc/chap-migration-examples.adoc
@@ -134,7 +134,7 @@ Log back into JBoss BRMS 5 Guvnor and locate the Fact Model JAR and download it 
 
 image::6309.png[]
 
-In Business Central, log into *Authoring* -> *Artifact Repository*.  Press *Upload* and locate the JAR that you downloaded from JBoss BRMS 5.
+In Business Central, log in to *Authoring* -> *Artifact Repository*.  Press *Upload* and locate the JAR that you downloaded from JBoss BRMS 5.
 
 [NOTE]
 ====

--- a/docs/product-user-guide/src/main/asciidoc/chap-deploying-projects.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/chap-deploying-projects.adoc
@@ -303,7 +303,7 @@ kcontext.getKieRuntime().signalEvent("signalRefId", data, processInstanceId);
 
 To signal a process instance from Business Central, do the following:
 
-. Log into Business Central.
+. Log in to Business Central.
 . Click *Process Management* -> *Process Instances*.
 . Locate the required process instance and click *Signal* in the instance row.
 . Fill the following fields:

--- a/docs/product-user-guide/src/main/asciidoc/chap-process-designer.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/chap-process-designer.adoc
@@ -1692,7 +1692,7 @@ This file is identical to a work item definition file created in Business Centra
 
 To create a custom work item definition (WID) in the Web Process Designer, follow these steps:
 
-. Log into Business Central.
+. Log in to Business Central.
 . Click *Authoring* -> *Project Authoring*.
 . Choose the organizational unit and repository of your project to view the assets in your project.
 . Click *WORK ITEM DEFINITIONS* -> *WorkDefinitions*.
@@ -1879,7 +1879,7 @@ For more information about asynchronous execution, see _{DEVELOPMENT_GUIDE}_.
 To register a work item handler in Business Central, follow these steps:
 
 .Procedure: Uploading JAR File
-. Log into Business Central.
+. Log in to Business Central.
 . Click *Authoring* -> *Artifact repository*.
 . Click *Upload* and select the JAR file of your work item handler.
 . Click *Upload*.

--- a/docs/product-user-guide/src/main/asciidoc/data-object-deployment-descriptor-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/data-object-deployment-descriptor-proc.adoc
@@ -4,7 +4,7 @@
 For advanced persistence configuration, you can modify the `kie-deployment-descriptor.xml` file. This file defines deployment in the jBPM runtime, persistence unit information, and other advanced deployment settings. Automatic configuration of the JPA Marshalling Strategies is only available in JBoss BPM Suite.
 
 .Procedure
-. Go to *Menu* → *Projects* and select your project.
+. Go to *Menu* -> *Design* -> *Projects* and select your project.
 . In the upper-right corner, click *Settings*, and then click *Project Settings: Project General Settings* -> *Deployment descriptor* to open the `kie-deployment-descriptor.xml` editor.
 +
 

--- a/docs/product-user-guide/src/main/asciidoc/data-objects-create-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/data-objects-create-proc.adoc
@@ -4,7 +4,7 @@
 The data objects that you define can be implemented in various types of assets in your project, and are essential building blocks for your project.
 
 .Procedure
-. Go to *Menu* → *Projects* and select your project.
+. Go to *Menu* -> *Design* -> *Projects* and select your project.
 . Click *Create New Asset* → *Data Object*.
 . Enter the name and select the package. The name must be unique across the package, but it is possible to have two data objects with the same name in two different packages.
 . To make your Data Object persistable, check the *Persistable* checkbox.

--- a/docs/product-user-guide/src/main/asciidoc/data-objects-persistable-modify-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/data-objects-persistable-modify-proc.adoc
@@ -4,7 +4,7 @@
 Business central contains a `persistence.xml` file with default persistence settings. You can modify these persistence settings for all persistable data objects.
 
 .Procedure
-. Go to *Menu* → *Projects* and select your project.
+. Go to *Menu* -> *Design* -> *Projects* and select your project.
 . In the upper-right corner of the screen, click *Settings*, and then click *Project Settings: Project General Settings* -> *Persistence descriptor* to open the `persistence.xml` editor.
 +
 

--- a/docs/product-user-guide/src/main/asciidoc/decision-tables-upload-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/decision-tables-upload-proc.adoc
@@ -4,7 +4,7 @@
 After you define your rules in an external XLS or XLSX file, you can upload the file as a decision table in your project.
 
 .Procedure
-. Go to *Menu* -> *Projects* and select your project.
+. Go to *Menu* -> *Design* -> *Projects* and select your project.
 . Click *Create New Asset* -> *Decision Table (Spreadsheet)*.
 . Enter an informative *Decision Table* name and select the appropriate *Package*.
 . Select the file type (*xls* or *xlsx*), click the *Choose File...* icon, and select the spreadsheet. Click *Ok* to upload.

--- a/docs/product-user-guide/src/main/asciidoc/enumerations-add-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/enumerations-add-proc.adoc
@@ -4,7 +4,7 @@
 You can add data enumerations to your package that can be used in other assets in your project. This expands the options that are presented in drop-down menus or fields configured in guided rules, guided decision tables, and other assets.
 
 .Procedure
-. Go to *Menu* -> *Projects* and select your project.
+. Go to *Menu* -> *Design* -> *Projects* and select your project.
 . Click *Create New Asset* -> *Enumeration*.
 +
 The enumeration file appears in your *Project Explorer*.

--- a/docs/product-user-guide/src/main/asciidoc/guided-decision-table-graphs-create-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/guided-decision-table-graphs-create-proc.adoc
@@ -4,7 +4,7 @@
 You can use guided decision table graphs to consolidate related guided decision tables in a single table editor.
 
 .Procedure
-. Go to *Menu* -> *Projects* and select your project.
+. Go to *Menu* -> *Design* -> *Projects* and select your project.
 . Click *Create New Asset* -> *Guided Decision Table Graph*.
 . Enter an informative *Guided Decision Table Graph Name* and select the *Package* in which the relevant decision tables and data objects are found.
 . Click *OK*.

--- a/docs/product-user-guide/src/main/asciidoc/guided-decision-tables-columns-field-work-item-con.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/guided-decision-tables-columns-field-work-item-con.adoc
@@ -1,7 +1,7 @@
 [[_guided_decision_tables_columns_field_work_item_con]]
 = "Set the value of a field with a Work Item parameter"
 
-With this column option, you can implement an action to set the value of a previously defined fact field to the value of a result parameter of a work item handler for the "THEN" portion of the rule. The work item must define a result parameter of the same data type as a field on a bound fact in order for you to set the field to the return parameter. (Work items are created in *Menu* -> *Projects* -> *_[select project]_* -> *Create new asset* -> *Work Item Definition*.)
+With this column option, you can implement an action to set the value of a previously defined fact field to the value of a result parameter of a work item handler for the "THEN" portion of the rule. The work item must define a result parameter of the same data type as a field on a bound fact in order for you to set the field to the return parameter. (Work items are created in *Menu* -> *Design* -> *Projects* -> *_[select project]_* -> *Create new asset* -> *Work Item Definition*.)
 
 An _<<_guided_decision_tables_columns_work_item_con, Execute a Work Item>>_ column must already be created in the table for this column option to be created.
 

--- a/docs/product-user-guide/src/main/asciidoc/guided-decision-tables-columns-work-item-con.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/guided-decision-tables-columns-work-item-con.adoc
@@ -1,7 +1,7 @@
 [[_guided_decision_tables_columns_work_item_con]]
 = "Execute a Work Item"
 
-With this column option, you can execute a work item handler, based on your predefined work item definitions in Business Central. (Work items are created in *Menu* -> *Projects* -> *_[select project]_* -> *Create new asset* -> *Work Item Definition*.)
+With this column option, you can execute a work item handler, based on your predefined work item definitions in Business Central. (Work items are created in *Menu* -> *Design* -> *Projects* -> *_[select project]_* -> *Create new asset* -> *Work Item Definition*.)
 
 .Required Column Parameters
 The following parameters are required in the *Add a new column* wizard to set up this column type:

--- a/docs/product-user-guide/src/main/asciidoc/guided-decision-tables-create-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/guided-decision-tables-create-proc.adoc
@@ -4,7 +4,7 @@
 You can use guided decision tables to define rule attributes, meta-data, conditions, and actions in a tabular format that can be added to your business rules project.
 
 .Procedure
-. Go to *Menu* -> *Projects* and select your project.
+. Go to *Menu* -> *Design* -> *Projects* and select your project.
 . Click *Create New Asset* -> *Guided Decision Table*.
 . Enter an informative *Guided Decision Table* name and select the appropriate *Package*.
 . Select *Use Wizard* to finish setting up the table in the Wizard, or leave this option unselected to finish creating the table and specify remaining configurations in the guided decision table editor.

--- a/docs/product-user-guide/src/main/asciidoc/guided-rule-templates-create-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/guided-rule-templates-create-proc.adoc
@@ -4,7 +4,7 @@
 You can create guided rule templates to define rule structure and data that can be used for other rules, instead of defining many different rule structures individually.
 
 .Procedure
-. Go to *Menu* -> *Projects* and select your project.
+. Go to *Menu* -> *Design* -> *Projects* and select your project.
 . Click *Create New Asset* -> *Guided Rule Template*.
 . Enter an informative *Guided Rule Template* name and select the appropriate *Package*.
 +

--- a/docs/product-user-guide/src/main/asciidoc/guided-rules-create-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/guided-rules-create-proc.adoc
@@ -4,7 +4,7 @@
 Guided rules enable you to define business rules in a structured format, based on the data objects associated with the rules. You can create and define guided rules individually for your project.
 
 .Procedure
-. Go to *Menu* -> *Projects* and select your project.
+. Go to *Menu* -> *Design* -> *Projects* and select your project.
 . Click *Create New Asset* -> *Guided Rule*.
 . Enter an informative *Guided Rule* name and select the appropriate *Package*. You can check *Use Domain Specific Language (DSL)* to use DSL. For details, see <<rules_dsl_con>>.
 +

--- a/docs/product-user-guide/src/main/asciidoc/rules-facts-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/rules-facts-proc.adoc
@@ -4,7 +4,7 @@
 You can narrow down the facts available during rule creation and modification by adding the facts to the `package-names-white-list` file in your project. This file is a text file that accepts single package names on each line. By adding a group of facts to this file, you can speed up the loading process as you create rules.
 
 .Procedure
-. Go to *Menu* -> *Projects*, select your project, and select any existing asset.
+. Go to *Menu* -> *Design* -> *Projects*, select your project, and select any existing asset.
 . In *Project Explorer*, click the gear icon and select *Repository View*.
 . Click *`package-names-white-list`* to open the file.
 +


### PR DESCRIPTION
Ready to merge with upstream 7.4.x.

Cherry-picked from BXMSDOC-1836-master. This PR updates instances of **Menu -> Projects** to **Menu -> Design -> Projects**, according to our team decision. The former had been used in the Getting Started Guide and was starting to be used in the User Guide. I rectified the divergence.

While I was at it, I also changed all instances of **log/logging/logged into** (and any related forms) to **in to**, which is correct. Been bugging me for a long time and has needed to get corrected. So just fixed with this PR.

[Link to JIRA](https://issues.jboss.org/browse/BXMSDOC-1836)
