### PR TITLE
AF-593+: Move Guvnor modules to uberfire and kie-wb-common.

### DIFF
--- a/code/pom.xml
+++ b/code/pom.xml
@@ -21,12 +21,12 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.guvnor</groupId>
-      <artifactId>guvnor-rest-backend</artifactId>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-rest-backend</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.guvnor</groupId>
-      <artifactId>guvnor-rest-client</artifactId>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-rest-client</artifactId>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -50,9 +50,9 @@
         <scope>import</scope>
       </dependency>
       <dependency>
-        <groupId>org.guvnor</groupId>
-        <artifactId>guvnor-bom</artifactId>
-        <version>${version.org.kie}</version>
+        <groupId>org.uberfire</groupId>
+        <artifactId>uberfire-bom</artifactId>
+        <version>${version.org.uberfire}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Fixes build error from missing guvnor artifacts.