### PR TITLE
BXMSDOC-1800 When installing kie-execution-server only, the server won't start

### DIFF
--- a/docs/product-installation-guide/src/main/asciidoc/eap-bxms-run-proc.adoc
+++ b/docs/product-installation-guide/src/main/asciidoc/eap-bxms-run-proc.adoc
@@ -22,6 +22,22 @@ $ ./standalone.sh
 ----
 standalone.bat
 ----
++
+[NOTE]
+====
+If you deployed Execution Server without Business Central on EAP then you must use one of the following commands to start EAP with the standalone-full profile.
+
+On Linux or Unix-based systems:
+----
+$ /standalone.sh -c standalone-full.xml
+----
+
+On Windows:
+[source,bash]
+----
+standalone.bat -c standalone-full.xml
+----
+====
 . In a web browser, open the URL `localhost:8080/business-central`.
 . Log in using the user name
 ifdef::BPMS[]


### PR DESCRIPTION
[BXMSDOC-1800](https://issues.jboss.org/browse/BXMSDOC-1800)
[SME Review](https://issues.jboss.org/browse/BXMSDOC-1851)
[Peer Review](https://issues.jboss.org/browse/BXMSDOC-1854)