### PR TITLE
[7.4.x] DROOLS-1748: Drools workbench datasource on Wildfly domain

### DIFF
--- a/docs/shared-kie-docs/src/main/asciidoc/Workbench/Authoring/DataSourceManagement/DataSourceManagement-section.adoc
+++ b/docs/shared-kie-docs/src/main/asciidoc/Workbench/Authoring/DataSourceManagement/DataSourceManagement-section.adoc
@@ -181,3 +181,107 @@ And they are aligned with the latest database versions supported by the Wildfly 
 
 .By Default Drivers
 image::Workbench/Authoring/DataSourceManagement/DefaultDrivers.png[align="center"]
+
+[[_wb.advancedsettings]]
+== Advanced Settings
+
+The data source management system advanced settings can be found in the datasource-management.properties file in the WEB-INF/classes
+directory of the given Workbench distribution file.
+
+The data source management system has the ability of working with two different internal implementations for the data
+sources and drivers. An implementation based on the Wildfly/EAP native data sources and drivers, and a container
+independent implementation.
+Wildfly/EAP Workbench distributions are configured by default for using the native Wildlfy/EAP
+containers implementations, and Tomcat8 distributions are configured for using the container independent implementations.
+This latter implementation can also be used for Wildfly/EAP containers.
+
+The valid combinations are:
+
+WildflyDataSourceProvider + WildflyDriverProvider +
+or +
+DBCPDataSourceProvider + DBCPDriverProvider
+
+The datasource.management.wildfly.xxxxx  properties are only suited for the WildflyXXXProviders.
+
+
+[[_wb.advancedsettings.wildlfy]]
+== Advanced Settings for Workbench Wildlfy/EAP distributions
+
+|===
+|Property name |By default value|Description
+
+
+|datasource.management.DataSourceProvider
+|WildflyDataSourceProvider
+|see Advanced Settings.
+
+|datasource.management.DriverProvider
+|WildflyDriverProvider
+|see Advanced Settings.
+
+|datasource.management.wildfly.host
+|localhost
+|Name or ip address used for the Wildlfy server management interface binding.
+
+|datasource.management.wildfly.port
+|9990
+|Port used for the Wildlfy server management interface binding.
+
+|datasource.management.wildfly.admin
+|
+|Administration user for connecting to the Wildfly server running current Workbench. In general it's not necessary to set this value but might be needed in cases when the Wildlfy management interface is bound to an address different than localhost.
+
+|datasource.management.wildfly.password
+|
+|Administration user password for connecting to the Wildfly server running current Workbench. In general it's not necessary to set this value but might be needed in cases when the Wildlfy management interface is bound to an address different than localhost.
+
+|datasource.management.wildfly.realm
+|ManagementRealm
+|Realm for the administration user authentication.
+
+|datasource.management.wildfly.profile
+|
+|The profile name used for starting the Wildfly domain, e.g. default, full, full-ha, etc. This value must only by set when the Workbench is running in clustering mode and the hosting Wildfly servers are configured by using domains. Do not set if the Wildlfy servers are running as standalone servers.
+
+|datasource.management.wildfly.serverGroup
+|
+|The server group to which current Wildfly server instance belongs, e.g. primary-server-group, etc. This value must only by set when the Workbench is running in clustering mode and the hosting Wildfly servers are configured by using domains. Do not set if the Wildlfy servers are running as standalone servers.
+
+|datasource.management.DefChangeHandler
+|
+|This value must only by set when the Workbench is running in clustering mode. If the hosting Wildfly servers are configured by using domains the following value must be used _DomainModeChangeHandler_ and the the following value _StandaloneModeChangeHandler_ must be used in cases when the hosting Wildlfy servers are running as standalone servers.
+Clustering installations that uses the DBCPXXXProviders must be configured for using the the _StandaloneModeChangeHandler_.
+|===
+
+[NOTE]
+====
+The properties above can also be set by passing system properties to the JVM using the Java standard mechanism. e.g. -Ddatasource.management.wildfly.port=1234.
+Values configured by using this mechanism will override the values configured in the datasource-management.properties file.
+====
+
+[[_wb.advancedsettings.tomcat]]
+== Advanced Settings for Tomcat distributions
+
+|===
+|Property name |By default value|Description
+
+
+|datasource.management.DataSourceProvider
+|DBCPDataSourceProvider
+|This is the only option available for Tomcat 8 distributions, see Advanced Settings.
+
+|datasource.management.DriverProvider
+|DBCPDriverProvider
+|This is the only option available for Tomcat 8 distributions, see Advanced Settings.
+
+|datasource.management.DefChangeHandler
+|
+|This value must only by set when the Workbench is running in clustering mode. Tomcat distributions only support the
+_StandaloneModeChangeHandler_ value.
+|===
+
+[NOTE]
+====
+The properties above can also be set by passing system properties to the JVM using the Java standard mechanism. e.g. -Ddatasource.management.wildfly.port=1234.
+Values configured by using this mechanism will override the values configured in the datasource-management.properties file.
+====


### PR DESCRIPTION
    - adds missing advanced settings documentation

(cherry picked from commit 90646b396cb12f5cf54ded6f3e87b14f04423255)