### PR TITLE
Updating the document-attribute file to remove refrence to Beta 2.0 f…

### DIFF
--- a/docs/shared-kie-docs/src/main/asciidoc/Product/document-attributes.adoc
+++ b/docs/shared-kie-docs/src/main/asciidoc/Product/document-attributes.adoc
@@ -18,7 +18,7 @@ endif::BPMS[]
 :ENTERPRISE_VERSION: 7.0
 :COMMUNITY_VERSION: 7.0
 :PRODUCT_VERSION: {ENTERPRISE_VERSION}
-:RELEASE: Limited Availability Beta Build 2
+:RELEASE: Limited Availability
 :BOM_VERSION: 7.0.0.ER-redhat-3
 :MAVEN_ARTIFACT_VERSION: 7.3.0.Final-redhat-1
 


### PR DESCRIPTION
Update to the document-attributes.adoc file to remove reference to Beta 2.0 from all books.