### PR TITLE
BXMSDOC-1517 (for upstream 7.4.x): Updated anchor name format in all product guides

### DIFF
--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/amazon-ec2-about-con.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/amazon-ec2-about-con.adoc
@@ -1,5 +1,5 @@
 
-[[_amazon_ec2_about_con]]
+[id='_amazon_ec2_about_con']
 = About Amazon EC2 
 
 Amazon Elastic Compute Cloud (Amazon EC2) is a web service that provides a computing environment in the Amazon Web Services (AWS) cloud. Deploying {PRODUCT} to Amazon EC2 has been supported since version 6.2.

--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/amazon-ec2-configuring-user-data-proc.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/amazon-ec2-configuring-user-data-proc.adoc
@@ -1,5 +1,5 @@
 
-[[_amazon_ec2_configuring_user_data_proc]]
+[id='_amazon_ec2_configuring_user_data_proc']
 = Configuring User Data Ports on Amazon EC2 
 
 After you create your virtual machine instance on Amazon Elastic Compute Cloud (Amazon EC2) and create a security group, and before starting your new instance, you must configure your user data ports.

--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/amazon-ec2-creating-ami-proc.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/amazon-ec2-creating-ami-proc.adoc
@@ -1,5 +1,5 @@
 
-[[_amazon_ec2_creating_ami_proc]]
+[id='_amazon_ec2_creating_ami_proc']
 = Creating a New AMI from a Configured Instance
 An Amazon Machine Image (AMI) is a template for an Amazon Elastic Cloud (Amazon EC2) instance. After you have set up your virtual machine instance on Amazon EC2, you can create a new AMI from that instance, as follows:
 

--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/amazon-ec2-creating-new-security-group-proc.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/amazon-ec2-creating-new-security-group-proc.adoc
@@ -1,4 +1,4 @@
-[[_amazon_ec2_creating_new_security_group_proc]]
+[id='_amazon_ec2_creating_new_security_group_proc']
 = Creating a New Security Group on Amazon EC2
 Before you deploy {PRODUCT}, you must create a new security group on Amazon Elastic Compute Cloud (Amazon EC2).
 

--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/amazon-ec2-creating-virt-mach-inst-proc.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/amazon-ec2-creating-virt-mach-inst-proc.adoc
@@ -1,4 +1,4 @@
-[[_amazon_ec2_creating_virt_mach_inst_proc]]
+[id='_amazon_ec2_creating_virt_mach_inst_proc']
 = Creating Virtual Machine Instance on Amazon EC2
 Before you install {PRODUCT}, you must create a virtual machine instance on Amazon Elastic Compute Cloud (Amazon EC2).
 

--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/amazon-ec2-getting-started-con.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/amazon-ec2-getting-started-con.adoc
@@ -1,5 +1,5 @@
 
-[[_amazon_ec2_getting_started_con]]
+[id='_amazon_ec2_getting_started_con']
 = Getting Started with Amazon EC2
 
 The following sections describe how to get started with Amazon Elastic Computer Cloud (Amazon EC2).

--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/amazon-ec2-logging-on-proc.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/amazon-ec2-logging-on-proc.adoc
@@ -1,5 +1,5 @@
 
-[[_amazon_ec2_logging_on_proc]]
+[id='_amazon_ec2_logging_on_proc']
 = Logging in to AWS
 This procedure describes how to log in to Amazon Web Services (AWS) and launch a virtual server.
 

--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/amazon-ec2-public-key-proc.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/amazon-ec2-public-key-proc.adoc
@@ -1,5 +1,5 @@
 
-[[_amazon_ec2_public_key_proc]]
+[id='_amazon_ec2_public_key_proc']
 = Importing a Public Key
 Before creating or starting an Amazon Web Services (AWS) instance, you must import your public key to AWS to be able to connect to the instance.
 

--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/amazon-ec2-run-jboss-on-vmi-proc.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/amazon-ec2-run-jboss-on-vmi-proc.adoc
@@ -1,5 +1,5 @@
 
-[[_amazon_ec2_run_jboss_on_vmi_proc]]
+[id='_amazon_ec2_run_jboss_on_vmi_proc']
 = Running {PRODUCT} on a Virtual Machine Instance on Amazon EC2
 Perform the following steps to run {PRODUCT} on a virtual machine instance on Amazon Elastic Cloud (Amazon EC2).
 

--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/amazon-ec2-virtual-instances-con.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/amazon-ec2-virtual-instances-con.adoc
@@ -1,5 +1,5 @@
 
-[[_amazon_ec2_virtual_instances_con]]
+[id='_amazon_ec2_virtual_instances_con']
 = Creating and Starting Virtual Machine Instances on Amazon EC2
 
 To deploy {PRODUCT} to Amazon Elastic Compute Cloud (Amazon EC2), you must have a valid membership in the JBoss Cloud Access program. The program provides a number of supported Amazon Machine Images (AMIs) created by Red Hat, while each of them has Red Hat Enterprise Linux 6 and Red Hat JBoss EAP 6 (together with other required software) pre-installed.

--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/amazon-starting-vm-proc.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/amazon-starting-vm-proc.adoc
@@ -1,5 +1,5 @@
 
-[[_amazon_starting_vm_proc]]
+[id='_amazon_starting_vm_proc']
 = Starting Virtual Machine Instance on Amazon EC2
 
 To start a virtual machine instance on Amazon Elastic Compute Cloud (Amazon EC2), do the following:

--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/appe-properties.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/appe-properties.adoc
@@ -280,7 +280,7 @@ ifdef::BPMS[]
 *org.jbpm.ejb.timer.tx*::
 +
 --
-Marks if the EJB timer service is transactional.  If set to `true`, the EJB time service starts participating in the transactions. Note that this property is available only in {PRODUCT} 6.4.2 and later.   
+Marks if the EJB timer service is transactional.  If set to `true`, the EJB time service starts participating in the transactions. Note that this property is available only in {PRODUCT} 6.4.2 and later.
 
 [cols="1,1", options="header"]
 |===
@@ -403,7 +403,7 @@ Allows setting a specific `TransactionManager` JNDI lookup name as a fallback in
 endif::BPMS[]
 
 ifdef::BPMS[]
-[[jbpm.usergroup.callback.properties]]
+[id='jbpm.usergroup.callback.properties']
 *jbpm.usergroup.callback.properties*::
 +
 --
@@ -438,7 +438,7 @@ An alternative classpath location of user info configuration (used by `LDAPUserI
 endif::BPMS[]
 
 ifdef::BPMS[]
-[[jbpm.user.info.properties]]
+[id='jbpm.user.info.properties']
 *jbpm.user.info.properties*::
 +
 --
@@ -644,7 +644,7 @@ Set this property in the application server in case your application uses EJBs. 
 endif::BPMS[]
 
 ifdef::BPMS[]
-[[org.jbpm.ht.callback]]
+[id='org.jbpm.ht.callback']
 *org.jbpm.ht.callback*::
 +
 --
@@ -669,7 +669,7 @@ Specifies the implementation of user group callback to be used:
 endif::BPMS[]
 
 ifdef::BPMS[]
-[[org.jbpm.ht.custom.callback]]
+[id='org.jbpm.ht.custom.callback']
 *org.jbpm.ht.custom.callback*::
 +
 --
@@ -687,7 +687,7 @@ A custom implementation of the `UserGroupCallback` interface in case the <<org.j
 endif::BPMS[]
 
 ifdef::BPMS[]
-[[org.jbpm.ht.custom.userinfo]]
+[id='org.jbpm.ht.custom.userinfo']
 *org.jbpm.ht.custom.userinfo*::
 +
 --
@@ -705,7 +705,7 @@ A custom implementation of the `UserInfo` interface in case the <<org.jbpm.ht.us
 endif::BPMS[]
 
 ifdef::BPMS[]
-[[org.jbpm.ht.userinfo]]
+[id='org.jbpm.ht.userinfo']
 *org.jbpm.ht.userinfo*::
 +
 --
@@ -946,7 +946,7 @@ ifdef::BPMS[]
 *org.jbpm.task.assignment.rules.query*::
 +
 --
-Specifies a rule query that returns a subset of task assignments from the session. The query is executed after firing all rules. If you set this property, assignments not matched by the query are not used. Defining a query enables you to select specific assignments when multiple assignments are present in your session for one task.  
+Specifies a rule query that returns a subset of task assignments from the session. The query is executed after firing all rules. If you set this property, assignments not matched by the query are not used. Defining a query enables you to select specific assignments when multiple assignments are present in your session for one task.
 
 [cols="1,1", options="header"]
 |===
@@ -1101,7 +1101,7 @@ The initial delay before the {PRODUCT} executor starts a job, in milliseconds.
 |===
 --
 
-[[org.kie.executor.interval]]
+[id='org.kie.executor.interval']
 *org.kie.executor.interval*::
 +
 --
@@ -1148,7 +1148,7 @@ The number of retries the {PRODUCT} executor attempts on a failed job.
 |===
 --
 
-[[org.kie.executor.timeunit]]
+[id='org.kie.executor.timeunit']
 *org.kie.executor.timeunit*::
 +
 --
@@ -1325,7 +1325,7 @@ The user name to connect to the controller REST API. This property is required w
 *org.kie.server.controller.templatefile*::
 +
 --
-The system property required to set a custom `templatefile.xml` template file for use with a standalone controller to store and retrieve container templates. 
+The system property required to set a custom `templatefile.xml` template file for use with a standalone controller to store and retrieve container templates.
 
 
 [cols="1,1", options="header"]
@@ -1800,7 +1800,7 @@ If the Git daemon is enabled, it uses this property as the port number.
 |===
 --
 
-[[org.uberfire.nio.git.dir]]
+[id='org.uberfire.nio.git.dir']
 *org.uberfire.nio.git.dir*::
 +
 --

--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/aries-batch-commands-proc.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/aries-batch-commands-proc.adoc
@@ -1,6 +1,6 @@
 
-[[batch_commands]]
-[[_aries_batch_commands_proc]]
+[id='batch_commands']
+[id='_aries_batch_commands_proc']
 = Defining Batch Commands
 
 The `<kie:batch>` element enables you to define a set of batch commands for a given KIE session. 

--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/aries-blueprint-about-con.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/aries-blueprint-about-con.adoc
@@ -1,5 +1,5 @@
 
-[[_aries_blueprint_about_con]]
+[id='_aries_blueprint_about_con']
 = About Apache Aries Blueprint
 
 Apache Aries is a set of pluggable Java components that enable an enterprise Open Service Gateway initiative (OSGi) application programming model. Apache Aries Blueprint is a container implementation and extension of application-focused specifications defined by OSGi. It supports the dynamic nature of the OSGi, where services can become available and unavailable at any time. 

--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/aries-closing-file-logger-proc.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/aries-closing-file-logger-proc.adoc
@@ -1,5 +1,5 @@
-[[_aries_closing_file_logger_proc]]
-[[closing_filelogger]]
+[id='_aries_closing_file_logger_proc']
+[id='closing_filelogger']
 = Closing a FileLogger
 
 You should close the `<kie:fileLogger>` logger to prevent memory leaks.

--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/aries-event-listeners-proc.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/aries-event-listeners-proc.adoc
@@ -1,6 +1,6 @@
 
-[[event_listeners]]
-[[_aries_event_listeners_proc]]
+[id='event_listeners']
+[id='_aries_event_listeners_proc']
 = Adding and Configuring Event Listeners
 {PRODUCT} supports adding three types of listeners to KieSessions:
 
@@ -79,7 +79,7 @@ You can also define multiple listeners of one type for a KIE session.
 ====
 
 [float]
-[[_kie_grouping_listeners]]
+[id='_kie_grouping_listeners']
 == Listener Groups
 
 The `kie-aries-blueprint` module allows you to group listeners. This is useful when you define a set of listeners that you want to attach to multiple sessions, or when switching from testing to production use. The following attribute is required:

--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/aries-kie-namespace-proc.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/aries-kie-namespace-proc.adoc
@@ -1,6 +1,6 @@
 
-[[kie_namespace]]
-[[_aries_kie_namespace_proc]]
+[id='kie_namespace']
+[id='_aries_kie_namespace_proc']
 = Configuring KIE Namespace
 
 If you are using {PRODUCT} with Apache Aries Blueprint, some Kie namespace elements must be set.

--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/aries-loggers-proc.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/aries-loggers-proc.adoc
@@ -1,6 +1,6 @@
 
-[[loggers]]
-[[_aries_loggers_proc]]
+[id='loggers']
+[id='_aries_loggers_proc']
 = Configuring Loggers
 
 {PRODUCT} supports the following loggers:

--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/cdi-con.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/cdi-con.adoc
@@ -1,5 +1,5 @@
 
-[[_cdi_con]]
+[id='_cdi_con']
 = About CDI
 
 Apart from the API based approach, Red Hat JBoss BPM Suite 7 also provides the Context and Dependency Injection (CDI) to build your custom applications. CDI is a collection of component management services for the Java EE platform that enables developers to use enterprise beans in web applications. The benefits of CDI include a simplified architecture and more resuable code.

--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/cdi-defining-mbeans-proc.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/cdi-defining-mbeans-proc.adoc
@@ -1,5 +1,5 @@
 
-[[_cdi_defining_mbeans_proc]]
+[id='_cdi_defining_mbeans_proc']
 = Defining MBeans for CDI Integration
 
 To make use of `jbpm-kie-services` in your system, you must provide some MBeans to satisfy all dependencies of the services. There are several MBeans that depend on actual scenarios.

--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-asset-repository.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-asset-repository.adoc
@@ -1,4 +1,4 @@
-[[_chap_asset_repository]]
+[id='_chap_asset_repository']
 = Asset Repository
 
 ifdef::BPMS[]
@@ -84,7 +84,7 @@ curl -X POST 'localhost:8080/business-central/rest/organizationalunits/' -u USER
 For further information, refer to chapter [ref]_Knowledge Store REST API_, section [ref]_Organizational Unit Calls_ of [ref]_{DEVELOPMENT_GUIDE}_.
 
 
-[[_creating_a_repository2]]
+[id='_creating_a_repository2']
 == Creating a Repository
 
 There are three ways to create a repository: through the *Administration* perspective of Business Central, the `kie-config-cli` tool, or using the REST API calls.
@@ -176,7 +176,7 @@ curl -X POST 'localhost:8080/business-central/rest/repositories/' -u USERNAME:PA
 For further information, refer to chapter [ref]_Knowledge Store REST API_, section [ref]_Repository Calls_ of [ref]_{DEVELOPMENT_GUIDE}_.
 
 
-[[_cloning_a_repository]]
+[id='_cloning_a_repository']
 == Cloning a Repository
 
 It is possible to clone a repository either in Business Central or using the REST API calls. The `kie-config-cli` tool cannot be used to clone arbitrary repositories. Run `git clone`, or use one of the following options instead:
@@ -284,7 +284,7 @@ curl -X POST 'localhost:8080/business-central/rest/repositories/' -u USERNAME:PA
 For further information, refer to chapter [ref]_Knowledge Store REST API_, section [ref]_Repository Calls_ of [ref]_{DEVELOPMENT_GUIDE}_.
 
 
-[[_deleting_a_repository]]
+[id='_deleting_a_repository']
 == Removing a Repository
 
 Repositories can be removed using any of the following procedures.
@@ -347,7 +347,7 @@ curl -X DELETE 'localhost:8080/business-central/rest/repositories/REPOSITORY_NAM
 For further information, refer to chapter [ref]_Knowledge Store REST API_, section [ref]_Repository Calls_ of [ref]_{DEVELOPMENT_GUIDE}_.
 
 
-[[_managing_assets]]
+[id='_managing_assets']
 == Managing Assets
 
 [NOTE]
@@ -447,7 +447,7 @@ Do not use *Deploy To Runtime* with Red Hat JBoss BRMS as it causes deploy failu
 endif::BRMS[]
 
 
-[[_maven_repository]]
+[id='_maven_repository']
 == Maven Repository
 
 Maven is a software project management tool which uses a project object model (POM) file to manage:
@@ -468,7 +468,7 @@ Remote::
 Refers to any other type of repository that can be accessed by a variety of protocols such as `file://` or `http://`. These repositories can be at a remote location set up by a third-party for downloading of artifacts or an internal repository set up on a file or HTTP server, used to share private artifacts between the development teams for managing internal releases.
 
 
-[[_configuring_deployment_to_a_remote_nexus_repository]]
+[id='_configuring_deployment_to_a_remote_nexus_repository']
 == Configuring Deployment to a Remote Nexus Repository
 
 Nexus is a repository manager frequently used in organizations to centralize storage and management of software development artifacts. It is possible to configure your project so that artifacts produced by every build are automatically deployed to a repository on a remote Nexus server.

--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-business-central-configuration.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-business-central-configuration.adoc
@@ -1,4 +1,4 @@
-[[_chap_business_central_configuration]]
+[id='_chap_business_central_configuration']
 = Business Central Configuration
 
 All Business Central configuration settings are loaded from the `_EAP_HOME_/standalone/deployments/business-central.war/WEB-INF/web.xml` file. If you deploy Business Central on Red Hat JBoss EAP server, files `jboss-web.xml` and `jboss-deployment-structure.xml` contain configuration settings as well.
@@ -8,7 +8,7 @@ All Business Central configuration settings are loaded from the `_EAP_HOME_/stan
 Business Central can be run on different platforms. For more information, see {PRODUCT} {URL_INSTALLATION_GUIDE}[Installation and Configuration Guide].
 ====
 
-[[_access_control2]]
+[id='_access_control2']
 == Access Control
 
 ifdef::BPMS[]
@@ -150,7 +150,7 @@ ldap.search.scope=SUBTREE_SCOPE
 
 You can define your own roles in `EAP_HOME/standalone/deployments/business-central.war/WEB-INF/classes/workbench-policy.properties`.
 
-[[_business_central_profile_configuration]]
+[id='_business_central_profile_configuration']
 == Business Central Profile Configuration
 
 
@@ -195,12 +195,12 @@ $ mv web-exec-server.xml web.xml
 * `Dorg.kie.active.profile=ui-server` - To activate UI server profile
 endif::BPMS[]
 
-[[_sect_configuring_standalone_business_central]]
+[id='_sect_configuring_standalone_business_central']
 == Configuring Standalone Business Central
 
 To see jBPM process or task data in the runtime perspectives of Business Central (for example the Process Definitions, Process Instances, and Tasks perspectives) you must configure a connection to an execution server so that the screens and perspectives related to monitoring can display data. If Business Central is not connected to an execution server, it will not have access to data.
 
-[[_sect_branding_the_business_central_application]]
+[id='_sect_branding_the_business_central_application']
 == Branding Business Central Application
 
 The Business Central web application can be customized by overriding some of its default styles. The personalized Business Central branding allows you to get a consistent appearance across all your applications, while it is also possible to create a different user interfaces for each team within your company. The customizable elements are built by using HTML files and images, which enables an easy and flexible customization of the application without having to recompile the code.
@@ -211,7 +211,7 @@ The following Business Central application elements can be customized:
 * The upper application banner displayed after logging in can be personalized.
 * In help pop-up windows, the label text and splash help images can be customized.
 
-[[_customizing_business_central_login_page]]
+[id='_customizing_business_central_login_page']
 === Customizing Business Central Login Page
 
 .Procedure: Changing Foreground Corner Images
@@ -234,7 +234,7 @@ endif::BRMS[]
 with a new SVG file.
 . Force a full reload of the login page, bypassing the cache, to view the changes.
 
-[[_customizing_business_central_application_header]]
+[id='_customizing_business_central_application_header']
 === Customizing Business Central Application Header
 
 . Start the EAP server, open Business Central in a web browser, and log in with your user credentials.
@@ -248,7 +248,7 @@ with a new SVG file.
 ----
 . Force a full reload of the page, bypassing the cache, to view the changes.
 
-[[_customizing_business_central_splash_help_windows]]
+[id='_customizing_business_central_splash_help_windows']
 === Customizing Business Central Splash Help Windows
 
 Each splash page and its corresponding HTML file are located in the `_EAP_HOME_/standalone/deployments/business-central.war/plugins/` directory. The files contain information about the images and the text to be displayed. For example, the `authoring_perspective.splash.js` splash page points to the `authoring_perspective.splash.html` file, which contains the names, captions, and location of all the image files that appear in the splash help pop-up windows of the Business Central Authoring perspective.
@@ -276,7 +276,7 @@ Each splash page and its corresponding HTML file are located in the `_EAP_HOME_/
 . Force a full reload, bypassing the cache, and access the splash help pop-up windows to view the changes.
 
 ifdef::BPMS[]
-[[_sect_deployment_descriptors]]
+[id='_sect_deployment_descriptors']
 == Deployment Descriptors
 
 Processes and rules within Red Hat JBoss BPM Suite 6 onwards are stored in Apache Maven based packaging, and are known as knowledge archives or KJAR. The rules, processes, assets, etc. are part of a jar file built and managed by Maven. A file kept inside the `META-INF` directory of the KJAR called `kmodule.xml` can be used to define the knowledge bases and sessions. This `kmodule.xml` file, by default, is empty.
@@ -464,7 +464,7 @@ The Spring based resolver allows you to look up a bean by its identifier from a 
 ----
 
 
-[[_managing_deployment_descriptors]]
+[id='_managing_deployment_descriptors']
 === Managing Deployment Descriptors
 
 Deployment Descriptors can be edited via the Business Central in one of two ways. Either graphically (by clicking on *Authoring* -> *Project Authoring* -> *Deployment Descriptor* or by clicking on *Authoring* -> *Administration* menu and then clicking through to the `META-INF` folder in the File Explorer. Click on the `kie-deployment-descriptor.xml` file to edit it manually.
@@ -493,7 +493,7 @@ The default behavior is to add required roles to this property based on reposito
 You can of course, edit these properties manually if required, as described above by providing roles that match actual roles defined in the security realm.
 
 
-[[_managing_deployment_override_policy]]
+[id='_managing_deployment_override_policy']
 == Managing Deployment Override Policy
 
 If a user tries to deploy an artifact with a GAV (Group-Id, Artifact-Id and Version) that already exists in the system, the deployment will fail and an error message will be displayed in the *Messages* panel.
@@ -506,7 +506,7 @@ However, there may be cases when the user _may_ want to overwrite existing deplo
 endif::BPMS[]
 
 
-[[_sect_extending_business_central]]
+[id='_sect_extending_business_central']
 == Extending Business Central
 
 Starting with version 6.1 of {PRODUCT}, Business Central can be configured to add new screens, menus, editors, splashscreens and perspectives by the Administrator. These elements can extend functionality of Business Central and can be accessed through the *Extensions* -> *Plugin Management*.
@@ -596,7 +596,7 @@ You can create multiple directories and associate perspectives with those direct
 You can create a new directory by clicking the image:6418.png[] button.
 
 
-[[_the_javascript_js_api_for_extensions]]
+[id='_the_javascript_js_api_for_extensions']
 === The JavaScript (JS) API for Extensions
 
 The extensibility of Business Central is achieved by an underlying JavaScript (JS) API which is automatically loaded if it is placed in the `plugins` folder of the Business Central webapp (typically: `_INSTALL_DIR_/business-central.war/plugins/`), or it can be loaded via regular JavaScript calls.
@@ -834,7 +834,7 @@ $vfs_write(uri,content,  function(a) {
 ----
 
 
-[[_configuring_table_columns]]
+[id='_configuring_table_columns']
 == Configuring Table Columns
 
 Business Central allows you to configure views that contain lists of items in the form of tables. You can resize columns, move columns, add or remove the default list of columns and sort the columns. This functionality is provided for all views that contain tables.

--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-business-process-model-and-notation.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-business-process-model-and-notation.adoc
@@ -1,9 +1,9 @@
-[[_chap_business_process_model_and_notation]]
+[id='_chap_business_process_model_and_notation']
 = Business Process Model and Notation
 
 Business Process Model and Notation (BPMN) is a standard notation for business process modeling. It aspires to link the gap between business analysts and programmers by providing a workflow language that can be clearly understood by both.
 
-[[_about_jboss_bpms2]]
+[id='_about_jboss_bpms2']
 == Components
 
 Red Hat JBoss BPM Suite integrates multiple components to support business processes throughout their entire life cycle and to provide process management features and tools for business analysts, developers, and business users. The product can be deployed on various JEE-compliant servers; the recommended option is Red Hat JBoss Enterprise Application Platform 6.
@@ -28,7 +28,7 @@ Red Hat JBoss BPM Suite consists of the following main components:
 Red Hat JBoss BRMS comes with its own Business Central application that is a subset of the Business Central application in Red Hat JBoss BPM Suite.
 ====
 
-[[_project]]
+[id='_project']
 == Project
 
 ifdef::BRMS[]
@@ -40,7 +40,7 @@ endif::BPMS[]
 
 As a project is a Maven project, it contains the Project Object Model file (`pom.xml`) with information on how to build the output artifact. It also contains the Module Descriptor file, `kmodule.xml`, that contains the KIE Base and KIE Session configuration for the assets in the project.
 
-[[_creating_a_project]]
+[id='_creating_a_project']
 == Creating Project
 
 It is possible to create a project either in the _Project Authoring_ perspective of Business Central or using the REST API calls.
@@ -117,7 +117,7 @@ curl -X POST 'localhost:8080/business-central/rest/repositories/REPOSITORY_NAME/
 
 For further information, refer to chapter [ref]_Knowledge Store REST API_, section [ref]_Repository Calls_ of the [ref]_{DEVELOPMENT_GUIDE}_.
 
-[[_adding_dependencies1]]
+[id='_adding_dependencies1']
 == Adding Dependencies
 
 To add dependencies to your project, do the following:
@@ -138,7 +138,7 @@ Additionally, you can use the *Package white list* when working with dependencie
 If working with modified artifacts, do not re-upload modified non-snapshot artifacts as Maven will not know these artifacts have been updated, and it will not work if it is deployed in this manner.
 ====
 
-[[_creating_package]]
+[id='_creating_package']
 == Creating Package
 
 To be able to import resources and reference them, create your resources, including processes, in a package of a particular project. To create a package:

--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-cdi-integration.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-cdi-integration.adoc
@@ -1,4 +1,4 @@
-[[_chap_cdi_integration]]
+[id='_chap_cdi_integration']
 = CDI Integration
 
 include::cdi-con.adoc[leveloffset=+1]

--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-command-line-configuration.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-command-line-configuration.adoc
@@ -1,4 +1,4 @@
-[[chap_command_line_configuration]]
+[id='chap_command_line_configuration']
 = Command Line Configuration
 
 The `kie-config-cli` tool is a command line configuration tool that provides capabilities to manage the system repository from the command line and can be used in an online or offline mode.
@@ -20,7 +20,7 @@ The tool is available on the https://access.redhat.com[Red Hat Customer Portal].
 Extract the zip package for supplementary tools you downloaded from the https://access.redhat.com[Red Hat Customer Portal]. It contains the directory `kie-config-cli-6.MINOR_VERSION-redhat-x-dist` with file `kie-config-cli.sh`.
 
 
-[[_starting_the_kie_config_cli_tool_in_online_mode]]
+[id='_starting_the_kie_config_cli_tool_in_online_mode']
 == Starting the kie-config-cli Tool in Online Mode
 
 . To start the `kie-config-cli` tool in online mode, navigate to the `kie-config-cli-6.MINOR_VERSION-redhat-x-dist` directory where you installed the tool and then execute the following command.
@@ -45,7 +45,7 @@ By default, the tool starts in online mode and asks for user credentials and a G
 Example: `git://kie-wb-host:9148/system`
 
 
-[[_starting_the_kie_config_cli_tool_in_offline_mode]]
+[id='_starting_the_kie_config_cli_tool_in_offline_mode']
 == Starting the kie-config-cli Tool in Offline Mode
 
 To operate in offline mode, append the offline parameter to the command as below.
@@ -69,7 +69,7 @@ In a Windows environment, run:
 Executing this command changes the tool's behaviour and displays a request to specify the folder where the system repository (`.niogit`) is located. If .niogit does not yet exist, the folder value can be left empty and a brand new setup is created.
 
 
-[[_commands_available_for_the_kie_config_cli_tool]]
+[id='_commands_available_for_the_kie_config_cli_tool']
 == Commands Available for the kie-config-cli Tool
 
 The following commands are available for managing the Git repository using the `kie-config-cli` tool:

--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-data-management.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-data-management.adoc
@@ -1,7 +1,7 @@
-[[_chap_data_management]]
+[id='_chap_data_management']
 = Data Management
 
-[[_data_backups]]
+[id='_data_backups']
 == Data Backups
 
 When applying a backup mechanism to {PRODUCT}, ensure you back up the following resources:
@@ -22,7 +22,7 @@ The location of the `.niogit` directory may be different based on your configura
 ====
 
 
-[[_indexing_foreign_keys]]
+[id='_indexing_foreign_keys']
 == Setup Indexes
 
 [float]
@@ -38,12 +38,12 @@ Process and Task Dashboard in 6.1 has been refactored in order to cope with high
 Note that _ALL_ the columns in these two tables need to be indexed and not just the primary and foreign keys.
 
 
-[[_setting_up_the_database]]
+[id='_setting_up_the_database']
 == Setting up and Editing the Database
 
 For information on how to change the database for {PRODUCT}, see {URL_INSTALLATION_GUIDE}#chap_special_setups[Persistence Setups] of the _{INSTALLATION_GUIDE}_.
 
-[[_ddl_scripts]]
+[id='_ddl_scripts']
 == DDL Scripts
 
 DDL scripts for database tables for {PRODUCT} are available for download on the Customer Portal. These scripts allow you to study the tables and use them to create the tables and indexes manually or in databases that are not directly supported.

--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-execution-error-management.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-execution-error-management.adoc
@@ -1,4 +1,4 @@
-[[chap-execution-error-management]]
+[id='chap-execution-error-management']
 = Execution Error Management
 
 When an execution error occurs, the process stops and rolls back to the most recent stable state (the closest safe point) and continues its execution. If an error of any kind is not handled by the process, the entire transaction rolls back, leaving the process instance in the previous wait state. Any trace of this is only visible in the logs, and usually displayed to the caller who sent the request to the process engine.
@@ -42,7 +42,7 @@ This information is mainly used for errors that are of unknown type; that is, er
 `ExecutionErrorStorage` is a pluggable strategy that permits various ways of persisting information about execution errors. Storage is used directly by the handler that gets an instance of the store when it is created (when RuntimeEngine is created). Default storage implementation is based on the database table, which stores every error and includes all of the available information. Some errors may not contain details, as this depends on the type of error and whether or not it is possible to extract specific information.
 
 
-[[_sect_error_types_and_filters]]
+[id='_sect_error_types_and_filters']
 == Error Types and Filters
 
 Error handling attempts to catch and handle any kind of error, therefore it needs a way to categorize errors. By doing this, it is able to properly extract information from the error and make it pluggable, as some users may require specific types of errors to be thrown and handled in different ways than what is provided by default.
@@ -76,7 +76,7 @@ Filters are given a higher execution order based on the lowest value of the prio
 . Job
 . DB
 
-[[_sect_view_process_instance_errors]]
+[id='_sect_view_process_instance_errors']
 == View Errors in the Process Instances Perspective
 
 In Business Central, there are two perspectives where administrators are made aware of process errors.
@@ -92,7 +92,7 @@ In the *Process Instances* perspective, the *Errors* column displays the number 
 The *Error Management* view shows a list of errors, filtered by the selected process instance ID.
 
 
-[[_sect_error_management_perspective]]
+[id='_sect_error_management_perspective']
 == Manage Errors Using the Error Management Perspective
 
 By definition, every error that is caught and stored is unacknowledged, meaning that it is to be handled by someone or something (in case of automatic error recovery). The basis of filtering on existing errors is whether or not they have been taken care of. Acknowledgment on each error saves the user who performed the acknowledgment and the time stamp for traceability purposes.
@@ -113,7 +113,7 @@ Click the *Go to job* button to view the associated job information in the *Jobs
 + 
 The *Jobs* perspective allows you to restart, reschedule, or retry the corresponding job.
 
-[[sect-filtering-errors]]
+[id='sect-filtering-errors']
 == Advanced Search Filtering of Errors
 
 Users with administrator or process administrator permissions can filter errors using the *Search* tab in the *Execution Errors* perspective.
@@ -168,7 +168,7 @@ image::DateRangeSearch.png[Search by Date Range]
 
 For more information about advanced search filtering, see {URL_USER_GUIDE}#chap-process-admin-quick-filtering[Process Administration Advanced Search Filtering] in the {USER_GUIDE}.
 
-[[_sect_auto_acknowledge_errors]]
+[id='_sect_auto_acknowledge_errors']
 == Auto Acknowledging Execution Errors
 
 When executions errors occur they are unacknowledged by default, and require a manual action to be performed otherwise they are always seen as information that requires attention. In case of larger volumes, manual actions can be time consuming and not suitable in some situations. 
@@ -201,7 +201,7 @@ The following steps are optional, and allow you to configure auto acknowledge jo
 +
 image::auto_acknowledge_error_job2.png[]
 
-[[_sect_error_list_cleanup]]
+[id='_sect_error_list_cleanup']
 == Cleaning Up the Error List
 
 The `ExecutionErrorInfo` error list table can be cleaned up to remove redundant information. Depending on the life cycle of the process, errors may remain in the list for some time, and there is no direct API with which to clean up the list. Instead, `jbpm-executor` commands can be scheduled to periodically clean up errors. 

--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-integrating-red-hat-jboss-bpm-suite-with-red-hat-jboss-fuse.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-integrating-red-hat-jboss-bpm-suite-with-red-hat-jboss-fuse.adoc
@@ -1,4 +1,4 @@
-[[_chap_integrating_with_red_hat_jboss_fuse]]
+[id='_chap_integrating_with_red_hat_jboss_fuse']
 = Integrating {PRODUCT} with Red Hat JBoss Fuse
 
 Red Hat JBoss Fuse integration allows users of Red Hat JBoss Fuse to complement their integration solution with additional features provided by Red Hat JBoss BPM Suite and Red Hat JBoss BRMS.
@@ -85,7 +85,7 @@ The following table provides example of use cases for some of the features liste
 | Use KIE-Aries-Blueprint integration.
 |===
 
-[[_spring]]
+[id='_spring']
 [float]
 === kie-spring Feature Further Information
 
@@ -111,7 +111,7 @@ The integration pack features are defined in the `karaf-features-_VERSION_-featu
 The file can also be downloaded from either the Red Hat JBoss Fuse product page or {PRODUCT} product page on the Red Hat Customer Portal.
 
 
-[[_installupdate_core_integration_features]]
+[id='_installupdate_core_integration_features']
 == Installing and Updating Core Integration Features
 
 [NOTE]
@@ -227,7 +227,7 @@ JBossFuse:karaf@root> features:install drools-module
 endif::BRMS[]
 
 
-[[_install_additional_integration_features]]
+[id='_install_additional_integration_features']
 == Installing Additional Integration Features
 
 Use the following procedure for additional integration with SwitchYard and Apache Camel.
@@ -291,7 +291,7 @@ The [class]``MVELUserGroupCallback`` class fails to initialize in an OSGi enviro
 ====
 
 
-[[_sect_install_jboss_fuse_integration_quickstart_applications]]
+[id='_sect_install_jboss_fuse_integration_quickstart_applications']
 == Installing Red Hat JBoss Fuse Integration Quick Start Applications
 
 The following features for Red Hat JBoss Fuse integration quick start applications are provided by `org/jboss/integration/fuse/quickstarts/karaf-features/VERSION/karaf-features-VERSION-features.xml`:
@@ -334,7 +334,7 @@ JBossFuse:karaf@root> features:install fuse-bxms-quickstart-switchyard-bpm-servi
 . Unpack the contents of the system directory into your existing `_INSTALLATION_DIRECTORY_/system` directory.
 
 
-[[_testing_your_first_quickstart_application]]
+[id='_testing_your_first_quickstart_application']
 === Testing Your First Quick Start Application
 
 .Procedure: Testing Quick Start Application

--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-integrating-red-hat-jboss-brms-with-red-hat-jboss-fuse.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-integrating-red-hat-jboss-brms-with-red-hat-jboss-fuse.adoc
@@ -1,4 +1,4 @@
-[[_chap_integrating_red_hat_jboss_brms_with_red_hat_jboss_fuse]]
+[id='_chap_integrating_red_hat_jboss_brms_with_red_hat_jboss_fuse']
 = Integrating Red Hat JBoss BRMS with Red Hat JBoss Fuse
 
 Red Hat JBoss Fuse integration allows users of Red Hat JBoss Fuse to complement their integration solution with additional features provided by Red Hat JBoss BPM Suite and Red Hat JBoss BRMS.
@@ -67,7 +67,7 @@ The following table provides example of use cases for some of the features liste
 | Use KIE-Aries-Blueprint integration.
 |===
 
-[[_spring]]
+[id='_spring']
 [float]
 = kie-spring Feature Further Information
 
@@ -93,7 +93,7 @@ This file (and supporting repositories) is located in http://repository.jboss.or
 The file can also be downloaded from either the Red Hat JBoss Fuse 6.2 or {PRODUCT} product page in the Red Hat Customer Portal.
 
 
-[[_installupdate_core_integration_features]]
+[id='_installupdate_core_integration_features']
 == Installing and Updating Core Integration Features
 
 [NOTE]
@@ -201,7 +201,7 @@ JBossFuse:karaf@root> features:install drools-module
 ----
 
 
-[[_install_additional_integration_features]]
+[id='_install_additional_integration_features']
 == Installing Additional Integration Features
 
 Use the following procedure for additional integration with SwitchYard and Apache Camel.
@@ -267,7 +267,7 @@ The [class]``MVELUserGroupCallback`` class fails to initialize in an OSGi enviro
 ====
 
 
-[[_sect_install_jboss_fuse_integration_quickstart_applications]]
+[id='_sect_install_jboss_fuse_integration_quickstart_applications']
 == Installing Red Hat JBoss Fuse Integration Quick Start Applications
 
 The following features for Red Hat JBoss Fuse integration quick start applications are provided by `org/jboss/integration/fuse/quickstarts/karaf-features/1.0.0.redhat-_VERSION_/karaf-features-1.0.0.redhat-_VERSION_-features.xml`:
@@ -307,7 +307,7 @@ JBossFuse:karaf@root> features:install fuse-bxms-switchyard-quickstart-bpm-servi
 . Unpack the contents of the system directory into your existing `_INSTALLATION_DIRECTORY_/system` directory.
 
 
-[[_testing_your_first_quickstart_application]]
+[id='_testing_your_first_quickstart_application']
 === Testing Your First Quick Start Application
 
 .Procedure: Testing Quick Start Application

--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-integrating-red-hat-jboss-bxms-with-red-hat-sso.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-integrating-red-hat-jboss-bxms-with-red-hat-sso.adoc
@@ -176,7 +176,7 @@ The RH-SSO server converts the user names to lowercase. Therefore, after integra
 You can also configure RH-SSO adapter for EAP by updating your applications WAR file to use the RH-SSO security subsystem. However, the recommended approach is configuring the adapter through the RH-SSO subsystem. This means that you are updating EAP configuration instead of applying the configuration on each WAR file.
 ====
 
-[[_adding_a_new_user]]
+[id='_adding_a_new_user']
 === Adding a New User
 
 To add new users and assign them a role to access Business Central:
@@ -500,7 +500,7 @@ If you have enabled the basic authentication in the RH-SSO client adapter config
 curl http://admin:password@localhost:8080/kie-execution-server/services/rest/server/
 ----
 
-[[_token_based_authentication]]
+[id='_token_based_authentication']
 === Token-Based Authentication
 
 If you want to opt for a more secure option of authentication, you can consume the remote services from both Business Central and {KIE_SERVER} using a granted token provided by RH-SSO.

--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-integration-with-aries-blueprint.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-integration-with-aries-blueprint.adoc
@@ -1,4 +1,4 @@
-[[_chap_integration_with_aries_blueprint]]
+[id='_chap_integration_with_aries_blueprint']
 = Integration with Apache Aries Blueprint
 
 This chapter explains the integration elements of {PRODUCT} specific to Apache Aries Blueprint.

--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-integration-with-spring.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-integration-with-spring.adoc
@@ -1,7 +1,7 @@
-[[_chap_integration_with_spring]]
+[id='_chap_integration_with_spring']
 = Integration with Spring
 
-[[_configuring_red_hat_jboss_bpm_suite_with_apache_spring]]
+[id='_configuring_red_hat_jboss_bpm_suite_with_apache_spring']
 == Configuring {PRODUCT} with Spring
 
 The

--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-kie-server-configuration.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-kie-server-configuration.adoc
@@ -1,4 +1,4 @@
-[[_chap_the_realtime_decision_server]]
+[id='_chap_the_realtime_decision_server']
 = {KIE_SERVER}
 
 The {KIE_SERVER}
@@ -16,7 +16,7 @@ You can provision the {KIE_SERVER} instances through Business Central. In this c
 
 NOTE: For more information, see the {URL_DEVELOPMENT_GUIDE}#intelligent_process_server_and_realtime_decision_server[Intelligent Process Server and Realtime Decision Server] chapter of the _{DEVELOPMENT_GUIDE}_.
 
-[[_deploying_the_realtime_decision_server]]
+[id='_deploying_the_realtime_decision_server']
 == Deploying {KIE_SERVER}
 
 The {KIE_SERVER} is distributed as a web application archive (WAR) file `kie-execution-server.war`. When you install {PRODUCT}, deploy the `kie-execution-server.war` file for full functionality. For information about how to deploy the {KIE_SERVER}, see the {INSTALLATION_GUIDE}.
@@ -43,10 +43,10 @@ After deploying the {KIE_SERVER}:
 </response>
 ----
 
-[[_installing_different_containers]]
+[id='_installing_different_containers']
 == Installing {KIE_SERVER} in Other Containers
 
-[[_decision_server_tomcat]]
+[id='_decision_server_tomcat']
 === Red Hat JBoss Web Server 2.__X__/3.__X__, Tomcat 8.__X__/9.__X__
 
 Use the following procedure to install the {KIE_SERVER} in a Tomcat container.
@@ -82,10 +82,10 @@ $ ./startup.sh -Dorg.kie.server.id=first-kie-server -Dorg.kie.server.location=ht
 It is not possible to use the JMS interface if the {KIE_SERVER} was installed on Tomcat or any other web container. The web container version of the WAR file contains only the REST interface.
 ====
 
-[[_realtime_decision_server_setup]]
+[id='_realtime_decision_server_setup']
 == {KIE_SERVER} Setup
 
-[[_bootstrap_switches]]
+[id='_bootstrap_switches']
 === Bootstrap Switches
 
 The {KIE_SERVER} accepts a number of bootstrap switches (system properties) to configure the behavior of the server.
@@ -332,7 +332,7 @@ endif::BPMS[]
 * `true`; the deployment of the server application joins the controller connection thread with the main deployment and awaits its completion. This option can lead to a potential deadlock in case more applications are on the same server instance. It is strongly recommended to use only one application (the server) on one server instance.
 |===
 
-[[_managed_decision_server]]
+[id='_managed_decision_server']
 === Managed {KIE_SERVER}
 
 A managed instance requires an available controller to start the {KIE_SERVER}.  
@@ -356,7 +356,7 @@ To run the {KIE_SERVER} in standalone mode without connecting to controllers, se
 ====
 
 [float]
-[[_registering_a_decision_server]]
+[id='_registering_a_decision_server']
 === Configuring {KIE_SERVER} Managed by Business Central
 
 WARNING: This section provides a sample setup that you can use for testing purposes. Some of the values are unsuitable for a production environment, and are marked as such.
@@ -477,7 +477,7 @@ ifdef::BRMS[.JVM Properties for Managed {KIE_SERVER} Instance]
 
 . Verify successful registration by logging in to Business Central and selecting *Deploy* -> *Execution Servers*. If successful, you can see the registered server ID.
 
-[[_unmanaged_decision_server]]
+[id='_unmanaged_decision_server']
 === Unmanaged {KIE_SERVER}
 
 An unmanaged {KIE_SERVER} is a standalone instance, and therefore must be configured individually using REST/JMS API from the {KIE_SERVER} itself. There is no controller involved. The configuration is automatically persisted by the server into a file and that is used as the internal server state, in case of restarts.
@@ -543,7 +543,7 @@ The following restrictions apply:
 endif::BPMS[]
 
 
-[[_creating_a_container]]
+[id='_creating_a_container']
 == Creating Containers
 
 Once the {KIE_SERVER} is registered, you can start adding containers. Containers are self-contained environments that have been provisioned to hold instances of your packaged and deployed rule instances.

--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-kie-server-router-integration.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-kie-server-router-integration.adoc
@@ -1,4 +1,4 @@
-[[_chap_kie_server_router_integration]]
+[id='_chap_kie_server_router_integration']
 
 = Intelligent Process Server Router Integration With Business Central
 

--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-localization-and-customization.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-localization-and-customization.adoc
@@ -1,7 +1,7 @@
-[[_chap_localization_and_customization]]
+[id='_chap_localization_and_customization']
 = Localization and Customization
 
-[[_available_languages2]]
+[id='_available_languages2']
 == Available Languages
 
 The {PRODUCT} web user interface can be viewed in multiple languages:
@@ -28,7 +28,7 @@ Dashbuilder does not support Traditional Chinese (``zh_TW``).
 endif::BPMS[]
 
 
-[[_changing_language_settings]]
+[id='_changing_language_settings']
 == Changing Language Settings
 
 [float]
@@ -92,7 +92,7 @@ Within Business Central, the application server does not need to be restarted af
 ====
 endif::BPMS[]
 
-[[_running_the_jvm_with_utf_8_encoding]]
+[id='_running_the_jvm_with_utf_8_encoding']
 == Running the JVM with UTF-8 Encoding
 
 {PRODUCT} is designed to work with UTF-8 encoding. If a different encoding system is being used by the JVM, unexpected errors might occur.

--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-logging.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-logging.adoc
@@ -1,4 +1,4 @@
-[[_chap_logging]]
+[id='_chap_logging']
 = Logging
 ifdef::BPMS[]
 The logging mechanism allows you to store information about the execution of a process instance. It is provided by a special event listener that listens to the Process Engine for any relevant events to be logged, so that the information can be stored separately from other non-log information stored either in the server built-in database (H2) or a connected data source using JPA or Hibernate.
@@ -132,7 +132,7 @@ The `jbpm-audit` module provides the event listener and also allows you to store
 If necessary, define your own data model of custom information and use the process event listeners to extract the information.
 
 
-[[_creating_a_logger]]
+[id='_creating_a_logger']
 == Logging events to database
 
 To log an event that occurs on runtime in a Process instance, an Element instance, or a variable instance, you need to do the following:
@@ -231,7 +231,7 @@ import org.jbpm.process.audit.JPAAuditLogService;
 endif::BPMS[]
 
 
-[[_logging4]]
+[id='_logging4']
 == Logback Functionality
 
 {PRODUCT} provides `logback` functionality for logging configuration.
@@ -253,7 +253,7 @@ Accordingly, everything configured is logged to the [ref]_Simple Logging Facade 
 ====
 
 
-[[_configuring_logging2]]
+[id='_configuring_logging2']
 == Configuring Logging
 
 To configure the logging level of the packages, create a `logback.xml` file in `business-central.war/WEB-INF/classes/logback.xml`. To set the logging level of the `org.drools` package to "debug" for verbose logging, you would need to add the following line to the file:
@@ -301,7 +301,7 @@ Additional logging can be configured in the individual container. To configure l
 
 
 ifdef::BPMS[]
-[[_configuring_logging3]]
+[id='_configuring_logging3']
 == Managing log files
 
 Red Hat JBoss BPM Suite manages most of the required maintenance. Automatically cleaned runtime data includes:
@@ -325,7 +325,7 @@ In order not to lose track of process instances, Red Hat JBoss BPM Suite offers 
 * Manual clean-up
 
 
-[[_aut_clean_up]]
+[id='_aut_clean_up']
 === Automatic Clean-Up
 
 Automatic clean-up uses the `LogCleanupCommand` executor command, which consists of logic to clean up all or selected data automatically. An advantage of the automatic clean-up method is the ability to schedule repeated clean-ups by using reoccurring job feature of the JBoss BPM Suite executor. This means that when one job completes, it provides information to the JBoss BPM Suite executor if and when the next instance of this job should be executed.
@@ -395,7 +395,7 @@ While all audit tables have a time stamp, some may be missing other parameters, 
 ====
 
 
-[[_aut_cleanup_setup]]
+[id='_aut_cleanup_setup']
 === Setting up Automatic Clean-up Job
 
 To set up automatic clean-up job, do the following:
@@ -413,7 +413,7 @@ org.jbpm.executor.commands.LogCleanupCommand
 . Click *Create* to finalize the job creation wizard. You have successfully created an automatic clean-up job.
 
 
-[[_man_clean_up]]
+[id='_man_clean_up']
 === Manual Clean-Up
 
 You may make use of audit API to do the clean-up manually with more control over parameters and thus more control over what will be removed. Audit API is divided into following areas:

--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-managing-security-for-red-hat-jboss-bpm-suite-dashbuilder.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-managing-security-for-red-hat-jboss-bpm-suite-dashbuilder.adoc
@@ -1,7 +1,7 @@
-[[_chap_managing_security_for_red_hat_jboss_bpm_suite_dashbuilder]]
+[id='_chap_managing_security_for_red_hat_jboss_bpm_suite_dashbuilder']
 = Managing Security for Red Hat JBoss BPM Suite Dashbuilder
 
-[[_logging_on_to_red_hat_jboss_bpms]]
+[id='_logging_on_to_red_hat_jboss_bpms']
 == Accessing Red Hat JBoss BPM Suite Dashbuilder
 
 Dashbuilder is the Red Hat JBoss BPM Suite web-based user interface for Business Activity Monitoring. To access the Dashbuilder from Business Central, go to *Dashboards* -> *Process & Task Dashboards*.
@@ -9,7 +9,7 @@ Dashbuilder is the Red Hat JBoss BPM Suite web-based user interface for Business
 The displayed dashboard provides statistics on runtime data selected on the left. You can create your own dashboard in the Dashbuilder. To do so, display the Dashbuilder by clicking *Dashboards* -> *Business Dashboards*.
 
 
-[[_managing_security]]
+[id='_managing_security']
 == Managing security
 
 To manage security, you can define custom authorization policies to grant or deny access to workspace, page, or panel instances per role.
@@ -25,7 +25,7 @@ Defined below is a list of the available roles for Dashbuilder:
 Thanks to the permissions system, you can build a workspace structure with several pages, menus, and panels and define what pages and panels within a page will be visible for each role. You can also define special types of users and give them restricted access to certain tooling features, or even restricted access to a page subset.
 
 
-[[_workspace_permissions]]
+[id='_workspace_permissions']
 == Workspace permissions
 
 .Procedure: Accessing Workspace Permissions
@@ -67,7 +67,7 @@ By default, the full set of permissions go to the role `admin`. This makes it ea
 ====
 
 
-[[_page_permissions]]
+[id='_page_permissions']
 == Page permissions
 
 . To access *Page permissions*, locate the *Pages* drop-down under the jBPM Dashboard (or whatever Dashboard you selected).
@@ -86,7 +86,7 @@ Under the *Permissions* section is a list of allowed actions that are applied to
 * **Edit permissions**: Ability to grant/deny permissions for the page.
 
 
-[[_panel_permissions]]
+[id='_panel_permissions']
 == Panel permissions
 
 . To access the *Panel permissions* page, expand the *Panel instances* option under the jBPM Dashboard (or whatever Dashboard you are using).

--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-migration.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-migration.adoc
@@ -1,4 +1,4 @@
-[[_chap_migration]]
+[id='_chap_migration']
 = Migration
 
 Migrating your projects from {PRODUCT} 5 to {PRODUCT} 6 requires careful planning and step by step evaluation of the various issues. You can plan for migration either manually, or by using automatic processes. Most real world migration will require a combination of these two processes.
@@ -79,7 +79,7 @@ To import the repository in JBoss Developer Studio, do the following
 
 
 ifdef::BPMS[]
-[[_runtime_migration]]
+[id='_runtime_migration']
 == Runtime Migration
 
 To run Red Hat JBoss BPM Suite 5 processes in Red Hat JBoss BPM Suite 6, do the following:
@@ -113,7 +113,7 @@ ksession.signalEvent("SomeEvent", null);
 endif::BPMS[]
 
 
-[[_api_and_backwards_compatibility]]
+[id='_api_and_backwards_compatibility']
 == API and Backwards Compatibility
 
 [float]
@@ -137,7 +137,7 @@ If you are instead using the REST API in {PRODUCT} 5, note that this has changed
 
 
 ifdef::BPMS[]
-[[_migrating_task_service]]
+[id='_migrating_task_service']
 == Migrating task service
 
 {PRODUCT} 6 provides support for a locally running task server only. This means that you do not need to setup any messaging service in your project. This differs from {PRODUCT} 5 because it provided a task server that was bridged from the core engine by using, most commonly, the messaging system provided by HornetQ.

--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-monitoring.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-monitoring.adoc
@@ -1,7 +1,7 @@
-[[_chap_monitoring]]
+[id='_chap_monitoring']
 = Monitoring
 
-[[_jboss_operations_network1]]
+[id='_jboss_operations_network1']
 == JBoss Operations Network
 
 A JBoss Operations Network plug-in can be used to monitor rules sessions for {PRODUCT}.
@@ -10,7 +10,7 @@ Due to a limitation of passing the JVM monitoring arguments via the Maven comman
 
 See the https://access.redhat.com/documentation/en-US/Red_Hat_JBoss_Operations_Network/3.3/html-single/Installation_Guide/index.html[Installation Guide] of _Red Hat JBoss Operations Network_ for installation instructions on the Red Hat JBoss ON server.
 
-[[_downloading_the_standalone_package1]]
+[id='_downloading_the_standalone_package1']
 == Downloading Red Hat JBoss BRMS for JBoss EAP
 
 . Go to the https://access.redhat.com[Red Hat Customer Portal] and log in.
@@ -20,7 +20,7 @@ See the https://access.redhat.com/documentation/en-US/Red_Hat_JBoss_Operations_N
 . Select *Red Hat JBoss BRMS {PRODUCT_VERSION}.0 Deployable for EAP 6* and then click *Download*.
 
 
-[[_installing_the_jboss_operations_network_plug_in]]
+[id='_installing_the_jboss_operations_network_plug_in']
 == Installing the JBoss BRMS Plug-in into JBoss ON
 
 Red Hat JBoss BRMS plug-in for JBoss Operations Network can be installed by either copying the plug-in JAR files to the JBoss Operations Network plug-in directory or through the JBoss Operations Network GUI.
@@ -54,7 +54,7 @@ To upload the JBoss BRMS plug-in through the JBoss Operations Network GUI, follo
 . The JBoss BRMS plug-in for JBoss Operations Network is now uploaded.
 
 
-[[_monitoring_knowledge_bases_and_knowledge_sessions1]]
+[id='_monitoring_knowledge_bases_and_knowledge_sessions1']
 == Monitoring Kie Bases and Kie Sessions
 
 In order for JBoss Operations Network to monitor KieBases and KieSessions, MBeans must be enabled.

--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-persistence.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-persistence.adoc
@@ -1,4 +1,4 @@
-[[_chap_persistence]]
+[id='_chap_persistence']
 = Persistence
 
 The runtime data of the Process Engine can be persisted in data stores. The persistence mechanism saves the data using marshalling: the runtime data is converted into a binary dataset and the dataset is saved in the data storage.
@@ -20,7 +20,7 @@ Red Hat JBoss BPM Suite will persist the following when persistence is configure
 Based on the persisted data, it is possible to restore the state of execution of all running process instances in case of failure or to temporarily remove running instances from memory and restore them later.
 By default, no persistence is configured.
 
-[[_safe_points]]
+[id='_safe_points']
 To allow persistence, you need to add the jbpm-persistence jar files to the classpath of your application and configure the engine to use persistence. The engine automatically stores the runtime state in the storage when the engine reaches a safe point. Safe points are points where the process instance has paused. When a process instance invocation reaches a safe point in the engine, the engine stores any changes to the process instance as a snapshot of the process runtime data. However, when a process instance is completed, the persisted snapshot of process instance runtime data is automatically deleted.
 
 If a failure occurs and you need to restore the engine runtime from the storage, the process instances are automatically restored and their execution resumes so there is no need to reload and trigger the process instances manually.
@@ -30,7 +30,7 @@ The runtime persistence data is to be considered internal to the engine. You sho
 To obtain information about the current execution state, refer to the history log. Query the database for runtime data only if absolutely necessary.
 
 
-[[_session3]]
+[id='_session3']
 == Session
 
 Sessions are persisted as [class]``SessionInfo`` entities. These persist the state of the runtime KIE session, and store the following data:
@@ -62,7 +62,7 @@ Sessions are persisted as [class]``SessionInfo`` entities. These persist the sta
 |
 |===
 
-[[_process_instance]]
+[id='_process_instance']
 == Process Instance
 
 Process instances are persisted as [class]``ProcessInstanceInfo`` entities, which persist the state of a process instance on runtime and store the following data:
@@ -153,7 +153,7 @@ RuntimeManager manager = RuntimeManagerFactory.Factory.get().newPerRequestRuntim
 ----
 
 
-[[_work_item]]
+[id='_work_item']
 == Work Item
 
 Work Items are persisted as [class]``workiteminfo`` entities, which persist the state of the particular work item instance on runtime and store the following data:
@@ -194,10 +194,10 @@ Work Items are persisted as [class]``workiteminfo`` entities, which persist the 
 |===
 
 
-[[_sect_persistence_configuration]]
+[id='_sect_persistence_configuration']
 == Persistence configuration
 
-[[_data_source_requirements]]
+[id='_data_source_requirements']
 === Persistence configuration
 
 Although persistence is not used by default, the dependencies needed are available in the runtime directory as jar files.
@@ -205,7 +205,7 @@ Although persistence is not used by default, the dependencies needed are availab
 Persistence is defined per session and you can define it either using the [class]``JBPMHelper`` class after you create a session or using the [class]``JPAKnowledgeService`` to create your session. The latter option provides more flexibility, while [class]``JBPMHelper`` has a method to create a session, and uses a configuration file to configure this session.
 
 
-[[_connecting_to_a_data_source]]
+[id='_connecting_to_a_data_source']
 === Configuring persistence using JBPMHelper
 
 To configure persistence of your session using JBPMHelper, do the following:
@@ -245,7 +245,7 @@ Any invocations on the session will now trigger the persistence process.
 Make sure the datasource is up and running on engine start. If you are running the in-memory H2 database, you can start the database from your application using the `JBPMHelper.startH2Server();` method call and register it with the engine using `JBPMHelper.setupDataSource();` method call.
 
 
-[[_programming_persistence]]
+[id='_programming_persistence']
 === Configuring persistence using JPAKnowledgeService
 
 To create your knowledge session and configure its persistence using JPAKnowledgeService, do the following:

--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-process-execution-server-configuration.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-process-execution-server-configuration.adoc
@@ -1,7 +1,7 @@
-[[_chap_process_execution_server]]
+[id='_chap_process_execution_server']
 = Process Execution Server Configuration
 
-[[_sect_assignment_rules]]
+[id='_sect_assignment_rules']
 == Assignment Rules
 
 Assignment rules are rules executed automatically when a Human Task is created or completed. This mechanism can be used to assign a Human Task automatically to a particular user of a group or prevent a user from completing a task in case of missing data.
@@ -49,7 +49,7 @@ end
 If user `mary` is one of the potential owners of a Human Task, the task will be automatically assigned to this user.
 ====
 
-[[_sect_mail_session]]
+[id='_sect_mail_session']
 == Mail Session
 
 A mail session defines mail server properties and is used for sending emails, for example when using an Email Service Task or sending and receiving email notifications of Human Task escalation.

--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-process-export-and-import.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-process-export-and-import.adoc
@@ -1,7 +1,7 @@
-[[_chap_process_export_and_import]]
+[id='_chap_process_export_and_import']
 = Process Creation, Import, and Export
 
-[[_creating_a_process]]
+[id='_creating_a_process']
 == Creating Process
 
 NOTE: Decide whether you want to create a process in a package of a particular project. See <<_creating_package>> for more information.
@@ -17,7 +17,7 @@ The *Create New Business Process* dialog window opens.
 +
 Process Editor with the newly created process opens.
 
-[[_importing_a_process_definition]]
+[id='_importing_a_process_definition']
 == Importing Process
 
 .Importing Process in BPMN2 or JSON Format in Process Editor
@@ -43,7 +43,7 @@ When importing processes, Process Editor provides visual support for process ele
 . Commit the changes.
 . Push the changes.
 
-[[_importing_a_process]]
+[id='_importing_a_process']
 == Exporting Process
 
 To export a business process:

--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-process-monitoring.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-process-monitoring.adoc
@@ -1,7 +1,7 @@
-[[_chap_process_monitoring]]
+[id='_chap_process_monitoring']
 = Process monitoring
 
-[[_jboss_operations_network1]]
+[id='_jboss_operations_network1']
 == JBoss Operations Network
 
 A JBoss Operations Network plug-in can be used to monitor rules sessions for {PRODUCT}.
@@ -10,7 +10,7 @@ Due to a limitation of passing the JVM monitoring arguments via the Maven comman
 
 See the https://access.redhat.com/documentation/en-US/Red_Hat_JBoss_Operations_Network/3.3/html-single/Installation_Guide/index.html[Installation Guide] of _Red Hat JBoss Operations Network_ for installation instructions on the Red Hat JBoss ON server.
 
-[[_installing_the_jboss_operations_network_plug_in]]
+[id='_installing_the_jboss_operations_network_plug_in']
 == Installing the JBoss BRMS Plug-in into JBoss ON
 
 Red Hat JBoss BRMS plug-in for JBoss Operations Network can be installed by either copying the plug-in JAR files to the JBoss Operations Network plug-in directory or through the JBoss Operations Network GUI.
@@ -44,7 +44,7 @@ To upload the JBoss BRMS plug-in through the JBoss Operations Network GUI, follo
 . The JBoss BRMS plug-in for JBoss Operations Network is now uploaded.
 
 
-[[_monitoring_knowledge_bases_and_knowledge_sessions1]]
+[id='_monitoring_knowledge_bases_and_knowledge_sessions1']
 == Monitoring Kie Bases and Kie Sessions
 
 In order for JBoss Operations Network to monitor KieBases and KieSessions, MBeans must be enabled.

--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-repository-hooks.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-repository-hooks.adoc
@@ -1,4 +1,4 @@
-[[_chap_repository_hooks]]
+[id='_chap_repository_hooks']
 = Repository Hooks
 
 In Business Central, it is possible to trigger a chosen action every time a particular event happens. For this purpose, you can configure the repository to use scripts called hooks.

--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-task-administration.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-task-administration.adoc
@@ -1,4 +1,4 @@
-[[chap-task-administration]]
+[id='chap-task-administration']
 = Task Administration in Business Central 
 
 Users with administrator or process administrator privileges can easily manage all user tasks in Business Central using the *Task Administration List*. To access the *Task Administration List*, click *Process Management* -> *Task Administration*. 

--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-transactions.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-transactions.adoc
@@ -1,7 +1,7 @@
-[[_chap_transactions]]
+[id='_chap_transactions']
 = Transactions
 
-[[_transactions4]]
+[id='_transactions4']
 == Transactions
 
 The Process Engine supports JTA transactions: local transactions are only supported when using Spring. Pure local transactions are not supported.
@@ -9,7 +9,7 @@ The Process Engine supports JTA transactions: local transactions are only suppor
 By default, each method invocation is considered a transaction. To change this behavior, for example, to combine multiple commands into one transaction, you will need to specify transaction boundaries.
 
 
-[[_defining_transactions]]
+[id='_defining_transactions']
 == Defining transactions
 
 To define a transaction, do the following:
@@ -91,7 +91,7 @@ ut.commit();
 ----
 
 
-[[_container_managed_transactions]]
+[id='_container_managed_transactions']
 == Container Managed Transactions
 
 In cases where JBoss BPM Suite is embedded inside an application that is in a container that can manage transactions by itself (Container Managed Transactions - CMT), a special dedicated transaction manager is provided using the [class]``org.jbpm.persistence.jta.ContainerManagerTransactionManager`` class. This is because the default implementation of the transaction manager in JBoss BPM Suite is based on the [class]``UserTransaction`` class getting the transaction status. However, some application servers in a CMT mode do not allow accessing the [class]``UserTransaction`` instance from JNDI.

--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/installing-jboss-on-vm-proc.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/installing-jboss-on-vm-proc.adoc
@@ -1,5 +1,5 @@
 
-[[_installing_jboss_on_vm_proc]]
+[id='_installing_jboss_on_vm_proc']
 = Installing {PRODUCT} on a Virtual Machine Instance
 To install {PRODUCT} on a virtual machine instance, do the following:
 

--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/sect-console-server-management.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/sect-console-server-management.adoc
@@ -1,4 +1,4 @@
-[[console-server-management]]
+[id='console-server-management']
 = Administration Console Server Management
 
 The Business Central management console allows you to manage multiple Intelligent Process Server instances through the *Server Templates* perspective, which you can access by clicking *Deploy* -> *Execution Servers*. The management console allows servers to integrate with Business Central for execution in two ways:

--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/sect-console-server-templates.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/sect-console-server-templates.adoc
@@ -1,4 +1,4 @@
-[[console-server-templates]]
+[id='console-server-templates']
 = Management Console Server Templates
 
 The Business Central management console integrates with the Intelligent Process Server router through the controller to allow a consolidated view of process instances, and allows you to interact with multiple servers through the same UI. Servers can be managed using the server templates, which are a definition of the runtime environment.

--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/sect-kie-server-router-console.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/sect-kie-server-router-console.adoc
@@ -1,4 +1,4 @@
-[[kie-server-router-console]]
+[id='kie-server-router-console']
 
 = The Intelligent Process Server Router Management Console
 

--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/sect-kie-server-router.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/sect-kie-server-router.adoc
@@ -1,4 +1,4 @@
-[[con-kie-server-router]]
+[id='con-kie-server-router']
 = Intelligent Process Server Router 
 
 The {KIE_SERVER} promotes architecture where there are many server instances responsible for running individual projects (KJARs). These instances can be completely independent or related domains, but they must be separated on different runtimes to avoid negatively impacting each other. The client application must be aware of all servers, including their location (URL), to properly interact with them. However, knowing the location of available containers is problematic, particularly in dynamic (cloud) environments where server availability is based on various conditions. 

--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/sect-starting-the-kie-server-router.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/sect-starting-the-kie-server-router.adoc
@@ -1,4 +1,4 @@
-[[starting-the-kie-server-router]]
+[id='starting-the-kie-server-router']
 = Starting the Intelligent Process Server Router
 
 The {KIE_SERVER} router allows you to aggregate multiple independent KIE server instances as though they are a single server. Use the following procedure to start the {KIE_SERVER} router.

--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/sect-using-server-templates.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/sect-using-server-templates.adoc
@@ -1,4 +1,4 @@
-[[using-server-templates]]
+[id='using-server-templates']
 = Using Server Templates
 
 The Business Central management console allows you to manage multiple Intelligent Process Server instances through the *Server Templates* perspective, which can be access by clicking *Deploy* -> *Execution Servers*. The management console allows servers to integrate with Business Central for execution in two ways:

--- a/docs/product-development-guide/src/main/asciidoc/chap-about-this-guide.adoc
+++ b/docs/product-development-guide/src/main/asciidoc/chap-about-this-guide.adoc
@@ -1,4 +1,4 @@
-[[_chap_about_this_guide]]
+[id='_chap_about_this_guide']
 = About This Guide
 
 This guide is intended for users who are implementing a standalone Red Hat JBoss BRMS solution or the complete Red Hat JBoss BPM Suite solution. It discusses the following topics:
@@ -27,7 +27,7 @@ This section highlights the KIE API with detailed description of how to create, 
 +
 This section comprises important reference material such as key knowledge terms, and examples.
 
-[[_audience]]
+[id='_audience']
 == Audience
 
 This book has been designed to be understood by:
@@ -35,7 +35,7 @@ This book has been designed to be understood by:
 * Author of rules and processes who are responsible for authoring and testing business rules and processes using Red Hat JBoss Developer Studio.
 * Java application developers responsible for developing and integrating business rules and processes into Java and Java EE enterprise applications.
 
-[[_prerequisites]]
+[id='_prerequisites']
 == Prerequisites
 
 Users of this guide must meet one or more of the following prerequisites:

--- a/docs/product-development-guide/src/main/asciidoc/chap-admin-services.adoc
+++ b/docs/product-development-guide/src/main/asciidoc/chap-admin-services.adoc
@@ -1,4 +1,4 @@
-[[_administration_service_interface]]
+[id='_administration_service_interface']
 = Administration Service Interfaces
 
 {PRODUCT} simplifies a number of low-level api operations by exposing the following administration interfaces.

--- a/docs/product-development-guide/src/main/asciidoc/chap-complex-event-processing.adoc
+++ b/docs/product-development-guide/src/main/asciidoc/chap-complex-event-processing.adoc
@@ -1,7 +1,7 @@
-[[_chap_complex_event_processing]]
+[id='_chap_complex_event_processing']
 = Complex Event Processing
 
-[[_introduction_to_complex_event_processing1]]
+[id='_introduction_to_complex_event_processing1']
 == Introduction to Complex Event Processing
 
 JBoss BRMS Complex Event Processing provides the JBoss Enterprise BRMS Platform with complex event processing capabilities.
@@ -51,7 +51,7 @@ As such, JBoss BRMS Complex Event Processing supports the following behaviors:
 * Support reactive rules.
 * Support adapters for event input into the engine (pipeline).
 
-[[_sect_events1]]
+[id='_sect_events1']
 == Events
 
 Events are a record of significant change of state in the application domain. From a complex event processing perspective, an event is a special type of fact or object. A fact is a known piece of data. For instance, a fact could be a stock's opening price. A rule is a definition of how to react to the data. For instance, if a stock price reaches $_X_, sell the stock.
@@ -80,7 +80,7 @@ It is possible to define and use sliding windows with events since all events ha
 
 Events can be declared as either _interval-based_ events or _point-in-time_ events. Interval-based events have a duration time and persist in working memory until their duration time has lapsed. Point-in-time events have no duration and can be thought of as interval-based events with a duration of zero.
 
-[[_event_declaration1]]
+[id='_event_declaration1']
 === Event Declaration
 
 To declare a fact type as an event, assign the `@role` metadata tag to the fact with the `event` parameter. The `@role` metadata tag can accept two possible values:
@@ -120,7 +120,7 @@ end
 
 For more information about type declarations, see <<_sect_type_declaration>>.
 
-[[_event_meta_data1]]
+[id='_event_meta_data1']
 === Event Metadata
 
 Every event has associated metadata. Typically, the metadata is automatically added as each event is inserted into working memory. The metadata defaults can be changed on an event-type basis using the metadata tags:
@@ -241,10 +241,10 @@ end
 ----
 ====
 
-[[_sect_clock_implementation_in_complex_event_processing]]
+[id='_sect_clock_implementation_in_complex_event_processing']
 == Clock Implementation in Complex Event Processing
 
-[[_session_clock]]
+[id='_session_clock']
 === Session Clock
 
 Events have strong temporal constraints making it is necessary to use a reference clock. If a rule needs to determine the average price of a given stock over the last sixty minutes, it is necessary to compare the stock price event's timestamp with the current time. The reference clock provides the current time.
@@ -258,7 +258,7 @@ Scenarios that require different clocks include the following:
 * _Special environments_: Specific environments may have specific time control requirements. For instance, clustered environments may require clock synchronization or JEE environments may require you to use an application server-provided clock.
 * _Rules replay or simulation_: In order to replay or simulate scenarios, it is necessary that the application controls the flow of time.
 
-[[_available_clock_implementations]]
+[id='_available_clock_implementations']
 === Available Clock Implementations
 
 JBoss BRMS Complex Event Processing comes equipped with two clock implementations:
@@ -327,12 +327,12 @@ FactHandle handle3 = session.insert(tick3);
 
 For a list of Maven dependencies, see example <<_embedded_jbpm_engine_dependencies>>. If you use Red Hat JBoss BRMS, see <<_embedded_drools_engine_dependencies>>.
 
-[[_sect_event_processing_modes]]
+[id='_sect_event_processing_modes']
 == Event Processing Modes
 
 Rules engines process facts and rules to provide applications with results. Regular facts (facts with no temporal constraints) are processed independent of time and in no particular order. Red Hat JBoss BRMS processes facts of this type in cloud mode. Events (facts which have strong temporal constraints) must be processed in real-time or near real-time. Red Hat JBoss BRMS processes these events in stream mode. Stream mode deals with synchronization and makes it possible for Red Hat JBoss BRMS to process events.
 
-[[_cloud_mode1]]
+[id='_cloud_mode1']
 === Cloud Mode
 
 _Cloud_ mode is the default operating mode of Red Hat JBoss Business Rules Management System.
@@ -372,7 +372,7 @@ drools.eventProcessingMode = cloud
 
 For a list of Maven dependencies, see example <<_embedded_jbpm_engine_dependencies>>. If you use Red Hat JBoss BRMS, see <<_embedded_drools_engine_dependencies>>.
 
-[[_stream_mode1]]
+[id='_stream_mode1']
 === Stream Mode
 
 _Stream_ mode processes events chronologically as they are inserted into the rules engine. Stream mode uses a session clock that enables the rules engine to process events as they occur in time. The session clock enables processing events as they occur based on the age of the events. Stream mode also synchronizes streams of events (so events in different streams can be processed in chronological order), implements sliding windows of interest, and enables automatic life-cycle management.
@@ -408,7 +408,7 @@ drools.eventProcessingMode = stream
 
 For a list of Maven dependencies, see example <<_embedded_jbpm_engine_dependencies>>. If you use Red Hat JBoss BRMS, see <<_embedded_drools_engine_dependencies>>.
 
-[[_sect_event_streams]]
+[id='_sect_event_streams']
 == Event Streams
 
 _Complex event processing use cases_ deal with streams of events. The streams can be provided to the application using JMS queues, flat text files, database tables, raw sockets, or even web service calls.
@@ -424,7 +424,7 @@ A stream is also known as an _entry point_.
 
 Facts from one entry point, or stream, may join with facts from any other entry point in addition to facts already in working memory. Facts always remain associated with the entry point through which they entered the engine. Facts of the same type may enter the engine through several entry points, but facts that enter the engine through entry point A will never match a pattern from entry point B.
 
-[[_declaring_and_using_entry_points1]]
+[id='_declaring_and_using_entry_points1']
 === Declaring and Using Entry Points
 
 Entry points are declared implicitly by making direct use of them in rules. Referencing an entry point in a rule will make the engine, at compile time, identify and create the proper internal structures to support that entry point.
@@ -492,7 +492,7 @@ atmStream.insert(aWithdrawRequest);
 For a list of Maven dependencies, see example <<_embedded_jbpm_engine_dependencies>>. If you use Red Hat JBoss BRMS, see <<_embedded_drools_engine_dependencies>>.
 
 
-[[_negative_pattern_in_stream_mode1]]
+[id='_negative_pattern_in_stream_mode1']
 === Negative Pattern in Stream Mode
 
 A _negative pattern_ is concerned with conditions that are not met. Negative patterns make reasoning in the absence of events possible. For instance, a safety system could have a rule that states "_If a fire is detected and the sprinkler is_ not _activated, sound the alarm._"
@@ -562,17 +562,17 @@ end
 ----
 ====
 
-[[_sect_temporal_operations]]
+[id='_sect_temporal_operations']
 == Temporal Operations
 
-[[_temporal_reasoning]]
+[id='_temporal_reasoning']
 === Temporal Reasoning
 
 Complex Event Processing requires the rules engine to engage in temporal reasoning. Events have strong temporal constraints so it is vital the rules engine can determine and interpret an event's temporal attributes, both as they relate to other events and the 'flow of time' as it appears to the rules engine. This makes it possible for rules to take time into account; for instance, a rule could state "_Calculate the average price of a stock over the last 60 minutes._"
 
 NOTE: JBoss BRMS Complex Event Processing implements interval-based time events, which have a duration attribute that is used to indicate how long an event is of interest. Point-in-time events are also supported and treated as interval-based events with a duration of 0 (zero).
 
-[[_temporal_operations1]]
+[id='_temporal_operations1']
 === Temporal Operations
 
 JBoss BRMS Complex Event Processing implements the following temporal operators and their logical complements (negation):
@@ -591,7 +591,7 @@ JBoss BRMS Complex Event Processing implements the following temporal operators 
 * `starts`
 * `started by`
 
-[[_after]]
+[id='_after']
 === After
 
 The `after` operator correlates two events and matches when the temporal distance (the time between the two events) from the current event to the event being correlated falls into the distance range declared for the operator.
@@ -637,7 +637,7 @@ $eventA : EventA(this after[-3m30s, -2m] $eventB)
 $eventA : EventA(this after[-2m, -3m30s] $eventB)
 ----
 
-[[_before]]
+[id='_before']
 === Before
 
 The `before` operator correlates two events and matches when the temporal distance (time between the two events) from the event being correlated to the current event falls within the distance range declared for the operator.
@@ -683,7 +683,7 @@ $eventA : EventA(this before[-3m30s, -2m] $eventB)
 $eventA : EventA(this before[-2m, -3m30s] $eventB)
 ----
 
-[[_coincides]]
+[id='_coincides']
 === Coincides
 
 The `coincides` operator correlates two events and matches when both events happen at the same time.
@@ -722,7 +722,7 @@ abs($eventA.endTimestamp - $eventB.endTimestamp) <= 10s
 
 WARNING: The `coincides` operator does not accept negative intervals, and the rules engine will throw an exception if an attempt is made to use negative distance internals.
 
-[[_during]]
+[id='_during']
 === During
 
 The `during` operator correlates two events and matches when the current event happens during the event being correlated.
@@ -753,7 +753,7 @@ The following rules apply when providing parameters for the `during` operator:
 If the values `5s` and `10s` are provided, the current event must start between 5 and 10 seconds after the correlated event, and similarly the current event must end between 5 and 10 seconds before the correlated event.
 * If four values are defined, the first and second values will be used as the minimum and maximum distances between the starting times of the events, and the third and fourth values will be used as the minimum and maximum distances between the end times of the two events.
 
-[[_finishes]]
+[id='_finishes']
 === Finishes
 
 The `finishes` operator correlates two events and matches when the current event's start timestamp post-dates the correlated event's start timestamp and both events end simultaneously.
@@ -796,7 +796,7 @@ abs($eventA.endTimestamp - $eventB.endTimestamp) <= 5s
 
 WARNING: The `finishes` operator does not accept negative intervals, and the rules engine will throw an exception if an attempt is made to use negative distance intervals.
 
-[[_finishes_by]]
+[id='_finishes_by']
 === Finishes By
 
 The `finishedby` operator correlates two events and matches when the current event's start time predates the correlated event's start time but both events end simultaneously. `finishedby` is the symmetrical opposite of the `finishes` operator.
@@ -837,7 +837,7 @@ abs($eventA.endTimestamp - $eventB.endTimestamp) <= 5s
 
 WARNING: The `finishedby` operator does not accept negative intervals, and the rules engine will throw an exception if an attempt is made to use negative distance intervals.
 
-[[_includes]]
+[id='_includes']
 === Includes
 
 The `includes` operator examines two events and matches when the event being correlated happens during the current event. It is the symmetrical opposite of the `during` operator.
@@ -866,7 +866,7 @@ The `includes` operator accepts 1, 2 or 4 optional parameters:
 If the values `5s` and `10s` are provided, the current event must start between 5 and 10 seconds after the correlated event, and similarly the current event must end between 5 and 10 seconds before the correlated event.
 * If four values are defined, the first and second values will be used as the minimum and maximum distances between the starting times of the events, and the third and fourth values will be used as the minimum and maximum distances between the end times of the two events.
 
-[[_meets1]]
+[id='_meets1']
 === Meets
 
 The `meets` operator correlates two events and matches when the current event ends at the same time as the correlated event starts.
@@ -905,7 +905,7 @@ abs($eventB.startTimestamp - $eventA.endTimestamp) <= 5s
 
 WARNING: The `meets` operator does not accept negative intervals, and the rules engine will throw an exception if an attempt is made to use negative distance intervals.
 
-[[_met_by1]]
+[id='_met_by1']
 === Met By
 
 The `metby` operator correlates two events and matches when the current event starts at the same time as the correlated event ends.
@@ -944,7 +944,7 @@ abs($eventA.startTimestamp - $eventB.endTimestamp) <= 5s
 
 WARNING: The `metby` operator does not accept negative intervals, and the rules engine will throw an exception if an attempt is made to use negative distance intervals.
 
-[[_overlaps]]
+[id='_overlaps']
 === Overlaps
 
 The `overlaps` operator correlates two events and matches when the current event starts before the correlated event starts and ends after the correlated event starts, but it ends before the correlated event ends.
@@ -968,7 +968,7 @@ The `overlaps` operator accepts one or two optional parameters:
 * If one parameter is defined, it will define the maximum distance between the start time of the correlated event and the end time of the current event.
 * If two values are defined, the first value will be the minimum distance, and the second value will be the maximum distance between the start time of the correlated event and the end time of the current event.
 
-[[_overlapped_by1]]
+[id='_overlapped_by1']
 === Overlapped By
 
 The `overlappedby` operator correlates two events and matches when the correlated event starts before the current event, and the correlated event ends after the current event starts but before the current event ends.
@@ -992,7 +992,7 @@ The `overlappedby` operator accepts one or two optional parameters:
 * If one parameter is defined, it sets the maximum distance between the start time of the correlated event and the end time of the current event.
 * If two values are defined, the first value will be the minimum distance, and the second value will be the maximum distance between the start time of the correlated event and the end time of the current event.
 
-[[_starts]]
+[id='_starts']
 === Starts
 
 The `starts` operator correlates two events and matches when they start at the same time, but the current event ends before the correlated event ends.
@@ -1034,7 +1034,7 @@ $eventA.endTimestamp < $eventB.endTimestamp
 
 WARNING: The `starts` operator does not accept negative intervals, and the rules engine will throw an exception if an attempt is made to use negative distance intervals.
 
-[[_started_by1]]
+[id='_started_by1']
 === Started By
 
 The `startedby` operator correlates two events. It matches when both events start at the same time and the correlating event ends before the current event.
@@ -1075,10 +1075,10 @@ $eventA.endTimestamp > $eventB.endTimestamp
 
 WARNING: The `startedby` operator does not accept negative intervals, and the rules engine will throw an exception if an attempt is made to use negative distance intervals.
 
-[[_sect_sliding_windows]]
+[id='_sect_sliding_windows']
 == Sliding Windows
 
-[[_sliding_time_windows]]
+[id='_sliding_time_windows']
 === Sliding Time Windows
 
 Stream mode allows events to be matched over a sliding time window. A _sliding window_ is a time period that stretches back in time from the present. For instance, a sliding window of two minutes includes any events that have occurred in the past two minutes. As events fall out of the sliding time window (in this case because they occurred more than two minutes ago), they will no longer match against rules using this particular sliding window.
@@ -1112,7 +1112,7 @@ end
 
 The engine will automatically discard any `SensorReading` more than ten minutes old and keep re-calculating the average.
 
-[[_sliding_length_windows]]
+[id='_sliding_length_windows']
 === Sliding Length Windows
 
 Similar to Time Windows, Sliding Length Windows work in the same manner; however, they consider events based on order of their insertion into the session instead of flow of time.
@@ -1146,7 +1146,7 @@ NOTE: The engine disregards events that fall off a window when calculating that 
 
 NOTE: Length based windows do not define temporal constraints for event expiration from the session, and the engine will not consider them. If events have no other rules defining temporal constraints and no explicit expiration policy, the engine will keep them in the session indefinitely.
 
-[[_sect_memory_management_for_events]]
+[id='_sect_memory_management_for_events']
 == Memory Management for Events
 
 Automatic memory management for events is available when running the rules engine in Stream mode. Events that no longer match any rule due to their temporal constraints can be safely retracted from the session by the rules engine without any side effects, releasing any resources held by the retracted events.
@@ -1159,7 +1159,7 @@ Event expiration can be explicitly set with the `@expires`.
 Implicitly::
 The rules engine can analyze the temporal constraints in rules to determine the window of interest for events.
 
-[[_explicit_expiration1]]
+[id='_explicit_expiration1']
 === Explicit Expiration
 
 Explicit expiration is set with a `declare` statement and the metadata `@expires` tag.
@@ -1178,7 +1178,7 @@ end
 
 Declaring expiration against an event-type will, in the above example `StockTick` events, remove any `StockTick` events from the session automatically after the defined expiration time if no rules still need the events.
 
-[[_inferred_expiration1]]
+[id='_inferred_expiration1']
 === Inferred Expiration
 
 The rules engine can calculate the expiration offset for a given event implicitly by analyzing the temporal constraints in the rules.

--- a/docs/product-development-guide/src/main/asciidoc/chap-getting-started-with-processes.adoc
+++ b/docs/product-development-guide/src/main/asciidoc/chap-getting-started-with-processes.adoc
@@ -1,4 +1,4 @@
-[[_chap_getting_started_with_processes]]
+[id='_chap_getting_started_with_processes']
 = Getting Started with Processes
 
 JBoss Business Process Management System is a light-weight, open-source, flexible Business Process Management (BPM) Suite that allows you to create, execute, and monitor business processes throughout their life cycle. The business processes allow you to model your business goals. They describe the steps that need to be executed to achieve those goals. It depicts the order of these goals in a flow chart. The business processes greatly improve the visibility and agility of your business logic.
@@ -19,7 +19,7 @@ The core of Red Hat JBoss BPM Suite is a light-weight, extensible workflow engin
 * Listeners to be notified of various events.
 * Ability to migrate running process instances to a new version of their process definition.
 
-[[_integrating_bpm_suite_engine_with_other_services]]
+[id='_integrating_bpm_suite_engine_with_other_services']
 == Integrating BPM Suite Engine With Other Services
 
 The Red Hat JBoss BPM Suite engine can be integrated with a few independent core services such as:

--- a/docs/product-development-guide/src/main/asciidoc/chap-getting-started-with-rules-and-facts.adoc
+++ b/docs/product-development-guide/src/main/asciidoc/chap-getting-started-with-rules-and-facts.adoc
@@ -1,4 +1,4 @@
-[[_chap_getting_started_with_rules_and_facts]]
+[id='_chap_getting_started_with_rules_and_facts']
 = Getting Started with Rules and Facts
 
 To create business rules, an appropriate fact model on which the business rules operate must be present. A fact is an instance of an application object represented as POJO. Rules that contain the business logic can then be authored by using either the Business Central web user interface or Red Hat JBoss Developer Studio.
@@ -26,7 +26,7 @@ Conditions inside the `when` clause of a rule query for fact combinations that m
 . All the rule-facts combinations are queued within a data construct called an agenda.
 . Finally, activations are processed one by one from the agenda, calling the rule consequences on the facts. Note that executing an activation can modify the contents of the agenda before the next activation is performed. The PHREAK and ReteOO algorithms handle such situations efficiently.
 
-[[_sect_create_your_first_rule]]
+[id='_sect_create_your_first_rule']
 == Creating and Executing Rules
 
 In this section, procedures describing how to create and execute rules using plain Java, Maven, Red Hat JBoss Developer Studio, and Business Central in {PRODUCT} are provided.
@@ -182,7 +182,7 @@ Hello Tom Summers!
 You are rich!
 ----
 
-[[_creating_and_executing_your_first_rule_using_maven]]
+[id='_creating_and_executing_your_first_rule_using_maven']
 === Creating and Executing Rules Using Maven
 
 . *Create a basic Maven archetype.*
@@ -416,7 +416,7 @@ Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
 [INFO] --------------------------------------------------------------
 ----
 
-[[_creating_and_executing_your_first_rule_using_jboss_developer_studio]]
+[id='_creating_and_executing_your_first_rule_using_jboss_developer_studio']
 === Creating and Executing Rules Using Red Hat JBoss Developer Studio
 
 NOTE: Make sure you have Red Hat JBoss Developer Studio properly set before proceeding further. See chapter {URL_INSTALLATION_GUIDE}#chap_red_hat_jboss_developer_studio[Red Hat JBoss Developer Studio] of _{INSTALLATION_GUIDE}_ for more information.
@@ -596,7 +596,7 @@ Hello Tom Summers!
 You are rich!
 ----
 
-[[_creating_and_executing_your_first_rule_using_business_central]]
+[id='_creating_and_executing_your_first_rule_using_business_central']
 === Creating and Executing Rules Using Business Central
 
 NOTE: Make sure you have {PRODUCT} successfully installed before proceeding further.
@@ -709,15 +709,15 @@ As these values satisfy the rule condition, the expected output looks similar to
 16:26:56,119 INFO  [stdout] (http-/127.0.0.1:8080-5) You are rich!
 ----
 
-[[_sect_execution_of_rules]]
+[id='_sect_execution_of_rules']
 == Execution of Rules
 
-[[_agenda]]
+[id='_agenda']
 === Agenda
 
 The Agenda is a _Rete_ feature. During actions on the `WorkingMemory`, rules may become fully matched and eligible for execution. A single Working Memory Action can result in multiple eligible rules. When a rule is fully matched an Activation is created, referencing the rule and the matched facts, and placed onto the Agenda. The Agenda controls the execution order of these Activations using a Conflict Resolution strategy.
 
-[[_agenda_processing]]
+[id='_agenda_processing']
 === Agenda Processing
 
 The engine cycles repeatedly through two phases:
@@ -727,19 +727,19 @@ The engine cycles repeatedly through two phases:
 
 The process repeats until the agenda is clear, in which case control returns to the calling application. When Working Memory Actions are taking place, no rules are being fired.
 
-[[_conflict_resolution]]
+[id='_conflict_resolution']
 === Conflict Resolution
 
 Conflict resolution is required when there are multiple rules on the agenda. As firing a rule may have side effects on the working memory, the rule engine needs to know in what order the rules should fire (for instance, firing _ruleA_ may cause _ruleB_ to be removed from the agenda).
 
-[[_agendagroup]]
+[id='_agendagroup']
 === AgendaGroup
 
 Agenda groups are a way to partition rules on the agenda. At any one time, only one group has "focus" which means that activations for rules in that group only will take effect. You can also have rules with "auto focus" which means that the focus is taken for its agenda group when that rule's conditions are true.
 
 Agenda groups are known as "modules" in CLIPS terminology. Agenda groups provide a way to create a "flow" between grouped rules. You can switch the group which has focus either from within the rule engine, or via the API. If your rules have a clear need for multiple "phases" or "sequences" of processing, consider using agenda-groups for this purpose.
 
-[[_setfocus]]
+[id='_setfocus']
 === setFocus()
 
 Each time `setFocus()` is called it pushes the specified Agenda Group onto a stack. When the focus group is empty it is popped from the stack and the focus group that is now on top evaluates. An Agenda Group can appear in multiple locations on the stack. The default Agenda Group is "MAIN", with all rules which do not specify an Agenda Group being in this group. It is also always the first group on the stack, given focus initially, by default.
@@ -751,7 +751,7 @@ The `setFocus()` method call looks like follows:
 ksession.getAgenda().getAgendaGroup("Group A").setFocus();
 ----
 
-[[_activationgroup]]
+[id='_activationgroup']
 === ActivationGroup
 
 An activation group is a set of rules bound together by the same `activation-group` rule attribute. In this group only one rule can fire, and after that rule has fired all the other rules are cancelled from the agenda. The `clear()` method can be called at any time, which cancels all of the activations before one has had a chance to fire.
@@ -763,10 +763,10 @@ An activation group looks like follows:
 ksession.getAgenda().getActivationGroup("Group B").clear();
 ----
 
-[[_sect_inference]]
+[id='_sect_inference']
 == Inference
 
-[[_the_inference_engine]]
+[id='_the_inference_engine']
 === The Inference Engine
 
 
@@ -776,7 +776,7 @@ The rules are stored in the production memory and the facts that the inference e
 
 Inferences can be forward chaining or backward chaining. In a forward chaining inference mechanism, when some data gets inserted into the working memory, the related rules are triggered and if the data satisfies the rule conditions, corresponding actions are taken. These actions may insert new data into the working memory and therefore trigger more rules and so on. Thus, the forward chaining inference is data driven. On the contrary, the backward chaining inference is goal driven. In this case, the system looks for a particular goal, which the engine tries to satisfy. If it cannot do so it searches for sub-goals, that is, conclusions that will complete part of the current goal. It continues this process until either the initial conclusion is satisfied or there are no more unsatisfied sub-goals. Correct use of inference can create agile and less error prone business rules, which are easier to maintain.
 
-[[_inference_example1]]
+[id='_inference_example1']
 === Inference Example
 
 The following example illustrates how an inference is made about whether a person is eligible to have a bus pass based on the rule conditions. Here is a rule that provides the age policy for a person to hold a bus pass:
@@ -799,7 +799,7 @@ $p : Person()
 IsAdult(person == $p)
 ----
 
-[[_sect_truth_maintenance]]
+[id='_sect_truth_maintenance']
 == Truth Maintenance
 
 The inference engine is responsible for logical decisions on assertions and retractions of facts. After regular insertions, facts are generally retracted explicitly. However, in case of logical assertions, the facts that were asserted are automatically retracted when the conditions that asserted the facts in the first place are no longer true. In other words, the facts are retracted when there is no single condition that supports the logical assertion.
@@ -894,7 +894,7 @@ then
 end
 ----
 
-[[_sect_using_decision_tables_in_spreadsheets]]
+[id='_sect_using_decision_tables_in_spreadsheets']
 == Using Decision Tables in Spreadsheets
 
 _Decision tables_ are a way of representing conditional logic in a precise manner, and are well suited to business-level rules.
@@ -903,7 +903,7 @@ Red Hat JBoss BRMS supports managing rules in a spreadsheet format. Since two fo
 
 NOTE: Use the XLS format if you are building and uploading decision tables using Business Central. Business Central does _not_ support decision tables in the CSV format.
 
-[[_open_office_example]]
+[id='_open_office_example']
 === OpenOffice Example
 
 .OpenOffice Screenshot
@@ -915,7 +915,7 @@ The rules start from row 17, with each row resulting in a rule. The conditions a
 
 NOTE: Although the decision tables look like they process top down, this is not necessarily the case. Ideally, rules are authored without regard for the order of rows. This makes maintenance easier, as rows will not need to be shifted around all the time.
 
-[[_rules_and_spreadsheets]]
+[id='_rules_and_spreadsheets']
 === Rules and Spreadsheets
 
 Rules Inserted into Rows::
@@ -927,26 +927,26 @@ It is possible to clear the agenda when a rule fires and simulate a very simple 
 Multiple Tables::
 You can have multiple tables on one spreadsheet. This way, rules can be grouped where they share common templates, but are still all combined into one rule package.
 
-[[_the_ruletable_keyword]]
+[id='_the_ruletable_keyword']
 === The RuleTable Keyword
 
 When using decision tables, the spreadsheet searches for the `RuleTable` keyword to indicate the start of a rule table (both the starting row and column).
 
 IMPORTANT: Keywords should all be in the same column.
 
-[[_the_ruleset_keyword]]
+[id='_the_ruleset_keyword']
 === The RuleSet Keyword
 
 The `RuleSet` keyword indicates the name to be used in the rule package that will encompass all the rules. This name is optional, using a default, but it _must_ have the `RuleSet` keyword in the cell immediately to the right.
 
-[[_data_defining_cells]]
+[id='_data_defining_cells']
 === Data-Defining Cells
 
 There are two types of rectangular areas _defining data_ that is used for generating a DRL file. One, marked by a cell labelled `RuleSet`, defines all DRL items except rules. The other one may occur repeatedly and is to the right and below a cell whose contents begin with `RuleTable`. These areas represent the actual decision tables, each area resulting in a set of rules of similar structure.
 
 A Rule Set area may contain cell pairs, one below the `RuleSet` cell and containing a keyword designating the kind of value contained in the other one that follows in the same row.
 
-[[_rule_table_columns]]
+[id='_rule_table_columns']
 === Rule Table Columns
 
 The columns of a Rule Table area define patterns and constraints for the left hand sides of the rules derived from it, actions for the consequences of the rules, and the values of individual rule attributes. A Rule Table area should contain one or more columns, both for conditions and actions, and an arbitrary selection of columns for rule attributes, at most one column for each of these. The first four rows following the row with the cell marked with `RuleTable` are earmarked as header area, mostly used for the definition of code to construct the rules. It is any additional row below these four header rows that spawns another rule, with its data providing for variations in the code defined in the Rule Table header.
@@ -958,7 +958,7 @@ All keywords are case insensitive.
 Only the first worksheet is examined for decision tables.
 ====
 
-[[_rule_set_entries]]
+[id='_rule_set_entries']
 === Rule Set Entries
 
 Entries in a Rule Set area may define DRL constructs (except rules), and specify rule attributes. While entries for constructs may be used repeatedly, each rule attribute may be given at most once, and it applies to all rules unless it is overruled by the same attribute being defined within the Rule Table area.
@@ -1003,7 +1003,7 @@ Entries must be given in a vertically stacked sequence of cell pairs. The first 
 |Optional, may be used repeatedly.
 |===
 
-[[_rule_attribute_entries_in_the_rule_set_area]]
+[id='_rule_attribute_entries_in_the_rule_set_area']
 === Rule Attribute Entries in Rule Set Area
 
 IMPORTANT: Rule attributes specified in a Rule Set area will affect all rule assets in the same package (not only in the spreadsheet). Unless you are sure that the spreadsheet is the only one rule asset in the package, the recommendation is to specify rule attributes not in a Rule Set area but in a Rule Table columns for each rule instead.
@@ -1064,12 +1064,12 @@ IMPORTANT: Rule attributes specified in a Rule Set area will affect all rule ass
 |A string containing a date and time definition. A rule cannot activate if the current date and time is after the `DATE-EXPIRES` attribute.
 |===
 
-[[_the_ruletable_cell]]
+[id='_the_ruletable_cell']
 === The RuleTable Cell
 
 All Rule Tables begin with a cell containing `RuleTable`, optionally followed by a string within the same cell. The string is used as the initial part of the name for all rules derived from this Rule Table, with the row number appended for distinction. This automatic naming can be overridden by using a `NAME` column. All other cells defining rules of this Rule Table are below and to the right of this cell.
 
-[[_column_types]]
+[id='_column_types']
 === Column Types
 
 The next row after the `RuleTable` cell defines the column type. Each column results in a part of the condition or the consequence, or provides some rule attribute, the rule name or a comment. Each attribute column may be used at most once.
@@ -1105,7 +1105,7 @@ The next row after the `RuleTable` cell defines the column type. Each column res
 |Optional, any number of columns.
 |===
 
-[[_conditional_elements]]
+[id='_conditional_elements']
 === Conditional Elements
 
 Given a column headed `CONDITION`, the cells in successive lines result in a conditional element.
@@ -1127,7 +1127,7 @@ If the cell above is empty, the interpolated result is used as is.
 * Text in the third cell below `CONDITION` is for documentation only. It should be used to indicate the column's purpose to a human reader.
 * From the fourth row on, non-blank entries provide data for interpolation as described above. A blank cell results in the omission of the conditional element or constraint for this rule.
 
-[[_action_statements]]
+[id='_action_statements']
 === Action Statements
 
 Given a column headed `ACTION`, the cells in successive lines result in an action statement:
@@ -1147,7 +1147,7 @@ If the cell above is empty, the interpolated result is used as is.
 
 NOTE: Using `$1` instead of `$param` will fail if the replacement text contains a comma.
 
-[[_metadata_statements]]
+[id='_metadata_statements']
 === Metadata Statements
 
 Given a column headed `METADATA`, the cells in successive lines result in a metadata annotation for the generated rules:
@@ -1157,14 +1157,14 @@ Given a column headed `METADATA`, the cells in successive lines result in a meta
 * Text in the third cell below `METADATA` is for documentation only. It should be used to indicate the column's purpose to a human reader.
 * From the fourth row on, non-blank entries provide data for interpolation as described above. A blank cell results in the omission of the metadata annotation for this rule.
 
-[[_interpolating_cell_data_example]]
+[id='_interpolating_cell_data_example']
 === Interpolating Cell Data Example
 
 * If the template is `Foo(bar == $param)` and the cell is `42`, then the result is `Foo(bar == 42)`.
 * If the template is `Foo(bar < $1, baz == $2)` and the cell contains `42,43`, the result will be `Foo(bar < 42, baz ==43)`.
 * The template `forall(&&){bar != $}` with a cell containing `42,43` results in `bar != 42 && bar != 43`.
 
-[[_tips_for_working_within_cells]]
+[id='_tips_for_working_within_cells']
 === Tips for Working Within Cells
 
 * Multiple package names within the same cell must be comma-separated.
@@ -1176,14 +1176,14 @@ Given a column headed `METADATA`, the cells in successive lines result in a meta
 * Anything can be placed in the object type row. Apart from the definition of a binding variable, it could also be an additional pattern that is to be inserted literally.
 * The cell below the `ACTION` header can be left blank. Using this style, anything can be placed in the consequence, not just a single method call. The same technique is applicable within a `CONDITION` column.
 
-[[_the_spreadsheetcompiler_class]]
+[id='_the_spreadsheetcompiler_class']
 === The SpreadsheetCompiler Class
 
 The `SpreadsheetCompiler` class is the main class used with API spreadsheet-based decision tables in the drools-decisiontables module. This class takes spreadsheets in various formats and generates rules in DRL.
 
 The `SpreadsheetCompiler` can be used to generate partial rule files and assemble them into a complete rule package after the fact. This allows the separation of technical and non-technical aspects of the rules if needed.
 
-[[_using_spreadsheet_based_decision_tables]]
+[id='_using_spreadsheet_based_decision_tables']
 === Using Spreadsheet-Based Decision Tables
 
 .Procedure: Task
@@ -1191,23 +1191,23 @@ The `SpreadsheetCompiler` can be used to generate partial rule files and assembl
 . If the Red Hat JBoss BRMS plug-in is being used, use the wizard to generate a spreadsheet from a template.
 . Use an XSL-compatible spreadsheet editor to modify the XSL.
 
-[[_lists1]]
+[id='_lists1']
 === Lists
 
 In Excel, you can create `lists` of values. These can be stored in other worksheets to provide valid lists of values for cells.
 
-[[_revision_control]]
+[id='_revision_control']
 === Revision Control
 
 When changes are being made to rules over time, older versions are archived. Some applications in Red Hat JBoss BRMS provide a limited ability to keep a history of changes, but it is recommended to use an alternative means of revision control.
 
-[[_tabular_data_sources]]
+[id='_tabular_data_sources']
 === Tabular Data Sources
 
 A tabular data source can be used as a source of rule data. It can populate a template to generate many rules. This can allow both for more flexible spreadsheets, but also rules in existing databases for instance (at the cost of developing the template up front to generate the rules).
 
 
-[[_dependencies_for_guided_decision_tables1]]
+[id='_dependencies_for_guided_decision_tables1']
 == Dependency Management for Guided Decision Tables, Scorecards, and Rule Templates
 
 When you build your own application with the embedded Drools or jBPM engine that uses guided decision tables, guided scorecards, or guided rule templates, you need to add the `drools-workbench-models-guided-dtable`, `drools-workbench-models-guided-scorecard`, and `drools-workbench-models-guided-template` dependencies respectively, on the class path.
@@ -1235,7 +1235,7 @@ When using Maven, declare the dependencies in the `pom.xml` file as shown below:
 ----
 
 
-[[_sect_logging]]
+[id='_sect_logging']
 == Logging
 
 The logging feature enables you to investigate what the Rule Engine does at the back-end. The rule engine uses Java logging API SLF4J for logging. The underlying logging back-end can be Logback, Apache Commons Logging, Log4j, or `java.util.logging`. You can add a dependency to the logging adaptor for your logging framework of choice.
@@ -1253,7 +1253,7 @@ Here is an example of how to use Logback by adding a Maven dependency:
 
 NOTE: If you are developing for an ultra light environment, use `slf4j-nop` or `slf4j-simple`.
 
-[[_configuring_logging_level]]
+[id='_configuring_logging_level']
 === Configuring Logging Level
 
 Here is an example of how you can configure the logging level on the package `org.drools` in your `logback.xml` file when you are using Logback:

--- a/docs/product-development-guide/src/main/asciidoc/chap-human-tasks-management.adoc
+++ b/docs/product-development-guide/src/main/asciidoc/chap-human-tasks-management.adoc
@@ -1,12 +1,12 @@
-[#_chap_human_tasks_management]
+[id='_chap_human_tasks_management']
 = Human Tasks Management
 
-[#_human_tasks]
+[id='_human_tasks']
 == Human Tasks
 
 Human Tasks are tasks within a process that must be carried out by human actors. BRMS Business Process Management supports a human task node inside processes for modeling the interaction with human actors. The human task node allows process designers to define the properties related to the task that the human actor needs to execute; for example, the type of task, the actor, and the data associated with the task can be defined by the human task node. A back-end human task service manages the lifecycle of the tasks at runtime. The implementation of the human task service is based on the WS-HumanTask specification, and the implementation is fully pluggable; this means users can integrate their own human task solution if necessary. Human tasks nodes must be included inside the process model and the end users must interact with a human task client to request their tasks, claim and complete tasks.
 
-[#_using_user_tasks_in_processes]
+[id='_using_user_tasks_in_processes']
 == Using User Tasks in Processes
 
 Red Hat JBoss BPM Suite supports the use of human tasks inside processes using a special User Task node defined by the BPMN2 Specification. A User Task node represents an atomic task that is executed by a human actor.
@@ -44,7 +44,7 @@ Apart from the above mentioned core and extra properties of user tasks, there ar
 
 To override the default values of these generic user properties, you must define a data input with the name of the property, and then set the desired value in the assignment section.
 
-[#_data_mapping]
+[id='_data_mapping']
 == Data Mapping
 
 Human tasks typically present some data related to the task that needs to be performed to the actor that is executing the task. Human tasks usually also request the actor to provide some result data related to the execution of the task. Task forms are typically used to present this data to the actor and request results.
@@ -53,7 +53,7 @@ You must specify the data that is used by the task when you define the user task
 
 Most of the times forms are used to display data to the end user. This allows them to generate or create new data to propagate to the process context to be used by future activities. In order to decide how the information flow from the process to a particular task and from the task to the process, you need to define which pieces of information must be automatically copied by the process engine.
 
-[#_task_lifecycle]
+[id='_task_lifecycle']
 == Task Lifecycle
 
 A human task is created when a user task node is encountered during the execution. The process leaves the user task node only when the associated human task is completed or aborted. The human task itself has a complete life cycle as well. The following diagram describes the human task life cycle.
@@ -73,7 +73,7 @@ While this life cycle explained above is the normal life cycle, the specificatio
 * Stopping a task in progress.
 * Skipping a task (if the task has been marked as skippable), in which case the task will not be executed.
 
-[#_sect_task_permissions]
+[id='_sect_task_permissions']
 == Task Permissions
 
 Only users associated with a specific task are allowed to modify or retrieve information about the task. This allows users to create a Red Hat JBoss BPM Suite workflow with multiple tasks and yet still be assured of both the confidentiality and integrity of the task status and information associated with a task.
@@ -213,17 +213,17 @@ You can use the following Java API methods from `UserTaskAdminService` to modify
 * `removeExcludedOwners()`: To remove existing excluded owners from given task.
 
 
-[#_sect_task_permissions1]
+[id='_sect_task_permissions1']
 == Task Service
 
-[#_task_service_and_process_engine]
+[id='_task_service_and_process_engine']
 === Task Service and Process Engine
 
 Human tasks are similar to any other external service that are invoked and implemented as a domain-specific service. As a human task is an example of such a domain-specific service, the process itself only contains a high-level, abstract description of the human task to be executed and a work item handler that is responsible for binding this (abstract) task to a specific implementation.
 
 You can plug in any human task service implementation, such as the one that is provided by JBoss BPM Suite, or may register your own implementation. The Red Hat JBoss BPM Suite provides a default implementation of a human task service based on the WS-HumanTask specification. If you do not need to integrate JBoss BPM Suite with another existing implementation of a human task service, you can use this service. The Red Hat JBoss BPM Suite implementation manages the life cycle of the tasks (such as creation, claiming, completion) and stores the state of all the tasks, task lists, and other associated information. It also supports features like internationalization, calendar integration, different types of assignments, delegation, escalation and deadlines. You can find the code for the implementation in the jbpm-human-task module. The Red Hat JBoss BPM Suite task service implementation is based on the WS-HumanTask (WS-HT) specification. This specification defines (in detail) the model of the tasks, the life cycle, and many other features.
 
-[#_task_service_api]
+[id='_task_service_api']
 === Task Service API
 
 The human task service exposes a Java API for managing the life cycle of tasks. This allows clients to integrate (at a low level) with the human task service. Note that, the end users should probably not interact with this low-level API directly, but use one of the more user-friendly task clients instead. These clients offer a graphical user interface to request task lists, claim and complete tasks, and manage tasks in general. The task clients listed below use the Java API to internally interact with the human task service. Of course, the low-level API is also available so that developers can use it in their code to interact with the human task service directly.
@@ -293,7 +293,7 @@ return content;
 For a list of Maven dependencies, see example <<_embedded_jbpm_engine_dependencies>>.
 
 
-[#_interacting_with_the_task_service]
+[id='_interacting_with_the_task_service']
 === Interacting with the Task Service
 
 In order to get access to the Task Service API, it is recommended to let the Runtime Manager ensure that everything is setup correctly. From the API perspective, if you use the following approach, there is no need to register the Task Service with the Process Engine:
@@ -333,7 +333,7 @@ For a list of Maven dependencies, see example <<_embedded_jbpm_engine_dependenci
 
 The Runtime Manager registers the Task Service with the Process Engine automatically. If you do not use the Runtime Manager, you have to set the `LocalHTWorkItemHandler` in the session to get the Task Service notify the Process Engine once the task completes. In Red Hat JBoss BPM Suite, the Task Service runs locally to the Process and Rule Engine. This enables you to create multiple light clients for different Process and Rule Engine's instances. All the clients can share the same database.
 
-[#_task_event_listener]
+[id='_task_event_listener']
 === Accessing Task Variables Using TaskEventListener
 
 Task variables can be accessed in the `TaskEventListener` for process instances.
@@ -632,7 +632,7 @@ Task comments are stored in the `task_comment` table. See a list of `task_commen
 For more information about task data model, see <<_sect_audit_log>>.
 
 [float]
-[#_people_assignments]
+[id='_people_assignments']
 === Entities and People Assignments
 
 Information about particular users and groups are stored in the `OrganizationalEntity` table. The attribute `DTYPE` determines whether it is a user or a group and `id` is the name of a user (for example `bpmsAdmin`) or a group (for example `Administrators`).
@@ -658,7 +658,7 @@ PeopleAssignments_Recipients::
 Not fully supported.
 
 
-[#_reassignments]
+[id='_reassignments']
 [float]
 === Reassignments
 
@@ -672,7 +672,7 @@ The `Deadline` table stores deadline information: the unique ID of a deadline (`
 
 The `Reassignment` table refers to the `Escalation` table: the `Escalation_Reassignments_Id` attribute in `Reassignments` is equivalent to the `id` attribute in `Escalation`.
 
-[#_notifications]
+[id='_notifications']
 [float]
 === Notifications
 
@@ -682,7 +682,7 @@ Recipients of a notification are stored in the `Notification_Recipients` table, 
 
 The `Notification_email_header` stores the ID of a notification in the `Notification_id` attribute and the ID of an email that is sent in the `emailHeader_id` attribute. The `email_header` table contains the unique ID of an email (`id`), content of an email (`body`), the _name_ of a user who is sending an email (`fromAddress`), the language of an email (`language`), the _email address_ to which it is possible to reply (`replyToAddress`), and the subject of an email (`subject`).
 
-[#_attachments]
+[id='_attachments']
 [float]
 === Attachments
 
@@ -724,13 +724,13 @@ You can attach an attachment with an arbitrary type and content to each task. Th
 
 The `Content` table stores the actual binary content of an attachment. The content type is defined in the `Attachment` table. The maximum size of an attachment is 2 GB.
 
-[#_delegations]
+[id='_delegations']
 [float]
 === Delegations
 
 Each task defines whether it can be escalated to another user or a group in the `allowedToDelegate` attribute of the `Task` table. The `Delegation_delegates` table stores the tasks that can be escalated (in the `task_id` attribute) and the users to which the tasks are escalated (`entity_id`).
 
-[#_connecting_to_custom_directory_information_services]
+[id='_connecting_to_custom_directory_information_services']
 === Connecting to Custom Directory Information Services
 
 
@@ -803,7 +803,7 @@ Using a custom [parameter]``UserGroupInfoProducer`` is not recommended or suppor
 ====
 . Restart your server. Your custom callback implementation should now be used by Business Central.
 
-[#_sect_ldap_connection]
+[id='_sect_ldap_connection']
 === LDAP Connection
 
 
@@ -828,7 +828,7 @@ The LDAP `UserGroupCallback` implementation takes the following properties:
 * [property]``java.naming.provider.url``: LDAP url (by default ``ldap://localhost:389``; if the protocol is set to `ssl` then ``ldap://localhost:636``)
 
 
-[#_connecting_to_ldap]
+[id='_connecting_to_ldap']
 ==== Connecting to LDAP
 
 
@@ -877,7 +877,7 @@ ldap.user.roles.filter=(member\={0})
 ----
 
 
-[#_task_escalation]
+[id='_task_escalation']
 == Task Escalation
 
 It is possible to implement Task Escalation for your Human Tasks to set up a timer within which certain task must be finished. To learn more about Task Escalation, see {URL_USER_GUIDE}#escalation[A.3.2. Escalation] from {USER_GUIDE}. Red Hat JBoss BPM Suite also supports custom implementation of the Email Notification Events in the Task Escalation service, which requires you to do the following:
@@ -894,7 +894,7 @@ This will cause the Task Escalation Service to trigger your custom Email Notific
 * Task information, such as task ID, name, and description.
 * Process information, such as process instance ID, process ID, and deployment ID.
 
-[#_task_assignment_strategies]
+[id='_task_assignment_strategies']
 == Task Assignment Strategies
 
 {PRODUCT} enables you to automatically assign new tasks to a potential owner of the task, using one of the available task assignment strategies. You can enable and set this feature using system properties. For more information about system properties, see the `org.jbpm.services.task.assignment` and `org.jbpm.task.assignment` properties in the {URL_ADMIN_GUIDE}#system_properties[System Properties] section of the _{ADMIN_GUIDE}_.
@@ -980,7 +980,7 @@ end
 --
 
 
-[#custom-task-assignment-strategy]
+[id='custom-task-assignment-strategy']
 == Custom Task Assignment Strategy
 A custom strategy for task assignment is created by extending the `AssignmentStrategy` interface. A custom strategy allows you to assign tasks in a way you want, rather than relying on one of the provided assignment strategies.
 
@@ -1034,7 +1034,7 @@ public class CustomStrategy implements AssignmentStrategy {
 
 
 ifdef::BPMS[]
-[#_retrieving_process_and_task_information]
+[id='_retrieving_process_and_task_information']
 == Retrieving Process and Task Information
 
 There are two services which can be used when building list-based user interfaces: the `RuntimeDataService` and `TaskQueryService`.
@@ -1147,7 +1147,7 @@ Since the `QueryFilter` inherits all of the mentioned attributes, it provides th
 Moreover, additional filtering can be applied to the queries to provide more advanced options when searching for user tasks and processes.
 endif::BPMS[]
 
-[#_advanced_queries]
+[id='_advanced_queries']
 == Advanced Queries with QueryService
 
 `QueryService` provides advanced search capabilities based on JBoss BPM Suite Dashbuilder datasets. You can retrieve data from the underlying data store by means of, for example, JPA entity tables, or custom database tables.
@@ -1395,7 +1395,7 @@ QueryParam.in(COLUMN_STATUS, 1, 3));
 
 For a list of Maven dependencies, see <<_embedded_jbpm_engine_dependencies>>.
 
-[#_advanced_queries_ips]
+[id='_advanced_queries_ips']
 === Advanced Queries Through {KIE_SERVER}
 
 To use advanced queries, you need to deploy the {KIE_SERVER}. See the {KIE_SERVER} chapter in the {USER_GUIDE} to learn more about the {KIE_SERVER}. Also, for a list of endpoints you can use, see the Advanced Queries for the {KIE_SERVER} chapter in the _{USER_GUIDE}_.

--- a/docs/product-development-guide/src/main/asciidoc/chap-install-and-setup-jboss-developer-studio.adoc
+++ b/docs/product-development-guide/src/main/asciidoc/chap-install-and-setup-jboss-developer-studio.adoc
@@ -1,4 +1,4 @@
-[[_chap_install_and_setup_jboss_developer_studio]]
+[id='_chap_install_and_setup_jboss_developer_studio']
 = Install and Set up Red Hat JBoss Developer Studio
 
 Red Hat JBoss Developer Studio is the JBoss Integrated Development Environment (IDE) based on Eclipse. Get the latest Red Hat JBoss Developer Studio from the https://access.redhat.com[Red Hat Customer Portal]. Red Hat JBoss Developer Studio provides plug-ins with tools and interfaces for Red Hat JBoss BRMS and Red Hat JBoss BPM Suite. These plugins are based on the community version of these products. So, the Red Hat JBoss BRMS plug-in is called the Drools plug-in and the Red Hat JBoss BPM Suite plug-in is called the jBPM plug-in.
@@ -7,7 +7,7 @@ See the _Red Hat JBoss Developer Studio_ documentation for installation and setu
 
 WARNING: Due to an issue in the way multi-byte rule names are handled, you must ensure that the instance of Red Hat JBoss Developer Studio is started with the file encoding set to `UTF-8`. You can do this by editing the `$_JBDS_HOME_/studio/jbdevstudio.ini` file and adding the following property: `"-Dfile.encoding=UTF-8"`.
 
-[[_installing_the_jboss_developer_studio_plug_ins]]
+[id='_installing_the_jboss_developer_studio_plug_ins']
 == Installing Red Hat JBoss Developer Studio Plug-ins
 
 Get the latest Red Hat JBoss Developer Studio from the https://access.redhat.com[Red Hat Customer Portal]. The Red Hat JBoss BRMS and Red Hat JBoss BPM Suite plug-ins for Red Hat JBoss Developer Studio are available using the update site.
@@ -22,7 +22,7 @@ Get the latest Red Hat JBoss Developer Studio from the https://access.redhat.com
 . Read the license and accept it by selecting the appropriate radio button, and click *Finish*.
 . Restart Red Hat JBoss Developer Studio after the installation process finishes.
 
-[[_configuring_the_jboss_brmsbpm_suite_server]]
+[id='_configuring_the_jboss_brmsbpm_suite_server']
 == Configuring Red Hat JBoss BRMS/BPM Suite Server
 
 Red Hat JBoss Developer Studio can be configured to run the Red Hat JBoss BRMS and Red Hat JBoss BPM Suite server.
@@ -39,7 +39,7 @@ To open the Red Hat JBoss BPM Suite view, go to *Window* -> *Open Perspective* -
 For configuring Red Hat JBoss BPM Suite server, select the Red Hat JBoss EAP directory which has Red Hat JBoss BPM Suite installed.
 . Provide a name for the server in the *Name* field, ensure that the configuration file is set, and click *Finish*.
 
-[[_importing_projects_from_a_git_repository_into_jboss_developer_studio]]
+[id='_importing_projects_from_a_git_repository_into_jboss_developer_studio']
 == Importing Projects from Git Repository into Red Hat JBoss Developer Studio
 
 You can configure Red Hat JBoss Developer Studio to connect to a central Git asset repository. The repository stores rules, models, functions, and processes.

--- a/docs/product-development-guide/src/main/asciidoc/chap-intelligent-process-server.adoc
+++ b/docs/product-development-guide/src/main/asciidoc/chap-intelligent-process-server.adoc
@@ -15,7 +15,7 @@ Red Hat JBoss BPM Suite supports two execution servers for processes: {KIE_SERVE
 
 This chapter describes the {KIE_SERVER} APIs and extensions.
 
-[[_extensions]]
+[id='_extensions']
 = {KIE_SERVER} Extensions
 
 {KIE_SERVER_BPMS} and {KIE_SERVER_BRMS} contain extensions that enable certain execution capabilities.
@@ -208,7 +208,7 @@ brq.redhat.documentation.CustomKieServerApplicationComponentsService
 
 When you start the {KIE_SERVER}, the `server/helloworld` endpoint becomes available, for example `http://localhost:8080/kie-server/services/rest/server/helloworld`. 
 
-[[_realtime_decision_server]]
+[id='_realtime_decision_server']
 = The REST API for {KIE_SERVER} Execution
 
 You can communicate with the {KIE_SERVER} through the REST API.
@@ -256,7 +256,7 @@ The rest of the endpoints will work only if your {KIE_SERVER} has BPM capabiliti
 Check the following URI for capabilities of your {KIE_SERVER} : __http://_SERVER:PORT_/kie-execution-server/services/rest/server__.
 ====
 
-[[_brms_commands]]
+[id='_brms_commands']
 == BRMS Commands
 
 [POST] /containers/instances/_CONTAINER_ID_::
@@ -339,7 +339,7 @@ An example response:
 ====
 ifdef::BPMS[]
 
-[[_managing_processes]]
+[id='_managing_processes']
 == Managing Processes
 
 
@@ -599,7 +599,7 @@ $ curl -X POST  -u 'kieserver:kieserver1!' -H 'Content-type: application/json' -
 ====
 endif::BPMS[]
 
-[[_process_queries]]
+[id='_process_queries']
 == Managing Process Definitions
 
 Use this base URI: `http://_SERVER:PORT_/kie-execution-server/services/rest/server/containers/_CONTAINER_ID_/processes/definitions`. To use pagination, use the `page` and `pageSize` query parameters. See the list of endpoints: 
@@ -743,7 +743,7 @@ An example response:
 ----
 ====
 
-[[_user_tasks]]
+[id='_user_tasks']
 == Managing User Tasks
 
 
@@ -906,7 +906,7 @@ When you turn on the security settings, you can provide a user with sufficient p
 
 If you disabled the security settings and still experience authentication issues, configure the {KIE_SERVER} callback:
 
-[[_configuring_usergroupcallback]]
+[id='_configuring_usergroupcallback']
 .Configuring UserGroupCallback
 . Override the default JAAS UserGroupCallback on the server side:
 +
@@ -1801,7 +1801,7 @@ Aditional parameters you can use: ``varValue``, ``status``, ``user``.
 ----
 
 ifdef::BPMS[]
-[[_advanced_queries2]]
+[id='_advanced_queries2']
 == Advanced Queries for the {KIE_SERVER}
 
 The {KIE_SERVER} supports the following commands through the REST API.
@@ -1975,7 +1975,7 @@ $ curl -X POST -u 'kieserver:kieserver1!' -H 'Content-type: application/xml' --d
 endif::BPMS[]
 ifdef::BPMS[]
 
-[[_job_execution]]
+[id='_job_execution']
 == Managing Job Execution
 
 
@@ -2145,7 +2145,7 @@ An example response:
 ====
 endif::BPMS[]
 
-[[sect-job-filtering]]
+[id='sect-job-filtering']
 == Advanced Search Filtering of Jobs
 
 Users with administrator or process administrator permissions can filter jobs using the *Search* tab in the *Jobs* perspective.
@@ -2241,7 +2241,7 @@ Response Type::
 An _application/octet-stream_ attachment.
 --
 
-[[_post_document]]
+[id='_post_document']
 [POST] /::
 +
 --
@@ -2315,7 +2315,7 @@ Deletes the specified document.
 
 
 ifdef::BPMS[]
-[[_the_rest_api_for_managing_the_realtime_decision_server]]
+[id='_the_rest_api_for_managing_the_realtime_decision_server']
 = The REST API for {KIE_SERVER} Administration
 
 This section provides information about the Rest API for both managed and unmanaged {KIE_SERVER} environments.
@@ -3978,7 +3978,7 @@ Returns a list of all the nodes in a process instance.
 
 The base URI for task administration is `http://_SERVER:PORT_/kie-execution-server/services/rest/server/admin/containers/_CONTAINER_ID_/tasks`. The following endpoints are available:
 
-[[_pot-owners]]
+[id='_pot-owners']
 [PUT] _TASK_ID_/pot-owners::
 +
 --
@@ -4223,7 +4223,7 @@ Payload is not required.
 
 ifdef::BPMS[]
 
-[[_intelligent_process_server_ui_extension]]
+[id='_intelligent_process_server_ui_extension']
 = {KIE_SERVER} UI Extension
 
 The {KIE_SERVER} is focused on execution and contains no UI for interaction. To simplify creating custom UI, {KIE_SERVER} is capable of providing:
@@ -4413,10 +4413,10 @@ image::9804.png[]
 ====
 endif::BPMS[]
 
-[[_rest_api_overview]]
+[id='_rest_api_overview']
 = {KIE_SERVER} Java Client API Overview
 
-[[_client_config]]
+[id='_client_config']
 == Client Configuration
 
 You need to declare a configuration object and set server communication aspects, such as the protocol (REST or JMS), credentials and the payload format (XStream, JAXB or JSON). For additional example, follow the Hello World project.
@@ -4522,7 +4522,7 @@ Note that you must assign the the `guest` role to the user `kieserver`. Addition
 </dependency>
 ----
 
-[[_jms_interaction_patterns]]
+[id='_jms_interaction_patterns']
 === JMS Interaction Patterns
 
 Since version 6.4 of {PRODUCT}, {KIE_SERVER} Client integration with JMS has been enhanced by several interaction patterns. Available interaction patterns are:
@@ -4572,7 +4572,7 @@ In case you are using asynchronous or fire and forget response handlers, you can
 
 WARNING: JMS transactions are supported only on Red Hat JBoss Enterprise Application Platform. JMS transactions are _not_ tested on Oracle WebLogic Server and IBM WebSphere Application Server.
 
-[[_server_response]]
+[id='_server_response']
 == Server Response
 
 Service responses are represented by the `org.kie.server.api.model.ServiceResponse<T>` object, where `T` represents the payload type. It has the following attributes:
@@ -4596,7 +4596,7 @@ System.out.println(response.getResult());
 
 NOTE: A service response is retrieved only if you are using the request reply response handler. In case of asynchronous or fire and forget response handlers, all remote calls always return `null`.
 
-[[_server_commands]]
+[id='_server_commands']
 == Inserting and Executing Commands
 
 To insert commands, use the `org.kie.api.command.KieCommands` class. To instantiate the `KieCommands` class, use `org.kie.api.KieServices.get().getCommands()`. If you want to add multiple commands, use the `BatchExecutionCommand` wrapper.
@@ -4652,7 +4652,7 @@ Add the `org.drools:drools-compiler` dependency into your `pom.xml` file. See th
 ----
 See <<_embedded_jbpm_engine_dependencies>> for a list of further Maven dependencies.
 
-[[_server_capabilities]]
+[id='_server_capabilities']
 == Listing Server Capabilities
 
 From version 6.2, {KIE_SERVER} supports the business process execution. To find out server capabilities, use the `org.kie.server.api.model.KieServerInfo` object.
@@ -4679,7 +4679,7 @@ public void listCapabilities() {
 ----
 ====
 
-[[_containers]]
+[id='_containers']
 == Listing Containers
 
 
@@ -4729,7 +4729,7 @@ public void listContainersWithFilter() {
 ====
 
 
-[[_container_handling]]
+[id='_container_handling']
 == Handling Containers
 
 You can use the {KIE_SERVER} Java client to create and dispose containers.
@@ -4773,7 +4773,7 @@ public void disposeAndCreateContainer() {
 A conversation between a client and a specific {KIE_SERVER} container in a clustered environment is secured by a unique `conversationID`. The `conversationID`  is transferred using the `X-KIE-ConversationId` REST header. If you update the container, unset the previous `conversationID`.  Use `KieServiesClient.completeConversation()` to unset the `conversationID` for Java API.
 ====
 
-[[_decision_server_clients]]
+[id='_decision_server_clients']
 == Available {KIE_SERVER} Clients
 
 `KieServicesClient` serves also as an entry point for other clients with the ability to perform various operations, such as Red Hat JBoss BRMS commands and manage processes.
@@ -4799,7 +4799,7 @@ The `getServicesClient` method provides access to any of these clients:
 RuleServicesClient rulesClient = kieServicesClient.getServicesClient(RuleServicesClient.class);
 ----
 
-[[_business_processes]]
+[id='_business_processes']
 == Listing Available Business Processes
 
 
@@ -4870,7 +4870,7 @@ public static void startProcess() {
 
 ifdef::BPMS[]
 
-[[_querydefinition]]
+[id='_querydefinition']
 == QueryDefinition for {KIE_SERVER} Using Java Client API
 
 `QueryDefinition` is a feature used to execute advanced queries. For more information about advanced queries, see <<_advanced_queries2>>. To register and execute query definitions using the Java Client API, see the following example:

--- a/docs/product-development-guide/src/main/asciidoc/chap-jboss-brms-and-jboss-bpm-suite-architecture.adoc
+++ b/docs/product-development-guide/src/main/asciidoc/chap-jboss-brms-and-jboss-bpm-suite-architecture.adoc
@@ -1,7 +1,7 @@
-[[_chap_jboss_brms_and_jboss_bpm_suite_architecture]]
+[id='_chap_jboss_brms_and_jboss_bpm_suite_architecture']
 = Red Hat JBoss BRMS and Red Hat JBoss BPM Suite Architecture
 
-[[_sect_jboss_business_rules_management_system]]
+[id='_sect_jboss_business_rules_management_system']
 == Red Hat JBoss Business Rules Management System
 
 Red Hat JBoss BRMS is an open source business rule management system that provides rules development, access, change, and management capabilities. In today's world, when IT organizations consistently face changes in terms of policies, new products, government imposed regulations, a system like JBoss BRMS makes it easy by separating business logic from the underlying code. It includes a rule engine, a rules development environment, a management system, and a repository. It allows both developers and business analysts to view, manage, and verify business rules as they are executed within an IT application infrastructure.
@@ -34,7 +34,7 @@ Drools Fusion provides event processing capabilities to the Red Hat JBoss BRMS p
 +
 We encourage you to use Red Hat JBoss Developer Studio (JBDS) with Red Hat JBoss BRMS plug-ins to develop and test business rules. The Red Hat JBoss Developer Studio builds upon an extensible, open source Java-based IDE Eclipse providing platform and framework capabilities, making it ideal for Red Hat JBoss BRMS rules development.
 
-[[_jboss_brms_features]]
+[id='_jboss_brms_features']
 === Red Hat JBoss BRMS Features
 
 The Red Hat JBoss BRMS provides the following key features:
@@ -50,7 +50,7 @@ The Red Hat JBoss BRMS provides the following key features:
 * Easy to maintain business logic.
 * Enables several stakeholders (business analysts, developer, administrators) to contribute in defining the business logic.
 
-[[_sect_jboss_business_process_management_suite]]
+[id='_sect_jboss_business_process_management_suite']
 == Red Hat JBoss Business Process Management Suite
 
 Red Hat JBoss BPM Suite is an open source business process management system that combines business process management and business rules management. Red Hat JBoss BRMS offers tools to author rules and business processes, but does not provide tools to start or manage the business processes. Red Hat JBoss BPM Suite includes all the Red Hat JBoss BRMS functionality, with additional capabilities of business activity monitoring, starting business processes, and managing tasks using Business Central. Red Hat JBoss BPM Suite also provides a central repository to store rules and processes.
@@ -86,7 +86,7 @@ For example, if you are developing a web application, include the Red Hat JBoss 
 +
 The business artifacts of a Red Hat JBoss BPM Suite project, such as process models, rules, and forms, are stored in Git repositories managed through the Business Central. You can also access these repositories outside of Business Central through the Git or SSH protocols.
 
-[[_jboss_bpm_suite_features]]
+[id='_jboss_bpm_suite_features']
 === Red Hat JBoss BPM Suite Features
 
 Red Hat JBoss BPM Suite provides the following features:
@@ -105,17 +105,17 @@ Red Hat JBoss BPM Suite provides the following features:
 * Remote API to process engine as a service (REST, JMS, Remote Java API).
 * Integration with Maven, Spring, and OSGi.
 
-[[_supported_platforms]]
+[id='_supported_platforms']
 == Supported Platforms and APIs
 
 For a list of supported containers and configurations, see section {URL_INSTALLATION_GUIDE}#supported_platforms[Supported Platforms] of _{INSTALLATION_GUIDE}_. 
 
 The `kie-api` is a fully supported API and it is the recommended way to interact with your project. For further information about API supportability, see Knowledgebase article  https://access.redhat.com/solutions/1344003[What Are the Public and Internal APIs for BPM Suite and BRMS 6?].
 
-[[_sect_use_cases]]
+[id='_sect_use_cases']
 == Use Cases
 
-[[_use_cases3]]
+[id='_use_cases3']
 === Use Case: Business Decision Management in Insurance Industry with Red Hat JBoss BRMS
 
 Red Hat JBoss BRMS comprises a high performance rule engine, a rule repository, easy to use rule authoring tools, and complex event processing rule engine extensions. The following use case describes how these features of Red Hat JBoss BRMS are implemented in insurance industry.
@@ -129,7 +129,7 @@ image::3628.png[]
 
 Red Hat JBoss BRMS provides the decision management functionality, that automatically determines the products to present to the applicant based on the rules defined by the business analysts. The rules are implemented as decision tables, so they can be easily understood and modified without requiring additional support from IT.
 
-[[_use_cases1]]
+[id='_use_cases1']
 === Use Case: Process­-Based Solution in Loan Industry
 
 This section describes a use case of deploying Red Hat JBoss BPM Suite to automate business processes (such as loan approval process) at a retail bank. This use case is a typical process-based specific deployment that might be the first step in a wider adoption of Red Hat JBoss BPM Suite throughout an enterprise. It leverages features of both business rules and processes of Red Hat JBoss BPM Suite.

--- a/docs/product-development-guide/src/main/asciidoc/chap-kie-api.adoc
+++ b/docs/product-development-guide/src/main/asciidoc/chap-kie-api.adoc
@@ -1,11 +1,11 @@
-[[_chap_java_apis]]
+[id='_chap_java_apis']
 = Java APIs
 
 Red Hat JBoss BRMS and Red Hat JBoss BPM Suite provide various Java APIs which enable you to embed runtime engines into your application.
 
 NOTE: It is recommended to use the services described in <<_sect_kie_services>>. These high-level APIs deal with low-level details and enable you to focus solely on business logic.
 
-[[_sect_kie_api]]
+[id='_sect_kie_api']
 == KIE API
 
 The KIE (_Knowledge Is Everything_) API is used to load and execute business processes. To interact with the process engine—for example to start a process—you need to set up a session, which is used to communicate with the process engine. A session must have a reference to a knowledge base, which contains references to all the relevant process definitions and searches the definitions whenever necessary.
@@ -25,7 +25,7 @@ It is possible to create more independent sessions or multiple sessions; for exa
 
 The Red Hat JBoss BPM Suite projects have a clear separation between the APIs users interact with and the actual implementation classes. The public API exposes most of the features that users can safely use, however, experienced users can still access internal classes. Keep in mind that the internal APIs may change in the future.
 
-[[_sect_kie_framework]]
+[id='_sect_kie_framework']
 === KIE Framework
 
 In the Red Hat JBoss BPM Suite environment, the life cycle of KIE systems is divided into the following labels:
@@ -57,7 +57,7 @@ In the Red Hat JBoss BPM Suite environment, the life cycle of KIE systems is div
 |Managing any session or a KIE container.
 |===
 
-[[_kiebase]]
+[id='_kiebase']
 === KIE Base
 
 The KIE API enables you to create a knowledge base that includes all the process definitions that may need to be executed. To create a knowledge base, use `KieHelper` to load processes from various resources (for example, from the class path or from the file system), and then create a new knowledge base from that helper. The following code snippet shows how to manually create a simple knowledge base consisting of only one process definition, using a resource from the class path:
@@ -211,7 +211,7 @@ import org.kie.api.runtime.KieSessionConfiguration;
         }
 ----
 
-[[_sect_kiesession]]
+[id='_sect_kiesession']
 === KIE Session
 
 Once the knowledge base is loaded, create a session to interact with the engine. The session can then be used to start new processes and signal events. The following code snippet shows how to create a session and start a new process instance:
@@ -327,7 +327,7 @@ manager.close();
 
 For Maven dependencies, see <<_embedded_jbpm_engine_dependencies>>. For further information about the Runtime Manager, see <<_sect_runtime_manager>>.
 
-[[_the_processruntime_interface]]
+[id='_the_processruntime_interface']
 ==== Process Runtime Interface
 
 The `ProcessRuntime` interface, which is extended by `KieSession`, defines methods for interacting with processes. See the interface below:
@@ -441,7 +441,7 @@ WorkItemManager getWorkItemManager();
 }
 ----
 
-[[_event_listeners]]
+[id='_event_listeners']
 ==== Event Listeners
 
 A knowledge session provides methods for registering and removing listeners.
@@ -573,7 +573,7 @@ logger.close();
 
 `KieRuntimeLogger` uses the comprehensive event system in Red Hat JBoss BRMS to create an audit log that can be used to log the execution of an application for later inspection, using tools such as the Red Hat JBoss Developer Studio audit viewer.
 
-[[_correlation_keys]]
+[id='_correlation_keys']
 ==== Correlation Keys
 
 When working with processes, you may require to assign a given process instance a business identifier for later reference without knowing the generated process instance ID. To provide such capabilities, Red Hat JBoss BPM Suite enables you to use the `CorrelationKey` interface that is composed of `CorrelationProperties`.
@@ -680,7 +680,7 @@ Collection<ProcessInstanceDesc> getProcessInstancesByCorrelationKey
   (CorrelationKey correlationKey);
 ----
 
-[[_threads]]
+[id='_threads']
 ==== Threads
 
 Multi-threading is divided into _technical_ and _logical_ multi-threading.
@@ -702,7 +702,7 @@ When a service task is reached in a process, the engine invokes the handler of t
 
 Human tasks are a typical example of a service that needs to be invoked asynchronously, as the engine does not have to wait until a human actor responds to the request. The human task handler only creates a new task when the human task node is triggered. The engine then is able to continue the execution of the process (if necessary) and the handler notifies the engine asynchronously when the user completes the task.
 
-[[_globals_in_kie]]
+[id='_globals_in_kie']
 ==== Globals
 
 Globals are named objects that are visible to the engine differently from facts; changes in a global do not trigger reevaluation of rules. Globals are useful for providing static information, as an object offering services that are used in the RHS of a rule, or as a means to return objects from the rule engine. When you use a global on the LHS of a rule, make sure it is immutable, or, at least, do not expect changes to have any effect on the behavior of your rules.
@@ -743,7 +743,7 @@ To access your global variable, use the `getVariable()` method:
 processInstance.getContextInstance().getVariable("globalStatus");
 ----
 
-[[_kiefilesystem]]
+[id='_kiefilesystem']
 === KIE File System
 
 You can define the a KIE base and a KIE session that belong to a KIE module programmatically instead of using definitions in the `kmodule.xml` file. The API also enables you to add the file that contains the KIE artifacts instead of automatically reading the files from the resources folder of your project. To add KIE artifacts manually, create a `KieFileSystem` object, which is a sort of virtual file system, and add all the resources contained in your project to it.
@@ -822,7 +822,7 @@ Add all the resources to your `KieFileSystem` instance and build it by passing t
 
 When you build `KieFileSystem`, the resulting `KieModule` is automatically added to the `KieRepository` singleton. `KieRepository` is a singleton acting as a repository for all the available `KieModule` instances.
 
-[[_the_kmodule]]
+[id='_the_kmodule']
 === KIE Module
 
 Red Hat JBoss BRMS and Red Hat JBoss BPM Suite use Maven and align with Maven practices. A KIE project or a KIE module is a Maven project or a module with an additional metadata file `META-INF/kmodule.xml`. This file is a descriptor that selects resources to knowledge bases and configures sessions. There is also alternative XML support through Spring and OSGi BluePrints.
@@ -991,7 +991,7 @@ Since default values have been provided for all configuration aspects, the simpl
 
 In this way the KIE module will contain a single default KIE base. All KIE assets stored in the resources directory, or any directory in it, will be compiled and added to the default KIE base. To build the artifacts, it is sufficient to create a KIE container for them.
 
-[[_creating_a_kie_container]]
+[id='_creating_a_kie_container']
 === KIE Container
 
 The following example shows how to build a `KieContainer` object that reads resources built from the class path:
@@ -1066,7 +1066,7 @@ Use the `KieServices` interface to access KIE building and runtime facilities.
 
 The example shows how to compile all the Java sources and the KIE resources and deploy them into your KIE container, which makes its content available for use at runtime.
 
-[[_session_modification]]
+[id='_session_modification']
 ==== KIE Base Configuration
 
 Sometimes, for instance in an OSGi environment, the `KieBase` object needs to resolve types that are not in the default class loader. To do so, create a `KieBaseConfiguration` instance with an additional class loader and pass it to `KieContainer` when creating a new `KieBase` object. For example:
@@ -1092,7 +1092,7 @@ The `KieBase` object can create, and optionally keep references to, `KieSession`
 
 NOTE: If you are using Oracle WebLogic Server, note how it finds and loads application class files at runtime. When using a non-exploded WAR deployment, Oracle WebLogic Server packs the contents of `WEB-INF/classes` into `WEB-INF/lib/_wl_cls_gen.jar`. Consequently, when you use `KIE-Spring` to create `KieBase` and `KieSession` from resources stored in `WEB-INF/classes`, `KIE-Spring` fails to locate these resources. For this reason, the recommended deployment method on Oracle WebLogic Server is to use the exploded archives contained within the product ZIP file.
 
-[[_kie_plugin]]
+[id='_kie_plugin']
 === KIE Maven Plug-in
 
 The KIE Maven Plug-in validates and pre-compiles artifact resources. It is recommended that the plug-in is used at all times. To use the plug-in, add it to the build section of your Maven `pom.xml` file:
@@ -1121,7 +1121,7 @@ Building a KIE module without the Maven plugin copies all the resources into the
 
 NOTE: For compiling decision tables and processes, add their dependencies to project dependencies (as compile scope) or as plugin dependencies. For decision tables the dependency is `org.drools:drools-decisiontables` and for processes `org.jbpm:jbpm-bpmn2`.
 
-[[_kierepository]]
+[id='_kierepository']
 === KIE Repository
 
 When you build the content of `KieFileSystem`, the resulting `KieModule` is automatically added to `KieRepository`. `KieRepository` is a singleton acting as a repository for all the available KIE modules.
@@ -1170,7 +1170,7 @@ assertEquals(0, kieBuilder.getResults().getMessages(Message.Level.ERROR).size())
 ----
 ====
 
-[[_kiescanner]]
+[id='_kiescanner']
 === KIE Scanner
 
 The KIE Scanner continuously monitors your Maven repository to check for a new release of your KIE project. A new release is deployed in the `KieContainer` wrapping that project. The use of the `KieScanner` requires `kie-ci.jar` to be on the class path.
@@ -1226,7 +1226,7 @@ Since `KieScanner` relies on Maven, Maven should be configured with the correct 
 </profile>
 ----
 
-[[_command_executor]]
+[id='_command_executor']
 === Command Executor
 
 The `CommandExecutor` interface enables commands to be executed on both stateful and stateless KIE sessions. The stateless KIE session executes `fireAllRules()` at the end before disposing the session.
@@ -1296,7 +1296,7 @@ In the example above, multiple commands are executed, two of which populate the 
 
 All commands support XML (using XStream or JAXB marshallers) and JSON marshalling. For more information, see <<_marshalling>>.
 
-[[_marshalling]]
+[id='_marshalling']
 ==== Marshalling
 
 XML marshalling and unmarshalling of the JBoss BRMS Commands requires the use of special classes.
@@ -1389,7 +1389,7 @@ Marshaller marshaller = jaxbContext.createMarshaller();
 
 Ensure that the `drools-compiler` and `jaxb-xjc` libraries are present on the classpath. The fully-qualified class name of the `DroolsJaxbHelperProviderImpl` class is `org.drools.compiler.runtime.pipeline.impl.DroolsJaxbHelperProviderImpl`.
 
-[[_sect_supported_jboss_brms_commands]]
+[id='_sect_supported_jboss_brms_commands']
 ==== Supported Commands
 
 Red Hat JBoss BRMS supports the following list of commands:
@@ -1419,7 +1419,7 @@ The code snippets provided in the examples for these commands use a POJO `org.dr
 
 ====
 
-[[_batchexecutioncommand]]
+[id='_batchexecutioncommand']
 ===== BatchExecutionCommand
 
 The `BatchExecutionCommand` command wraps multiple commands to be executed together.
@@ -1498,7 +1498,7 @@ JAXB:
 </batch-execution>
 ----
 
-[[_insertobjectcommand]]
+[id='_insertobjectcommand']
 ===== InsertObjectCommand
 
 The `InsertObjectCommand` command is used to insert an object in the knowledge session. It has the following attributes:
@@ -1585,7 +1585,7 @@ JAXB:
 </insert>
 ----
 
-[[_retractcommand]]
+[id='_retractcommand']
 ===== RetractCommand
 
 The `RetractCommand` command is used to retract an object from the knowledge session. It has the following attributes:
@@ -1648,7 +1648,7 @@ JAXB:
 <retract fact-handle="0:234:345:456:567"/>
 ----
 
-[[_modifycommand]]
+[id='_modifycommand']
 ===== ModifyCommand
 
 The `ModifyCommand` command allows you to modify a previously inserted object in the knowledge session. It has the following attributes:
@@ -1718,7 +1718,7 @@ JAXB:
 </modify>
 ----
 
-[[_getobjectcommand]]
+[id='_getobjectcommand']
 ===== GetObjectCommand
 
 The `GetObjectCommand` command is used to get an object from a knowledge session. It has the following attributes:
@@ -1777,7 +1777,7 @@ JAXB:
 <get-object out-identifier="john" fact-handle="0:234:345:456:567"/>
 ----
 
-[[_insertelementscommand]]
+[id='_insertelementscommand']
 ===== InsertElementsCommand
 
 The `InsertElementsCommand` command is used to insert a list of objects. It has the following attributes:
@@ -1880,7 +1880,7 @@ JAXB:
 </insert-elements>
 ----
 
-[[_fireallrulescommand]]
+[id='_fireallrulescommand']
 ===== FireAllRulesCommand
 
 The `FireAllRulesCommand` command is used to allow execution of the rules activations created. It has the following attributes:
@@ -1943,7 +1943,7 @@ JAXB:
 <fire-all-rules out-identifier="firedActivations" max="10"/>
 ----
 
-[[_startprocesscommand]]
+[id='_startprocesscommand']
 ===== StartProcessCommand
 
 The `StartProcessCommand` command allows you to start a process using the ID. Additionally, you can pass parameters and initial data to be inserted. It has the following attributes:
@@ -2006,7 +2006,7 @@ JAXB:
 </start-process>
 ----
 
-[[_signaleventcommand]]
+[id='_signaleventcommand']
 ===== SignalEventCommand
 
 The `SignalEventCommand` command is used to send a signal event. It has the following attributes:
@@ -2087,7 +2087,7 @@ JAXB:
 </signal-event>
 ----
 
-[[_completeworkitemcommand]]
+[id='_completeworkitemcommand']
 ===== CompleteWorkItemCommand
 
 The `CompleteWorkItemCommand` command allows you to complete a WorkItem. It has the following attributes:
@@ -2144,7 +2144,7 @@ JAXB:
 <complete-work-item id="1001"/>
 ----
 
-[[_abortworkitemcommand]]
+[id='_abortworkitemcommand']
 ===== AbortWorkItemCommand
 
 The `AbortWorkItemCommand` command enables you to abort a work item the same way as `ksession.getWorkItemManager().abortWorkItem(workItemId)`. It has the following attributes:
@@ -2197,7 +2197,7 @@ JAXB:
 <abort-work-item id="1001"/>
 ----
 
-[[_querycommand]]
+[id='_querycommand']
 ===== QueryCommand
 
 The `QueryCommand` command executes a query defined in the knowledge base. It has the following attributes:
@@ -2260,7 +2260,7 @@ JAXB:
 <query name="persons" out-identifier="persons"/>
 ----
 
-[[_setglobalcommand]]
+[id='_setglobalcommand']
 ===== SetGlobalCommand
 
 The `SetGlobalCommand` command enables you to set an object to global state. It has the following attributes:
@@ -2345,7 +2345,7 @@ JAXB:
 </set-global>
 ----
 
-[[_getglobalcommand]]
+[id='_getglobalcommand']
 ===== GetGlobalCommand
 
 The `GetGlobalCommand` command allows you to get a previously defined global object. It has the following attributes:
@@ -2404,7 +2404,7 @@ JAXB:
 <get-global out-identifier="helperOutput" identifier="helper"/>
 ----
 
-[[_getobjectscommand]]
+[id='_getobjectscommand']
 ===== GetObjectsCommand
 
 The `GetObjectsCommand` command returns all the objects from the current session as a Collection. It has the following attributes:
@@ -2461,10 +2461,10 @@ JAXB:
 <get-objects out-identifier="objects"/>
 ----
 
-[[_sect_kie_configuration]]
+[id='_sect_kie_configuration']
 === KIE Configuration
 
-[[_build_result_severity1]]
+[id='_build_result_severity1']
 ==== Build Result Severity
 
 In some cases, it is possible to change the default severity of a type of build result. For instance, when a new rule with the same name of an existing rule is added to a package, the default behavior is to replace the old rule by the new rule and report it as an INFO. This is probably ideal for most use cases, but in some deployments the user might want to prevent the rule update and report it as an error.
@@ -2483,7 +2483,7 @@ drools.kbuilder.severity.duplicateFunction = <INFO|WARNING|ERROR>
 ----
 ====
 
-[[_statelesskiesession]]
+[id='_statelesskiesession']
 ==== StatelessKieSession
 
 The `StatelessKieSession` wraps the `KieSession`, instead of extending it. Its main focus is on the decision service type scenarios. It avoids the need to call `dispose()`. Stateless sessions do not support iterative insertions and the method call `fireAllRules()` from Java code; the act of calling `execute()` is a single-shot method that will internally instantiate a `KieSession`, add all the user data and execute user commands, call `fireAllRules()`, and then call `dispose()`. While the main way to work with this class is via the `BatchExecution` (a subinterface of `Command`) as supported by the `CommandExecutor` interface, two convenience methods are provided for when simple object insertion is all that's required. The `CommandExecutor` and `BatchExecution` are talked about in detail in their own section.
@@ -2564,7 +2564,7 @@ results.getValue("person");
 results.getValue("Get People");
 ----
 ====
-[[_sequential_mode]]
+[id='_sequential_mode']
 ===== Sequential Mode
 
 In a stateless session, the initial data set cannot be modified, and rules cannot be added or removed with the ReteOO algorithm. See <<_phreak_and_sequential_mode>> for more information about PHREAK and sequential mode. Sequential mode can be used with stateless sessions only.
@@ -2640,7 +2640,7 @@ KieBase kieBase = kc.newKieBase(conf);
 ----
 --
 
-[[_marshalling1]]
+[id='_marshalling1']
 ==== Marshalling
 
 The `KieMarshallers` are used to marshal and unmarshal KieSessions.
@@ -2733,7 +2733,7 @@ KSession ksession = kbase.newKieSession(ksconf, null);
 ----
 ====
 
-[[_kie_persistence]]
+[id='_kie_persistence']
 ==== KIE Persistence
 
 Longterm out of the box persistence with Java Persistence API (JPA) is possible with BRMS. It is necessary to have some implementation of the Java Transaction API (JTA) installed. For development purposes the Bitronix Transaction Manager is suggested, as it's simple to set up and works embedded, but for production use JBoss Transactions is recommended.
@@ -2835,10 +2835,10 @@ java.naming.factory.initial=bitronix.tm.jndi.BitronixInitialContextFactory
 ----
 ====
 
-[[_sect_kie_sessions]]
+[id='_sect_kie_sessions']
 === KIE Sessions
 
-[[_sect_stateless_kie_sessions]]
+[id='_sect_stateless_kie_sessions']
 ==== Stateless KIE Sessions
 
 A _stateless KIE session_ is a session without inference. A stateless session can be called like a function in that you can use it to pass data and then receive the result back.
@@ -2920,7 +2920,7 @@ Here, since the applicant is under the age of eighteen, their application will b
 .Result
 The preceding code executes the data against the rules. Since the applicant is under the age of 18, the application is marked as invalid.
 
-[[_configuring_rules_with_multiple_objects]]
+[id='_configuring_rules_with_multiple_objects']
 ===== Configuring Rules with Multiple Objects
 
 . To execute rules against any object-implementing `iterable` (such as a collection), add another class as shown in the example code below:
@@ -3005,14 +3005,14 @@ assertEquals(new Person("Mr John Smith"), results.getValue("mrSmith"));
 `CommandFactory` supports many other commands that can be used in the `BatchExecutor`. Some of these are `StartProcess`, `Query` and `SetGlobal`.
 ====
 
-[[_sect_stateful_kie_sessions]]
+[id='_sect_stateful_kie_sessions']
 ==== Stateful KIE Sessions
 
 A _stateful session_ allow you to make iterative changes to facts over time. As with the `StatelessKnowledgeSession`, the `StatefulKnowledgeSession` supports the `BatchExecutor` interface. The only difference is the `FireAllRules` command is not automatically called at the end.
 
 WARNING: Ensure that the `dispose()` method is called after running a stateful session. This is to ensure that there are no memory leaks. This is due to the fact that knowledge bases will obtain references to stateful knowledge sessions when they are created.
 
-[[_common_use_cases_for_stateful_sessions]]
+[id='_common_use_cases_for_stateful_sessions']
 ===== Common Use Cases for Stateful Sessions
 
 Monitoring::
@@ -3027,7 +3027,7 @@ For example, they could be applied to problems involving parcel tracking and del
 Ensuring compliance::
 For example, to validate the legality of market trades.
 
-[[_stateful_session_monitoring_example]]
+[id='_stateful_session_monitoring_example']
 ===== Stateful Session Monitoring Example
 
 . Create a model of what you want to monitor. In this example involving fire alarms, the rooms in a house have been listed. Each has one sprinkler. A fire can start in any of the rooms:
@@ -3074,7 +3074,7 @@ end
 +
 Whereas the stateless session employed standard Java syntax to modify a field, the rule above uses the `modify` statement. It acts much like a `with` statement.
 
-[[_sect_runtime_manager]]
+[id='_sect_runtime_manager']
 == Runtime Manager
 
 The `RuntimeManager` interface enables and simplifies the usage of KIE API.
@@ -3150,7 +3150,7 @@ Additionally, the runtime manager provides dedicated methods to dispose `Runtime
 
 === Usage
 
-[[_usage_scenario_for_runtimemanager_interface]]
+[id='_usage_scenario_for_runtimemanager_interface']
 ==== Usage Scenario
 
 Regular usage scenario for `RuntimeManager` is:
@@ -3169,7 +3169,7 @@ Regular usage scenario for `RuntimeManager` is:
 
 NOTE: When the `RuntimeEngine` is obtained from `RuntimeManager` within an active JTA transaction, then there is no need to dispose `RuntimeEngine` at the end, as it automatically disposes the `RuntimeEngine` on transaction completion (regardless of the completion status commit or rollback).
 
-[[_building_runtimemanager]]
+[id='_building_runtimemanager']
 ==== Building Runtime Manager
 
 Here is how you can build `RuntimeManager` (with `RuntimeEnvironment`) and get `RuntimeEngine` (that encapsulates `KieSession` and `TaskService`) from it:
@@ -3238,7 +3238,7 @@ This is automatically registered on the `KieSession`.
 
 WARNING: The `MVELUserGroupCallback` class fails to initialize in an OSGi environment. Do _not_ use or include `MVELUserGroupCallback` as it is not designed for production purposes.
 
-[[_strategies]]
+[id='_strategies']
 === Strategies
 
 There are multiple strategies of managing KIE sessions that can be used when working with the Runtime Manager.
@@ -3257,7 +3257,7 @@ It has the following characteristics:
 * Not contextual, that is when retrieving instances of `RuntimeEngine` from singleton `RuntimeManager`, Context instance is not important and usually the `EmptyContext.get()` method is used, although null argument is acceptable as well.
 * Keeps track of the ID of the `KieSession` used between `RuntimeManager` restarts, to ensure it uses the same session. This ID is stored as serialized file on disc in a temporary location that depends on the environment.
 
-[[_singleton_strategy_limitations]]
+[id='_singleton_strategy_limitations']
 [WARNING]
 ====
 Using the Singleton strategy with JTA transactions (`UserTransaction` or CMT) is not recommended because of a race condition. It can result in an `IllegalStateException` with a message similar to "_Process instance_ X _is disconnected_".
@@ -3306,7 +3306,7 @@ This instructs the `RuntimeManager` to maintain a strict relationship between `K
 
 Runtime Manager provides various ways how to register work item handlers and process event listeners.
 
-[[_registering_handlers_and_listeners_through_registerableitemsfactory]]
+[id='_registering_handlers_and_listeners_through_registerableitemsfactory']
 ==== Registering Through Registerable Items Factory
 
 The implementation of `RegisterableItemsFactory` provides a dedicated mechanism to create your own handlers or listeners.
@@ -3370,7 +3370,7 @@ org.jbpm.runtime.manager.impl.cdi.InjectableRegisterableItemsFactory::
 This is an extension of the default implementation (`DefaultRegisterableItemsFactory`) that is tailored for CDI environments and provides CDI style approach to finding handlers and listeners through producers.
 
 
-[[_registering_handlers_through_configuration_files]]
+[id='_registering_handlers_through_configuration_files']
 ==== Registering Through Configuration Files
 
 Alternatively, you may also register simple (stateless or requiring only `KieSession`) work item handlers by defining them as part of `CustomWorkItem.conf` file and update the class path. To use this approach do the following:
@@ -3397,7 +3397,7 @@ drools.workItemHandlers = CustomWorkItemHandlers.conf
 
 These steps register the work item handlers for any `KieSession` created by the application, regardless of it using the `RuntimeManager` or not.
 
-[[_registering_handlers_and_listeners_in_cdi_environment]]
+[id='_registering_handlers_and_listeners_in_cdi_environment']
 ==== Registering in CDI Environment
 
 When you are using `RuntimeManager` in CDI environment, you can use the dedicated interfaces to provide custom `WorkItemHandlers` and `EventListeners` to the `RuntimeEngine`.
@@ -3468,7 +3468,7 @@ All the components (`KieSession`, `TaskService`, and `RuntimeManager`) are provi
 
 NOTE: Whenever there is a need to interact with the process engine or task service from within handler or listener, recommended approach is to use `RuntimeManager` and retrieve `RuntimeEngine` (and then `KieSession` or `TaskService`) from it as that ensures a proper state.
 
-[[_control_parameters_to_alter_default_engine_behavior]]
+[id='_control_parameters_to_alter_default_engine_behavior']
 === Control Parameters
 
 The following control parameters are available to alter engine default behavior:
@@ -3577,7 +3577,7 @@ An alternative comparator class to empower the Start Process by Name feature.
 endif::BPMS[]
 
 ifdef::BPMS[]
-[[jbpm.usergroup.callback.properties]]
+[id='jbpm.usergroup.callback.properties']
 *jbpm.usergroup.callback.properties*::
 +
 --
@@ -3612,7 +3612,7 @@ An alternative classpath location of user information configuration (used by `LD
 endif::BPMS[]
 
 ifdef::BPMS[]
-[[jbpm.user.info.properties]]
+[id='jbpm.user.info.properties']
 *jbpm.user.info.properties*::
 +
 --
@@ -3647,7 +3647,7 @@ An alternative JNDI name to be used when there is no access to the default one f
 endif::BPMS[]
 
 ifdef::BPMS[]
-[[org.jbpm.ht.callback]]
+[id='org.jbpm.ht.callback']
 *org.jbpm.ht.callback*::
 +
 --
@@ -3672,7 +3672,7 @@ Specifies the implementation of user group callback to be used:
 endif::BPMS[]
 
 ifdef::BPMS[]
-[[org.jbpm.ht.custom.callback]]
+[id='org.jbpm.ht.custom.callback']
 *org.jbpm.ht.custom.callback*::
 +
 --
@@ -3690,7 +3690,7 @@ A custom implementation of the `UserGroupCallback` interface in case the <<org.j
 endif::BPMS[]
 
 ifdef::BPMS[]
-[[org.jbpm.ht.custom.userinfo]]
+[id='org.jbpm.ht.custom.userinfo']
 *org.jbpm.ht.custom.userinfo*::
 +
 --
@@ -3708,7 +3708,7 @@ A custom implementation of the `UserInfo` interface in case the <<org.jbpm.ht.us
 endif::BPMS[]
 
 ifdef::BPMS[]
-[[org.jbpm.ht.userinfo]]
+[id='org.jbpm.ht.userinfo']
 *org.jbpm.ht.userinfo*::
 +
 --
@@ -3777,7 +3777,7 @@ Enables or disables the JMS support of the executor. Set to `false` to disable J
 |===
 --
 
-[[org.kie.executor.interval]]
+[id='org.kie.executor.interval']
 *org.kie.executor.interval*::
 +
 --
@@ -3824,7 +3824,7 @@ The number of retries the async job executor attempts on a failed job.
 |===
 --
 
-[[org.kie.executor.timeunit]]
+[id='org.kie.executor.timeunit']
 *org.kie.executor.timeunit*::
 +
 --
@@ -3874,7 +3874,7 @@ endif::BPMS[]
 
 These allow you to fine tune the execution for the environment needs and actual requirements. All of these parameters are set as JVM system properties, usually with `-D` when starting a program such as an application server.
 
-[[_storing_process_variables_without_serialization]]
+[id='_storing_process_variables_without_serialization']
 === Variable Persistence Strategy
 
 Objects in Red Hat JBoss BPM Suite that are used as process variables must be serializable. That is, they must implement the `java.io.Serializable` interface. Objects that are not serializable can be used as process variables but for these you must implement and use a marshaling strategy and register it. The default strategy will not convert these variables into bytes. By default all objects need to be serializable.
@@ -3946,7 +3946,7 @@ public interface ObjectMarshallingStrategy {
 
 The methods `read()` and `write()` are for backwards compatibility. Use the methods `accept()`, `marshal()` and `unmarshal()` to create your strategy.
 
-[[_sect_kie_services]]
+[id='_sect_kie_services']
 == KIE Services
 
 {PRODUCT} provides a set of high level services on top of the Runtime Manager API. These services are the easiest way to embed BPM capabilities into a custom application.
@@ -3973,7 +3973,7 @@ CDI wrapper of the Executor Service core implementation
 NOTE: When working with KIE Services, you do not have to create your own wrappers around Runtime Manager, Runtime Engine, and KIE Session.
 KIE Services make use of Runtime Manager API best practices and thus, eliminate various risks when working with that API.
 
-[[_sect_deployment_service]]
+[id='_sect_deployment_service']
 === Deployment Service
 
 The Deployment Service is responsible for managing deployment units which include resources such as rules, processes, and forms.
@@ -4045,7 +4045,7 @@ long processInstanceId = processService.startProcess(deploymentUnit.getIdentifie
 ProcessInstance pi = processService.getProcessInstance(processInstanceId);
 ----
 
-[[_sect_runtime_data_service]]
+[id='_sect_runtime_data_service']
 === Runtime Data Service
 
 The Runtime Data Service provides access to actual data that is available on runtime such as:
@@ -4101,7 +4101,7 @@ results.put("Result", "some document data");
 userTaskService.complete(taskId, "john", results);
 ----
 
-[[_sect_query_service]]
+[id='_sect_query_service']
 === Query Service
 
 The Query Service provides advanced search capabilities that are based on DashBuilder Data Sets.
@@ -4414,7 +4414,7 @@ Executor Service provides:
 
 include::chap-admin-services.adoc[leveloffset=+2]
 
-[[_sect_cdi_integration]]
+[id='_sect_cdi_integration']
 == CDI Integration
 
 Apart from the API based approach, Red Hat JBoss BPM Suite 6 also provides the Context and Dependency Injection (CDI) to build your custom applications.
@@ -4426,7 +4426,7 @@ The `jbpm-services-cdi` module provides CDI wrappers of <<_sect_kie_services>> t
 A workaround is needed on the Oracle WebLogic Server for CDI to work. For more information, see {URL_ORACLE_GUIDE}#appe_additional_notes[Additional Notes] in the _{ORACLE_GUIDE}_.
 ====
 
-[[_configuring_cdi_integration]]
+[id='_configuring_cdi_integration']
 === Configuring CDI Integration
 
 To use the KIE Services in your CDI container, you must provide several CDI beans for these services to satisfy their dependencies. For example:
@@ -4508,7 +4508,7 @@ Optionally, you can use several other producers provided to deliver components l
 
 CDI beans that implement the above-mentioned interfaces are collected at runtime and used when building a `KieSession` by the `RuntimeManager`.
 
-[[_sect_deployment_service_cdi]]
+[id='_sect_deployment_service_cdi']
 === Deployment Service as CDI Bean
 
 Deployment Service fires CDI events when deployment units are deployed or undeployed. This allows application components to react real time to the CDI events and store or remove deployment details from the memory. An event with the `@Deploy` qualifier is fired on deployment; an event with the `@Undeploy` qualifier is fired on undeployment. You can use CDI observer mechanism to get a notification on these events.
@@ -4541,7 +4541,7 @@ public void removeDeployment(@Observes @Undeploy DeploymentEvent event) {
 
 NOTE: The deployment service contains deployment synchronization mechanisms that enable you to persist deployed units into a database.
 
-[[_available_deployment_services]]
+[id='_available_deployment_services']
 ==== Available Deployment Services
 
 You can use qualifiers to instruct the CDI container which deployment service to use. {PRODUCT} contains the following Deployment Services:
@@ -4551,7 +4551,7 @@ You can use qualifiers to instruct the CDI container which deployment service to
 
 Note that every implementation of deployment service must have a dedicated implementation of deployment unit as the services mentioned above.
 
-[[_runtimemanager_as_cdi_bean]]
+[id='_runtimemanager_as_cdi_bean']
 === Runtime Manager as CDI Bean
 
 You can inject `RuntimeManager` as CDI bean into any other CDI bean within your application. `RuntimeManager` comes with the following predefined strategies and each of them have CDI qualifiers:

--- a/docs/product-development-guide/src/main/asciidoc/chap-maven-dependencies.adoc
+++ b/docs/product-development-guide/src/main/asciidoc/chap-maven-dependencies.adoc
@@ -1,4 +1,4 @@
-[[_chap_maven_dependencies]]
+[id='_chap_maven_dependencies']
 = Apache Maven
 
 http://maven.apache.org/[Apache Maven] is a distributed build automation tool used in Java application development to build and manage software projects. Apart from building, publishing, and deploying capabilities, using Maven for your Red Hat JBoss BRMS and Red Hat JBoss BPM suite projects ensures the following:
@@ -9,14 +9,14 @@ http://maven.apache.org/[Apache Maven] is a distributed build automation tool us
 * Dependencies and versions are well managed.
 * No need for additional build processing, as Maven builds output into a number of predefined types, such as JAR and WAR.
 
-[[_maven_repositories]]
+[id='_maven_repositories']
 == Maven Repositories
 
 Maven uses repositories to store Java libraries, plug-ins, and other build artifacts. These repositories can be local or remote. Red Hat JBoss BRMS and Red Hat JBoss BPM Suite products maintain local and remote maven repositories that you can add to your project for accessing the rules, processes, events, and other project dependencies. You must configure Maven to use these repositories and the Maven Central Repository to provide correct build functionality.
 
 When building projects and archetypes, Maven dynamically retrieves Java libraries and Maven plug-ins from local or remote repositories. Doing so promotes sharing and reuse of dependencies across projects.
 
-[[_using_maven_repository_in_your_project]]
+[id='_using_maven_repository_in_your_project']
 == Using the Maven Repository in Your Project
 
 You can direct Maven to use the Red Hat JBoss Enterprise Application Platform Maven repository in your project in one of the following ways:
@@ -28,7 +28,7 @@ The recommended approach is to direct Maven to use the Red Hat JBoss Enterprise 
 
 From version 6.1.0 onwards, Red Hat JBoss BPM Suite and Red Hat JBoss BRMS are designed to be used in combination with https://maven.repository.redhat.com/ga/[Red Hat JBoss Middleware Maven Repository] and Maven Central repository as dependency sources. Ensure that both repositories are available for project builds.
 
-[[_maven_configuration_file]]
+[id='_maven_configuration_file']
 == Maven Project Configuration File
 
 To use Maven for building and managing your Red Hat JBoss BRMS and Red Hat JBoss BPM Suite projects, you must configure your projects to be built with Maven. To do so, Maven provides the POM file (`pom.xml`) that holds configuration details for your project.
@@ -41,7 +41,7 @@ Find the schema for the `pom.xml` file at http://maven.apache.org/maven-v4_0_0.x
 
 For more information about POM files, see http://maven.apache.org/pom.html[Apache Maven Project POM Reference].
 
-[[_maven_settings_file]]
+[id='_maven_settings_file']
 == Maven Settings File
 
 The Maven settings file (`settings.xml`) is used to configure Maven execution. You can locate this file in the following locations:
@@ -82,7 +82,7 @@ The following is an example of a Maven `settings.xml` file. Note the `activeByDe
 ----
 
 
-[[_dependency_management]]
+[id='_dependency_management']
 == Dependency Management
 
 In order to use the correct Maven dependencies in your {PRODUCT} project, you must add relevant Bill Of Materials (BOM) files to the project's `pom.xml` file. Adding the BOM files ensures that the correct versions of transitive dependencies from the provided Maven repositories are included in the project.
@@ -118,7 +118,7 @@ Furthermore, declare dependencies needed for your project in the `dependencies` 
 
 * For a basic Red Hat JBoss BPM Suite project, declare the following dependencies:
 +
-[[_embedded_jbpm_engine_dependencies]]
+[id='_embedded_jbpm_engine_dependencies']
 .Embedded jBPM Engine Dependencies
 [source,xml]
 ----
@@ -148,7 +148,7 @@ Furthermore, declare dependencies needed for your project in the `dependencies` 
 
 * For a Red Hat JBoss BPM Suite project that uses CDI, declare the following dependencies:
 +
-[[_cdi_enabled_jbpm_engine_dependencies]]
+[id='_cdi_enabled_jbpm_engine_dependencies']
 .CDI-Enabled jBPM Engine dependencies 
 [source,xml]
 ----
@@ -170,7 +170,7 @@ Furthermore, declare dependencies needed for your project in the `dependencies` 
 
 * For a basic Red Hat JBoss BRMS project, declare the following dependencies:
 +
-[[_embedded_drools_engine_dependencies]]
+[id='_embedded_drools_engine_dependencies']
 .Embedded Drools Engine Dependencies
 [source,xml]
 ----
@@ -221,7 +221,7 @@ For other assets, declare org.drools:drools-workbench-models-* dependencies. -->
 Do not use both `kie-ci` and `kie-ci-osgi` in one `pom.xml` file.
 * To use the {KIE_SERVER}, declare the following dependencies:
 +
-[[_client_application_intelligent_process_server_dependencies]]
+[id='_client_application_intelligent_process_server_dependencies']
 .Client Application {KIE_SERVER} Dependencies
 [source,xml]
 ----
@@ -278,7 +278,7 @@ Do not use both `kie-ci` and `kie-ci-osgi` in one `pom.xml` file.
 ----
 * For testing purposes, declare the following dependencies:
 +
-[[_testing_dependencies]]
+[id='_testing_dependencies']
 .Testing Dependencies
 [source,xml]
 ----
@@ -359,7 +359,7 @@ For more information on BOM usage in Red Hat JBoss EAP 7, see the https://access
 ====
 
 
-[[_integrated_maven_dependencies]]
+[id='_integrated_maven_dependencies']
 == Integrated Maven Dependencies
 
 Throughout the Red Hat JBoss BRMS and BPM Suite documentation, various code samples are presented with KIE API for the 6.1._x_ releases. These code samples will require Maven dependencies in the various `pom.xml` file and should be included like the following example:
@@ -375,7 +375,7 @@ Throughout the Red Hat JBoss BRMS and BPM Suite documentation, various code samp
 
 All the Red Hat JBoss related product dependencies can be found at the following location: https://maven.repository.redhat.com/ga/[Red Hat Maven Repository].
 
-[[_uploading_artifacts_to_maven_repository]]
+[id='_uploading_artifacts_to_maven_repository']
 == Uploading Artifacts to Maven Repository
 
 There may be scenarios when your project may fail to fetch dependencies from a remote repository configured in its `pom.xml`. In such cases, you can programmatically upload dependencies to Red Hat JBoss BPM Suite by uploading artifacts to the embedded maven repository through Business Central. Red Hat JBoss BPM Suite uses a servlet for the maven repository interactions. This servlet processes a GET request to download an artifact and a POST request to upload one. You can leverage the servlet's POST request to upload an artifact to the repository using REST. To do this, implement the Http basic authentication and issue an HTTP POST request in the following format:
@@ -523,7 +523,7 @@ Once you specify the repository information in the `pom.xml`, add the correspond
 
 Now when you run the `mvn deploy` command, the JAR file gets uploaded.
 
-[[_deploying_red_hat_jboss_bpm_suite_artifacts_to_red_hat_jboss_fuse]]
+[id='_deploying_red_hat_jboss_bpm_suite_artifacts_to_red_hat_jboss_fuse']
 == Deploying Red Hat JBoss BPM Suite Artifacts to Red Hat JBoss Fuse
 
 Red Hat JBoss Fuse is an open source Enterprise Service Bus (ESB) with an elastic footprint and is based on Apache Karaf. The {PRODUCT_VERSION} version of {PRODUCT} supports deployment of runtime artifacts to Fuse.

--- a/docs/product-development-guide/src/main/asciidoc/chap-persistence-and-transactions.adoc
+++ b/docs/product-development-guide/src/main/asciidoc/chap-persistence-and-transactions.adoc
@@ -1,12 +1,12 @@
-[[_chap_persistence_and_transactions]]
+[id='_chap_persistence_and_transactions']
 = Persistence and Transactions
 
-[[_sect_process_instance_state]]
+[id='_sect_process_instance_state']
 == Process Instance State
 
 Red Hat JBoss BPM Suite allows persistent storage of information. For example, you can persistently store process runtime state to ensure that you will be able to resume your process instance in case of failure. While logs of current and previous process states are stored by default, you can store process definitions and logging information as well.
 
-[[_sect_runtime_state]]
+[id='_sect_runtime_state']
 === Runtime State
 
 
@@ -18,7 +18,7 @@ When you configure the Red Hat JBoss BPM Suite engine to use persistence, it aut
 
 Inexperienced users should not directly access and modify database tables containing runtime persistence data. Changes in the runtime state of process instances which are not done by the engine may have unexpected results. If you require information about the current execution state of a process instance, use the history log.
 
-[[_binary_persistence]]
+[id='_binary_persistence']
 === Binary Persistence
 
 Binary persistence, or marshaling, converts the state of the process instance into a binary dataset. Binary persistence is a mechanism used to store and retrieve information persistently. The same mechanism is also applied to the session state and work item states.
@@ -248,7 +248,7 @@ The `ContextMappingInfo` entity contains information about the contextual inform
 
 During the process engine execution, the state of a process instance is stored in safe points. When you execute a process instance, the engine continues the execution until there are no more actions to be performed. That is, the process instance has been completed, aborted, or is in the wait state in all of its paths. At that point, the engine has reached the next safe state, and the state of the process instance (and all other process instances that it affected) is stored persistently.
 
-[[_sect_audit_log]]
+[id='_sect_audit_log']
 == Audit Log
 
 Storing information about the execution of process instances can be useful when you need to, for example:
@@ -790,7 +790,7 @@ You can build indexers for both process and task variables. They are supported b
 
 The `ServiceLoader` service registers indexers. When you start indexing, all the registered indexers are examined. If no applicable indexer is found, the default indexer (`toString()` based) is used.
 
-[[_sect_transactions]]
+[id='_sect_transactions']
 == Transactions
 
 Red Hat JBoss BPM Suite engine supports Java Transaction API (JTA). The engine executes any method you invoke in a separate transaction unless you set transaction boundaries. Transaction boundaries allow you to combine multiple commands into one transaction.
@@ -909,7 +909,7 @@ NOTE: To ensure that the container is aware of process instance execution except
 .Using the CMT Dispose KieSession Command
 If you dispose of your `KieSession` directly when running in the CMT mode, you may generate exceptions, because Red Hat JBoss BPM Suite requires transaction synchronization. Use `org.jbpm.persistence.jta.ContainerManagedTransactionDisposeCommand` to dispose of your session.
 
-[[_sect_configuration]]
+[id='_sect_configuration']
 == Using Persistence
 
 Red Hat JBoss BPM Suite engine does not save runtime data persistently by default. To use persistence, you need to:
@@ -942,7 +942,7 @@ Following is a list of dependencies for the default combination with Hibernate a
 * `slf4j-jdk14` (`org.slf4j`)
 * `h2` (`com.h2database`)
 
-[[_manually_configuring_jboss_bpm_suite_engine_to_use_persistence]]
+[id='_manually_configuring_jboss_bpm_suite_engine_to_use_persistence']
 === Manually Configuring Red Hat JBoss BPM Suite Engine to Use Persistence
 
 Use `JPAKnowledgeService` to create a knowledge session based on a knowledge base, a knowledge session configuration (if necessary), and the environment. Ensure that the environment contains a reference to your Entity Manager Factory. For example:

--- a/docs/product-development-guide/src/main/asciidoc/chap-remote-api.adoc
+++ b/docs/product-development-guide/src/main/asciidoc/chap-remote-api.adoc
@@ -1,4 +1,4 @@
-[[_chap_remote_api]]
+[id='_chap_remote_api']
 = Remote API
 
 Red Hat JBoss BPM Suite provides various ways how to access the execution server in Business Central remotely including REST, JMS, SOAP, and EJB interfaces. Moreover, it provides remote Java API which allows developers to work with the `RuntimeEngine` interface while remote calls are executed in the background, using either REST or JMS.
@@ -8,7 +8,7 @@ Red Hat JBoss BPM Suite provides various ways how to access the execution server
 It is not recommended to use Business Central remote APIs to any further extent, with the exception of the Knowledge Store REST API. Instead, {KIE_SERVER} should be used. Both execution servers can be configured to use the same data source, thus processes and tasks started on one server are accessible from the other server. See section _Unified Execution Servers_ of _{ADMIN_GUIDE}_ for more details.
 ====
 
-[[_sect_rest_api]]
+[id='_sect_rest_api']
 == REST API
 
 Representational State Transfer (hereinafter referred to as REST) is a style of software architecture of distributed systems. It enables a highly abstract client-server communication: clients initiate requests to servers to a particular URL with parameters if needed and servers process the requests and return appropriate responses based on the requested URL. The requests and responses are built around the transfer of representations of resources. A resource can be any coherent and meaningful concept that may be addressed, such as a repository, a process, a rule, and so on.
@@ -32,7 +32,7 @@ All REST API calls use the following URL with the request body: `http://__SERVER
 It is not possible to issue REST API calls on project resources, such as rule files, work item definitions, process definition files, and so on. Operations on such files should be performed using Git and its REST API directly.
 ====
 
-[[sect_knowledge_store_rest_api]]
+[id='sect_knowledge_store_rest_api']
 === Knowledge Store REST API
 
 REST API calls to the Knowledge Store REST API allow you to manage the organization units, repositories, and projects.
@@ -112,7 +112,7 @@ Removes a job with the given `_JOB_ID_`. If the job is not being processed yet, 
 
 Both of these job calls return a `JobResult` instance.
 
-[[organizational_unit_calls]]
+[id='organizational_unit_calls']
 ==== Organizational Unit Calls
 
 Organizational unit calls are calls to the Knowledge Store that allow you to manage its organizational units which are useful to model departments and divisions. An organization unit can hold multiple repositories.
@@ -186,7 +186,7 @@ Adds a repository to an organizational unit.
 [DELETE] /organizationalunits/__ORGANIZATIONAL_UNIT_NAME__/repositories/_REPOSITORY_NAME_::
 Removes a repository from an organizational unit.
 
-[[repository_calls]]
+[id='repository_calls']
 ==== Repository Calls
 
 Repository calls are calls to the Knowledge Store that allow you to manage its Git repositories and their projects.
@@ -338,7 +338,7 @@ Creates a project in a repository.
 [DELETE] /repositories/_REPOSITORY_NAME_/projects/_PROJECT_NAME_::
 Removes a project in a repository.
 
-[[_maven_calls]]
+[id='_maven_calls']
 ==== Maven Calls
 
 Maven calls are calls to a project in the Knowledge Store that allow you to compile and deploy the project resources.
@@ -357,7 +357,7 @@ Compiles and runs the tests. Equivalent to `mvn test`. Returns a `TestProjectReq
 [POST] /repositories/_REPOSITORY_NAME_/projects/_PROJECT_NAME_/maven/deploy/::
 Deploys the project. Equivalent to `mvn deploy`. Returns a `DeployProjectRequest` instance.
 
-[[_sect_deployment_rest_api]]
+[id='_sect_deployment_rest_api']
 === Deployment REST API
 
 The KIE module JAR files can be deployed or undeployed using the Business Central UI or the REST API calls.
@@ -370,7 +370,7 @@ Deployment units are represented by a unique deployment ID consisting of the fol
 . KIE base ID (optional)
 . KIE session ID (optional)
 
-[[_deployment_calls]]
+[id='_deployment_calls']
 ==== Deployment Calls
 
 The following deployment calls are provided:
@@ -469,7 +469,7 @@ WARNING: In version 6.4 of the product, start timer events keep starting new pro
 [GET] /deployment/_DEPLOYMENT_ID_/processes::
 Lists all available process definitions in a given deployment unit. Returns an instance of `JaxbProcessDefinitionList`.
 
-[[_asynchronous_calls1]]
+[id='_asynchronous_calls1']
 ==== Asynchronous Calls
 
 The following deployment calls described in the previous section are asynchronous REST operations:
@@ -486,7 +486,7 @@ This means that:
 * The POST request has been successfully queued, but the result of the actual operation (deploying or undeploying the deployment unit) cannot be determined from this code. Interrogate the `JaxbDeploymentUnit` object returned by the GET `/deployment/_DEPLOYMENT_ID_` call to obtain that state.
 * The `JaxbDeploymentUnit` object returned using the GET request is only valid for the point in time which it was checked. Its status may change after the GET request has completed.
 
-[[_sect_process_image_rest_api]]
+[id='_sect_process_image_rest_api']
 === Process Image REST API
 
 Red Hat JBoss BPM Suite allows you to get a diagram of your process in Business Central through the remote REST API. To get the diagram, you need to generate the image based on the SVG source first, which is done automatically by the process designer when you save a process definition.
@@ -503,7 +503,7 @@ Returns an SVG image of the process definition diagram.
 [GET] /runtime/_DEPLOYMENT_ID_/process/_PROCESS_DEFINITION_ID_/image/_PROCESS_INSTANCE_ID_::
 Returns an SVG image of the process instance diagram, with highlighted currently active nodes.
 
-[[_sect_runtime_rest_api]]
+[id='_sect_runtime_rest_api']
 === Runtime REST API
 
 Runtime REST API provided by Business Central allows you to work with its underlying execution server, including process engine, task service, and business rule engine, and manipulate runtime data.
@@ -512,12 +512,12 @@ NOTE: It is recommended to use {KIE_SERVER} instead of Business Central for all 
 
 With the exception of `execute` operations (see <<_execute_calls>>), all the other REST calls can use JAXB or JSON. The calls are synchronous and return the requested data as JAXB objects by default. When using JSON, the JSON media type (`application/json`) should be added to the `ACCEPT` header of the REST call.
 
-[[_rest_api_query_parameters]]
+[id='_rest_api_query_parameters']
 ==== Query Parameters
 
 The Runtime REST API calls can have various query parameters. To add a parameter to a call, add the `?` symbol to the URL and a parameter name with its value. For example, `http://localhost:8080/business-central/rest/task/query?workItemId=393` returns a list of all tasks (`TaskSummary` instances) based on the work item with ID `393`. Note that parameters and their values are _case sensitive_.
 
-[[_rest_api_map_parameters]]
+[id='_rest_api_map_parameters']
 ===== Map Parameters
 
 Some runtime REST API calls can use the `Map` parameter. That means it is possible to submit key-value pairs to the operation using a query parameter prefixed with the `map_` keyword. For example,
@@ -546,7 +546,7 @@ To perform the runtime REST calls from your Java application, see <<_sect_remote
 
 While interacting with the Remote API, some classes are to be included in the deployment. This enables users to pass instances of their own classes as parameters to certain operations. The REST calls that start with `/task` often do not contain any information about the associated deployment. In this case, an extra query parameter `deploymentId` is added to the REST call allowing the server to find the appropriate deployment class and deserialize the information passed with the call.
 
-[[_pagination5]]
+[id='_pagination5']
 ===== Pagination
 
 The pagination parameters allow you to define pagination of REST call results. The following pagination parameters are available:
@@ -575,7 +575,7 @@ Pagination parameters can be applied to the following REST requests:
 ----
 ====
 
-[[_object_data_type_parameters]]
+[id='_object_data_type_parameters']
 ===== Object Data Type Parameters
 
 By default, any object parameters provided in a REST call are considered to be strings. If you need to explicitly define the data type of a parameter in a call, you can do so by adding one of the following values to the parameter:
@@ -593,7 +593,7 @@ By default, any object parameters provided in a REST call are considered to be s
 
 Note that the intended use of these object parameters is to define data types of send signal and process variable values. For example, consider the use in the `startProcess` command in the `execute` operation. See <<_execute_calls>>.
 
-[[_sect_runtime_calls]]
+[id='_sect_runtime_calls']
 ==== Runtime Calls
 
 Runtime REST calls allow you to work with runtime data such as process instances, signals, and work items.
@@ -629,7 +629,7 @@ Returns `JaxbProcessInstanceWithVariablesResponse` with details about the active
 [GET] /runtime/_DEPLOYMENT_ID_/process/instance/__PROCESS_INSTANCE_ID__/variable/_VARIABLE_NAME_::
 Returns the `_VARIABLE_NAME_` variable in the `__PROCESS_INSTANCE_ID__` process instance. If the variable is primitive, the variable value is returned.
 
-[[_signal_calls]]
+[id='_signal_calls']
 ===== Signal Calls
 
 Signal calls allow you to send a signal to a deployment or a particular process instance.
@@ -673,7 +673,7 @@ curl -v -u admin 'localhost:8080/business-central/rest/runtime/myDeployment/proc
 [POST] /runtime/_DEPLOYMENT_ID_/withvars/process/instance/__PROCESS_INSTANCE_ID__/signal::
 Sends a signal event to the given process instance and returns `JaxbProcessInstanceWithVariablesResponse`.
 
-[[_work_item_calls]]
+[id='_work_item_calls']
 ===== Work Item Calls
 
 Work item calls allow you to complete or abort a particular work item as well as get details about a work item instance.
@@ -714,7 +714,7 @@ curl -v -u admin 'localhost:8080/business-central/rest/runtime/myDeployment/work
 [POST] /runtime/_DEPLOYMENT_ID_/workitem/__WORK_ITEM_ID__/abort::
 Aborts the given work item.
 
-[[_history_calls]]
+[id='_history_calls']
 ===== History Calls
 
 The history calls allow you to access audit log information about process instances.
@@ -784,7 +784,7 @@ Returns process instance logs for the processes that contain the given process v
 [GET] /history/variable/_VARIABLE_ID_/value/_VALUE_/instances::
 Returns process instance logs for the processes that contain the given process variable with the specified value.
 
-[[_sect_task_calls]]
+[id='_sect_task_calls']
 ==== Task Calls
 
 The task calls allow you to execute task operations as well as query the tasks and get task details.
@@ -806,7 +806,7 @@ Returns `JaxbContent` with a task content. For more information, see <<_content_
 [GET] /task/query::
 Another entry point for the `/query/runtime/task` calls of the REST Query API. See <<_sect_the_rest_query_api>>.
 
-[[_task_operations]]
+[id='_task_operations']
 ===== Task Operations
 
 The following operations can be executed on a task:
@@ -865,7 +865,7 @@ This operation can be performed by any user or a group specified as the administ
 |Nominate either a user or a group, specified by the `user` or the `group` query parameter, for the task.
 |===
 
-[[_content_operations]]
+[id='_content_operations']
 ===== Content Operations
 
 Both task and content operations return the serialized content associated with the given task.
@@ -880,7 +880,7 @@ Due to restrictions of REST operations, only the objects for which the following
 * The objects are _not_ instances of a local class, an anonymous class, or arrays of a local or an anonymous class.
 * The object classes are present on the class path of the server application.
 
-[[_sect_the_rest_query_api]]
+[id='_sect_the_rest_query_api']
 === REST Query API
 
 The REST Query API allows developers to query tasks, process instances, and their variables. The operations results are grouped by the process instance they belong to.
@@ -898,7 +898,7 @@ Rich query for process instances and process variables.
 
 You can specify a number of different query parameters. For more information, see <<_sect_query_parameters>>.
 
-[[_sect_query_parameters]]
+[id='_sect_query_parameters']
 ==== Query Parameters
 
 In the text below, _query parameters_ are strings such as `processInstanceId`, `taskId`, or `tid`. These query parameters are not case sensitive, with the exception of those also specifying the name of a user-defined variable. _Parameters_ are the values passed with query parameters, for example `org.process.frombulator`, `29`, or `harry`.
@@ -924,12 +924,12 @@ This process instance query returns a result that contains information about pro
 
 WARNING: When running Business Central on WebSphere application server, the server ignores the parameters of REST Query API calls without a value (for example `http://localhost:9080/business-central/rest/query/runtime/process?vv=john&all`). However, the server accepts the call if you specify an empty value for these parameters. For example `http://localhost:9080/business-central/rest/query/runtime/process?vv=john&all=`.
 
-[[_range_and_regular_expression_parameters]]
+[id='_range_and_regular_expression_parameters']
 ===== Range and Regular Expression Parameters
 
 There are two ways to define a value of a query parameter: using ranges or a simple regular expression.
 
-[[_range_query_parameters]]
+[id='_range_query_parameters']
 ===== Range Query Parameters
 
 To define the start of a range, add `_min` to the parameter's name. To define the end of a range, add `_max` to the parameter's name. Range ends are inclusive.
@@ -955,7 +955,7 @@ processId=org.example.process&taskId_min=52
 This task query returns a result that contains only the information about tasks associated with the `org.example.process` process definition and the tasks that have an ID larger than or equal to `52`.
 ====
 
-[[_regular_expression_query_parameters]]
+[id='_regular_expression_query_parameters']
 ===== Regular Expression Query Parameters
 
 To use regular expressions in a query parameter, add `_re` to the parameter's name. The regular expression language contains two special characters:
@@ -981,7 +981,7 @@ This process instance query returns a result that fulfills the following:
 * Contains only the information about process instances that have process version `2.0`.
 ====
 
-[[_parameter_table]]
+[id='_parameter_table']
 ==== List of Query Parameters
 
 Query parameters that can be defined in ranges have an `X` in the `MIN/MAX` column. Query parameters that use regular expressions have an `X` in the `Regex` column. The last column describes whether a query parameter can be used in task queries, process instance queries, or both.
@@ -1398,7 +1398,7 @@ For example, the query parameter and parameter pair `var_myVar=foo3` queries for
 |`all`
 |===
 
-[[_query_output_format]]
+[id='_query_output_format']
 ==== Query Output Format
 
 The REST Query API calls return the following results:
@@ -1406,7 +1406,7 @@ The REST Query API calls return the following results:
 * `JaxbQueryProcessInstanceResult` for all process instance queries.
 * `JaxbQueryTaskResult` for all task queries.
 
-[[_execute_calls]]
+[id='_execute_calls']
 === Execute Operations
 
 For remote communication, it is recommended to use the Remote Java API. See <<_sect_remote_java_api>>.
@@ -2176,7 +2176,7 @@ Supported query parameters are `workItemId`, `taskId`, `businessAdministrator`, 
 NOTE: None of these REST endpoints has an equivalent Java client. Return values are examples of classes that can be used when you retrieve responses of calls made from your Java application. Each response is either in an XML or JSON format.
 endif::BPMS[]
 
-[[_control_api]]
+[id='_control_api']
 === Control of REST API
 
 {PRODUCT} provides a way to control access when using the REST API by introducing access-restricting user roles. This feature is enabled by default. You can disable it in `web.xml`.
@@ -2230,7 +2230,7 @@ endif::BPMS[]
 |===
 
 
-[[_sect_jms]]
+[id='_sect_jms']
 == JMS
 
 The Java Message Service (JMS) is an API that allows Java Enterprise components to communicate with each other asynchronously and reliably.
@@ -2260,7 +2260,7 @@ The term _command request message_ used above refers to a JMS byte message that 
 
 JMS queue `KIE.EXECUTOR` is used in the Job Executor component to speed up processing of asynchronous tasks and defined jobs. See <<_job_executor_for_asynchronous_execution>> for more information about Job Executor. Note that the executor can work without JMS. You can disable JMS, for example, when you deploy {PRODUCT} on container without full JMS support out of the box, such as Tomcat. To disable JMS, set the following property: `org.kie.executor.jms=false`.
 
-[[_example_jms_usage]]
+[id='_example_jms_usage']
 === Example JMS Usage
 
 The following example shows the usage of the JMS API. The numbers (callouts) in the example refer to notes below that explain particular parts of the example. It is provided for the advanced users that do not wish to use the Red Hat JBoss BPM Suite Remote Java API which otherwise incorporates the logic shown below.
@@ -2551,14 +2551,14 @@ org.kie.server.jms.session.tx=true  // If not set, defaults to `false`.
 org.kie.server.jms.session.ack=$INTEGER  // Integer value matching one of the javax.jms.Session constants that represent `ack` mode.
 ----
 
-[[_soap_api]]
+[id='_soap_api']
 == SOAP API
 
 Simple Object Access Protocol (SOAP) is a type of distribution architecture used for exchanging information. SOAP requires a minimal amount of overhead on the system and is used as a protocol for communication, while it is versatile enough to allow the use of different transport protocols.
 
 Like REST, SOAP allows client-server communication. Clients can initiate requests to servers using URLs with parameters. The servers then process the requests and return responses based on the particular URL.
 
-[[_client_side_java_webservice_client]]
+[id='_client_side_java_webservice_client']
 === CommandWebService
 
 Business Central in {PRODUCT} provides a SOAP interface in the form of `CommandWebService`. A Java client is provided as a generated `CommandWebService` class and can be used as follows.
@@ -2598,7 +2598,7 @@ public JaxbProcessInstanceResponse startProcessInstance(String user, String pass
 
 The SOAP interface of Business Central in {PRODUCT} is currently available for Red Hat JBoss EAP, IBM WebSphere, and Oracle WebLogic servers.
 
-[[_sect_ejb_interface]]
+[id='_sect_ejb_interface']
 == EJB Interface
 
 Starting with version 6.1, the Red Hat JBoss BPM Suite execution engine supports an EJB interface for accessing `KieSession` and `TaskService` remotely. This enables close transaction integration between the execution engine and remote customer applications.
@@ -2643,7 +2643,7 @@ A synchronization service that synchronizes the information between Business Cen
 When you deploy the jBPM services EJB API, the executor is registered during the deployment of a kJAR. Hence the JNDI name used is only visible for the module where the EJB is deployed. If you want to use the executor service from a different module, use the `org.jbpm.executor.service.ejb-jndi` system property that enables you to configure the executor service JNDI name. For more information, see the {URL_ADMIN_GUIDE}#list_of_system_properties[List of System Properties] section of the _{ADMIN_GUIDE}_.
 ====
 
-[[_generating_the_ejb_services_war]]
+[id='_generating_the_ejb_services_war']
 === Generating EJB Services WAR File
 
 Follow the procedure below to create an EJB Services WAR file using the EJB interface.
@@ -2700,7 +2700,7 @@ private RuntimeDataServiceEJBRemote runtimeDataService;
 
 For more information about invoking remote EJBs, see the https://access.redhat.com/documentation/en-US/JBoss_Enterprise_Application_Platform/6.4/html/Development_Guide/sect-Invoking_Session_Beans.html[Invoking Session Beans] chapter of the _Red Hat JBoss EAP Development Guide_.
 
-[[_sect_remote_java_api]]
+[id='_sect_remote_java_api']
 == Remote Java API
 
 The Remote Java API provides `KieSession`, `TaskService`, and `AuditService` interfaces to the JMS and REST APIs.
@@ -2770,7 +2770,7 @@ To start your own project, specify the {PRODUCT} BOM in the project's `pom.xml` 
 ----
 For the supported Maven BOM version, see {URL_INSTALLATION_GUIDE}#supported_comps[Supported Component Versions] of the _{INSTALLATION_GUIDE}_.
 
-[[_common_remoteruntimeenginebuilder_configuration]]
+[id='_common_remoteruntimeenginebuilder_configuration']
 === Common Configuration
 
 The following common methods can be called on both `RemoteRestRuntimeEngineBuilder` and `RemoteJmsRuntimeEngineBuilder` when creating a new instance of `RemoteRuntimeEngine`:
@@ -2805,7 +2805,7 @@ Adds the correlation key properties which are necessary when interacting with a 
 clearCorrelationProperties()::
 Clears all the correlation key properties added by the `addCorrelationProperties` method.
 
-[[_the_rest_remote_java_runtimeengine_factory]]
+[id='_the_rest_remote_java_runtimeengine_factory']
 === REST Client
 
 The `RemoteRuntimeEngineFactory` class is the starting point for building and configuring a new `RemoteRuntimeEngine` instance that can interact with the Remote API. This class creates an instance of a REST client builder using the `newRestBuilder()` method. This builder is then used to create a `RemoteRuntimeEngine` instance that acts as a client to the remote REST API.
@@ -2920,7 +2920,7 @@ In addition, actual owners and users created by them can be retrieved using the 
 
 For a list of Maven dependencies, see <<_embedded_jbpm_engine_dependencies>>.
 
-[[_calling_tasks_without_deployment_id]]
+[id='_calling_tasks_without_deployment_id']
 ==== Calling Tasks Without Deployment ID
 
 The `addDeploymentId()` method called on the instance of `RemoteRuntimeEngineBuilder` requires the calling application to pass the `deploymentId` parameter to connect to Business Central. The `deploymentId` is the ID of the deployment with which the `RuntimeEngine` interacts. However, there may be applications that require working with human tasks and dealing with processes across multiple deployments. In such cases, where providing `deploymentId` parameters for multiple deployments to connect to Business Central is not feasible, it is possible to skip the parameter when using the fluent API of `RemoteRestRuntimeEngineBuilder`.
@@ -2958,7 +2958,7 @@ RuntimeEngine engine = RemoteRuntimeEngineFactory
 
 For a list of Maven dependencies, see <<_embedded_jbpm_engine_dependencies>>.
 
-[[_custom_model_objects_and_remote_api]]
+[id='_custom_model_objects_and_remote_api']
 ==== Custom Model Objects and Remote API
 
 Working with custom model objects from a client application using the Remote API is supported in Red Hat JBoss BPM Suite. Custom model objects can be created using the Data Modeler in Business Central. Once built and deployed successfully into a project, these objects are part of the project in the local Maven repository.
@@ -3040,7 +3040,7 @@ public class Person implements java.io.Serializable {
 
 If you are creating a data object, make sure that the class has the `@org.kie.api.remote.Remotable` annotation. The `@org.kie.api.remote.Remotable` annotation makes the entity available for use with the Red Hat JBoss BPM Suite remote services such as REST, JMS, and WS.
 
-[[_the_jms_remote_java_runtimeengine_factory]]
+[id='_the_jms_remote_java_runtimeengine_factory']
 === JMS Client
 
 `RemoteRuntimeEngineFactory` works similarly as the REST variation: it is a starting point for building and configuring a new `RemoteRuntimeEngine` instance that can interact with the remote JMS API. The main use for this class is to create a builder instance of JMS using the `newJmsBuilder()` method. The builder is then used to create a `RemoteRuntimeEngine` instance that will act as a client to the remote JMS API.
@@ -3174,7 +3174,7 @@ private InitialContext getRemoteJbossInitialContext(URL url, String user, String
 
 You can work with JMS queues directly without using `RemoteRuntimeEngine`. For more information, see the https://access.redhat.com/articles/2182341[How to Use JMS Queues Without the RemoteRuntimeEngine in Red Hat JBoss BPMS] article. However, this approach is not a recommended way to use the provided JMS interface.
 
-[[_supported_methods]]
+[id='_supported_methods']
 === Supported Methods
 
 The Remote Java API provides client-like instances of the `RuntimeEngine`, `KieSession`, `TaskService`, and `AuditService` interfaces. This means that while many of the methods in those interfaces are available, some are not. The following tables list the available methods. Methods not listed in the tables below throw `UnsupportedOperationException` explaining that the called method is not available.
@@ -3370,7 +3370,7 @@ Return value: `void`.
 
 == Troubleshooting
 
-[[_serialization_issues]]
+[id='_serialization_issues']
 === Serialization Issues
 
 Sometimes, users may wish to pass instances of their own classes as parameters to commands sent in a REST request or JMS message. In order to do this, there are a number of requirements.

--- a/docs/product-development-guide/src/main/asciidoc/chap-rule-algorithms.adoc
+++ b/docs/product-development-guide/src/main/asciidoc/chap-rule-algorithms.adoc
@@ -1,21 +1,21 @@
-[[_chap_rule_algorithms]]
+[id='_chap_rule_algorithms']
 = Rule Algorithms
 
 
-[[_sect_rete_algorithm]]
+[id='_sect_rete_algorithm']
 == Rete Algorithm
 
 The Rete algorithm, invented by Dr. Charles Forgy, describes how to process rules in the production memory to generate an efficient discrimination network. A discrimination network is used to filter data as it propagates through the network. The nodes at the top of the network would have many matches at the beginning and fewer matches at the end. At the bottom of the network are the terminal nodes.
 
 The Rete algorithm defines four basic nodes; _root_ node, _1-input_ node, _2-input_ node, and a _terminal_ node. 
 
-[[_the_rete_root_node]]
+[id='_the_rete_root_node']
 [float]
 === Rete Root Node
 
 The root node is where all objects enter the network. From there, the flow continues to the `ObjectTypeNode` node. For example, consider two objects: `Account` and `Order`. Matching every single node against every single object would be inefficient. Thus, the rule engine passes the object only to the nodes that match the object type. The easiest way to do this is to create an `ObjectTypeNode` and have all 1-input and 2-input nodes descend from it.
 
-[[_the_objecttypenode]]
+[id='_the_objecttypenode']
 [float]
 === ObjectTypeNode
 When an object is asserted, the rule engine retrieves a list of valid `ObjectTypesNodes` using a lookup in a HashMap from the object’s Class; if this list doesn’t exist, the rule engine scans all the `ObjectTypeNodes`, finding valid matches which it caches in the list. This enables the rule engine to match against any class type that matches with an `instanceof()` check.
@@ -28,7 +28,7 @@ image:Object_Type_Nodes.png[]
 * `LeftInputAdapterNodes`
 *  `BetaNodes`
 
-[[_alphanodes]]
+[id='_alphanodes']
 [float]
 === AlphaNodes
 
@@ -36,13 +36,13 @@ image:Object_Type_Nodes.png[]
 
 image:Alpha_Nodes.png[]
 
-[[_hashing]]
+[id='_hashing']
 [float]
 === Hashing
 
 The rule engine extends Rete by optimizing the propagation from `ObjectTypeNode` to `AlphaNode` using _hashing_. Each time an `AlphaNode` is added to an `ObjectTypeNode`, it adds the literal value as a key to the HashMap with the `AlphaNode` as the value. When a new instance enters the `ObjectType` node, rather than propagating to each `AlphaNode`, it can instead retrieve the correct `AlphaNode` from the HashMap, which avoids unnecessary literal checks.
 
-[[_betanodes]]
+[id='_betanodes']
 [float]
 === BetaNodes
 
@@ -63,7 +63,7 @@ To enable the first Object, `Cheese` object in the image above, to enter the net
 
 Terminal nodes are used to indicate a single rule having matched all its conditions; at this point, the rule has a full match. A rule with an _or_ conditional disjunctive connective results in subrule generation for each possible logical branch; thus one rule can have multiple terminal nodes.
 
-[[_node_sharing]]
+[id='_node_sharing']
 [float]
 === Node Sharing
 The rule engine also performs node sharing. Many rules repeat the same patterns, and node sharing enables the rule engine to collapse those patterns so that the rule patterns does not re-evaluate the pattern for every single instance. The following two rules share the first pattern, but not the last:
@@ -94,7 +94,7 @@ The compiled Rete network shows that the alpha node is shared, but the beta node
 .Node Sharing
 image::5954.png[]
 
-[[_reteoo]]
+[id='_reteoo']
 [float]
 === ReteOO
 
@@ -105,7 +105,7 @@ The ReteOO algorithm has been discontinued and is not supported since {PRODUCT} 
 
 ReteOO is an implementation of the Rete algorithm. Because it is an unsupported algorithm in {PRODUCT} 7.0, use the PHREAK algorithm, which iterates on ReteOO and addresses core issues of Rete.
 
-[[_phreak_algorithm]]
+[id='_phreak_algorithm']
 == PHREAK Algorithm
 
 The new PHREAK algorithm is evolved from the RETE algorithm. While RETE is considered eager and data oriented, PHREAK on the other hand follows lazy and goal oriented approach. The RETE algorithm does a lot of work during the insert, update and delete actions in order to find partial matches for all rules. In case of PHREAK, this partial matching of rule is delayed deliberately.
@@ -123,7 +123,7 @@ In addition to the enhancements listed in the Rete00 algorithm, PHREAK algorithm
 * Isolated rule evaluation.
 * Set-oriented propagations.
 
-[[_rule_evaluation_with_phreak_algorithm]]
+[id='_rule_evaluation_with_phreak_algorithm']
 == Rule Evaluation With PHREAK Algorithm
 
 When the rule engine starts, all the rules are unlinked. At this stage, there is no rule evaluation. The insert, update, and delete actions are queued before entering the beta network. The rule engine uses a simple heuristic--based on the rule most likely to result in firings--to calculate and select the next rule for evaluation. This delays the evaluation and firing of the other rules. When a rule has all the right input values populated, it gets linked in; a goal representing this rule is created and placed into a priority queue, which is ordered by salience. Each queue is associated with an `AgendaGroup`. The engine only evaluates rules for the active `AgendaGroup` by inspecting the queue and popping the goal for the rule with the highest salience. This means the work done shifts from the insert, update, delete phase to the `fireAllRules` phase. Only the rule for which the goal was created is evaluated, and other potential rule evaluations are delayed. While individual rules are evaluated, node sharing is still achieved through the process of segmentation.
@@ -144,7 +144,7 @@ The same bit-mask technique is used to also track dirty nodes, segments, and rul
 As opposed to a single unit of memory in RETE, PHREAK has three levels of memory. This allows for much more contextual understanding during the evaluation of a rule.
 
 [float]
-[[_phreak_and_sequential_mode]]
+[id='_phreak_and_sequential_mode']
 === PHREAK and Sequential Mode
 
 The sequential mode is supported for the PHREAK algorithm: the `modify` and `update` rule statements are now allowed. Any rule that has not yet been evaluated will have access to data modified by the previous rules that used `modify` or `update`. This results in a more intuitive behavior of the sequential mode.

--- a/docs/product-development-guide/src/main/asciidoc/chap-using-jboss-developer-studio-to-create-and-test-processes.adoc
+++ b/docs/product-development-guide/src/main/asciidoc/chap-using-jboss-developer-studio-to-create-and-test-processes.adoc
@@ -1,4 +1,4 @@
-[[_chap_using_jboss_developer_studio_to_create_and_test_processes]]
+[id='_chap_using_jboss_developer_studio_to_create_and_test_processes']
 = Using Red Hat JBoss Developer Studio to Create and Test Processes
 
 The Red Hat JBoss BPM Suite plug-in provides an environment for editing and testing processes, and enables integration with your application. The following features are provided:
@@ -6,15 +6,15 @@ The Red Hat JBoss BPM Suite plug-in provides an environment for editing and test
 * Wizards for creating Red Hat JBoss BPM Suite projects and BPMN2 processes.
 * A Red Hat JBoss BPM Suite perspective showing the most commonly used views in a predefined layout.
 
-[[_sect_jboss_bpm_suite_runtime]]
+[id='_sect_jboss_bpm_suite_runtime']
 == Red Hat JBoss BPM Suite Runtime
 
-[[_jboss_bpm_suite_runtime]]
+[id='_jboss_bpm_suite_runtime']
 === Red Hat JBoss BPM Suite Runtime
 
 A Red Hat JBoss BPM Suite runtime is a collection of JAR files that represent one specific release of the Red Hat JBoss BPM Suite project. Follow the steps described in the next section to create and configure a runtime. It is required to specify a default runtime for your Red Hat JBoss Developer Studio workspace, however, each project can override the default setting and therefore can have a specific runtime.
 
-[[_setting_the_jbpm_runtime1]]
+[id='_setting_the_jbpm_runtime1']
 === Setting the Red Hat JBoss BPM Suite Runtime
 
 To use the Red Hat JBoss BPM Suite plug-in with Red Hat JBoss Developer Studio, it is necessary to set up the runtime.
@@ -32,7 +32,7 @@ NOTE: Make sure you have the *JBoss Business Process and Rule Development* featu
 +
 Red Hat JBoss Developer Studio prompts you to update the runtime if you have any existing projects.
 
-[[_configuring_the_jboss_bpm_suite_server]]
+[id='_configuring_the_jboss_bpm_suite_server']
 === Configuring Red Hat JBoss BPM Suite Server
 
 Red Hat JBoss Developer Studio can be configured to run the Red Hat JBoss BPM Suite server.
@@ -55,7 +55,7 @@ image::dev_studio2_6.4.png[]
 image::dev_studio3_6.4.png[]
 . Click *Finish*.
 
-[[_connecting_jboss_developer_studio_to_the_asset_repository1]]
+[id='_connecting_jboss_developer_studio_to_the_asset_repository1']
 == Importing And Cloning Projects from Git Repository into Red Hat JBoss Developer Studio
 
 Red Hat JBoss Developer Studio can be configured to connect to a central Git repository, which stores rules, models, functions, and processes.
@@ -78,7 +78,7 @@ You can either clone a remote Git repository or import a local Git repository.
 . In the *Select a wizard to use for importing projects* step, select *Import as general project* and click *Next*.
 . Name the project and click *Finish*.
 
-[[_exploring_a_jboss_bpm_suite_application]]
+[id='_exploring_a_jboss_bpm_suite_application']
 == Components of Red Hat JBoss BPM Suite Application
 
 A Red Hat JBoss BPM Suite application consists of the following components:
@@ -94,7 +94,7 @@ When you create a BPM Suite project in Red Hat JBoss Developer Studio, the follo
 * `src/main/java`: stores class files (facts).
 * `src/main/resources`: stores `.drl` files (rules) and `.bpmn2` files (processes).
 
-[[_creating_a_jbpm_project]]
+[id='_creating_a_jbpm_project']
 == Creating Red Hat JBoss BPM Suite Project
 
 To create a Red Hat JBoss BPM Suite project in Red Hat JBoss Developer Studio:
@@ -124,7 +124,7 @@ The project contains the `kmodule.xml` configuration file under the `src/main/re
 
 If you selected Maven as a building option, the project contains the `pom.xml` file. By default, two dependencies are specified: `kie-api` and `jbpm-test`. Add more dependencies as required by your project.
 
-[[_converting_an_existing_java_project_to_a_bpm_suite_project]]
+[id='_converting_an_existing_java_project_to_a_bpm_suite_project']
 == Converting Existing Java Project to Red Hat JBoss BPM Suite Project
 
 To convert an existing Java project to a BPM Suite project:
@@ -134,7 +134,7 @@ To convert an existing Java project to a BPM Suite project:
 
 This converts your Java project to BPM Suite project and adds the jBPM Library to your project's classpath.
 
-[[_creating_processes_in_red_hat_jboss_developer_studio]]
+[id='_creating_processes_in_red_hat_jboss_developer_studio']
 == Creating Processes in Red Hat JBoss Developer Studio
 
 To create a new process:
@@ -145,7 +145,7 @@ To create a new process:
 +
 Process Editor with the newly created process opens and a start node appears on the canvas. Add more nodes and connections to further model the process.
 
-[[_modeling_processes_in_red_hat_jboss_developer_studio]]
+[id='_modeling_processes_in_red_hat_jboss_developer_studio']
 == Modeling and Validating Processes in Red Hat JBoss Developer Studio
 
 To model a process:
@@ -163,7 +163,7 @@ To validate a process, right-click the process `.bpmn2` file and select *Validat
 
 If the validation completes successfully, a dialogue window that states _The validation completed with no errors or warnings_ opens. If the validation is unsuccessful, the found errors display in the *Problems* tab. Fix the errors and rerun the validation.
 
-[[_the_audit_view]]
+[id='_the_audit_view']
 == Audit View
 
 The audit view in Red Hat JBoss Developer Studio shows the audit log, which is a log of all events that were logged from a session. To open the audit view, click *Window* -> *Show View* -> *Other* and select *Drools* -> *Audit*.
@@ -174,7 +174,7 @@ image::1215.png[]
 
 For more information about log files, see the following <<_file_logger>>.
 
-[[_file_logger]]
+[id='_file_logger']
 === File Logger
 
 A file logger logs events from a session into a file. To create a logger, use `KnowledgeRuntimeLoggerFactory` and add it to a session.
@@ -196,7 +196,7 @@ logger.close();
 ----
 ====
 
-[[_sect_synchronizing_jboss_developer_studio_workspace_with_business_central_repositories]]
+[id='_sect_synchronizing_jboss_developer_studio_workspace_with_business_central_repositories']
 == Synchronizing Red Hat JBoss Developer Studio Workspace with Business Central Repositories
 
 Red Hat JBoss BPM Suite allows you to synchronize your local workspace with one or more repositories that are managed inside Business Central with the help of Eclipse tooling for Git. Git is a popular distributed source code version control system. You can use any Git tool of your choice.
@@ -228,7 +228,7 @@ You can change the port used by the server to provide SSH access to the Git repo
 . Select *Import as general project* and click *Next*.
 . Provide a name for the repository and click *Finish*.
 
-[[_committing_changes_to_business_central]]
+[id='_committing_changes_to_business_central']
 === Committing Changes to Business Central
 
 To commit and push your local changes back to the Business Central repositories:
@@ -242,7 +242,7 @@ A new dialog box open showing all the changes you have on your local file system
 You can double-click each file to get an overview of the changes you did for that file.
 . Right-click your project again, and select *Team* -> *Push to Upstream*.
 
-[[_retrieving_the_changes_from_the_business_central_repository]]
+[id='_retrieving_the_changes_from_the_business_central_repository']
 === Retrieving Changes from Business Central Repository
 
 To retrieve the latest changes from the Business Central repository:
@@ -261,7 +261,7 @@ This merges all the changes from the original repository in Business Central.
 
 NOTE: It is possible that you have committed and/or conflicting changes in your local version, you might have to resolve these conflicts and commit the merge results before you will be able to complete the merge successfully. It is recommended to update regularly, before you start updating a file locally, to avoid merge conflicts being detected when trying to commit changes.
 
-[[_importing_individual_projects_from_repository]]
+[id='_importing_individual_projects_from_repository']
 === Importing Individual Projects from Repository
 
 When you import a repository, all the projects inside that repository are downloaded. It is however useful to mount one specific project as a separate Java project. Red Hat JBoss Developer Studio is then able to:
@@ -278,7 +278,7 @@ To import a project as a separate Java project:
 The *Import Maven Projects* dialog window opens with the project's `pom.xml` file displayed.
 . Click *Finish*.
 
-[[_adding_jboss_bpm_suite_libraries_to_your_project_classpath]]
+[id='_adding_jboss_bpm_suite_libraries_to_your_project_classpath']
 === Adding {PRODUCT} Libraries to Project Class Path
 
 To ensure your project compiles and executes correctly, add the {PRODUCT} libraries to the project's class path. To do so, right-click the project and select *Configure* -> *Convert to jBPM Project*.

--- a/docs/product-development-guide/src/main/asciidoc/chap-using-jboss-developer-studio-to-create-and-test-rules.adoc
+++ b/docs/product-development-guide/src/main/asciidoc/chap-using-jboss-developer-studio-to-create-and-test-rules.adoc
@@ -1,4 +1,4 @@
-[[_chap_using_jboss_developer_studio_to_create_and_test_rules]]
+[id='_chap_using_jboss_developer_studio_to_create_and_test_rules']
 = Using Red Hat JBoss Developer Studio to Create and Test Rules
 
 There are many ways to author rules in BRMS, however as a developer you would prefer an Integrated Development Environment (IDE) such as Red Hat JBoss Developer Studio that offers you advanced tooling and content assistance. Red Hat JBoss BRMS and Red Hat JBoss BPM Suite tooling are compatible with Red Hat JBoss Developer Studio version 7 and above. The Red Hat JBoss Developer Studio with Red Hat JBoss BPM Suite/BRMS plug-ins simplify your development tasks. These plug-ins provide the following features:
@@ -14,7 +14,7 @@ There are many ways to author rules in BRMS, however as a developer you would pr
 * Editor for modifying business process diagram.
 * Support for unit testing using JUnit and TestNG.
 
-[[_jboss_developer_studio_drools_perspective]]
+[id='_jboss_developer_studio_drools_perspective']
 == Red Hat JBoss Developer Studio Drools Perspective
 
 Red Hat JBoss Developer Studio comes with all the BRMS and BPM Suite plug-in requirements pre-packaged with it. It offers the following perspectives:
@@ -24,7 +24,7 @@ Red Hat JBoss Developer Studio comes with all the BRMS and BPM Suite plug-in req
 * _jBPM_: allows you to work with Red Hat JBoss BPM Suite resources.
 
 
-[[_sect_jboss_brms_runtimes]]
+[id='_sect_jboss_brms_runtimes']
 == Red Hat JBoss BRMS Runtimes
 
 A Drools runtime is a collection of JAR files on your file system that represent one specific release of the Drools project JARs. While creating a new runtime, you must either point to the release of your choice or create a new runtime on your file system from the jars included in the Drools plug-in. For creating a new runtime, you need to specify a default Drools runtime for your Eclipse workspace, but each individual project can override the default and select the appropriate runtime for that project specifically. You can add as many Drools runtimes as you need. In order to use the Red Hat JBoss BRMS plug-in with Red Hat JBoss Developer Studio, it is necessary to set up the runtime.
@@ -40,7 +40,7 @@ A Drools runtime is a collection of JAR files on your file system that represent
 . Click *OK*. If you already have projects in Red Hat JBoss Developer Studio, a dialog box will indicate that you have to restart Red Hat JBoss Developer Studio to update the runtime.
 
 
-[[_selecting_a_runtime_for_your_jboss_brms_project]]
+[id='_selecting_a_runtime_for_your_jboss_brms_project']
 === Selecting a Runtime for Your Red Hat JBoss BRMS Project
 
 Whenever you create a Drools project either by using the *New Drools Project*  wizard or by converting an existing Java project to a Drools project, the Drools plug-in automatically adds all the required JAR files to the classpath of your project.
@@ -51,7 +51,7 @@ To define a project-specific runtime, create a new Drools project and choose the
 
 
 
-[[_changing_the_runtime_of_your_jboss_brms_project]]
+[id='_changing_the_runtime_of_your_jboss_brms_project']
 === Changing the Runtime of Your Red Hat JBoss BRMS Project
 
 To change the runtime of a Drools project:
@@ -65,7 +65,7 @@ The project properties dialog opens.
 If you click the *Configure workspace settings...* link, the workspace preferences showing the currently installed Drools runtimes opens. You can add new runtimes there if required. If you uncheck the *Enable project specific settings* checkbox, it uses the default runtime as defined in your global preferences.
 . Click *OK*.
 
-[[_configuring_the_jboss_brms_server]]
+[id='_configuring_the_jboss_brms_server']
 === Configuring the Red Hat JBoss BRMS Server
 
 Red Hat JBoss Developer Studio can be configured to run the Red Hat JBoss BRMS\BPM Suite Server.
@@ -79,7 +79,7 @@ Red Hat JBoss Developer Studio can be configured to run the Red Hat JBoss BRMS\B
 . Set the home directory by clicking *Browse*. Navigate to and select the installation directory for Red Hat JBoss EAP 6.4 that has {PRODUCT} installed.
 . Provide a name for the server in the *Name* field, make sure that the configuration file is set, and click *Finish*.
 
-[[_exploring_a_jboss_brms_application]]
+[id='_exploring_a_jboss_brms_application']
 == Exploring Red Hat JBoss BRMS Application
 
 A BRMS project typically comprises the following:
@@ -94,7 +94,7 @@ Red Hat JBoss Developer Studio helps you generate the getter and setter methods 
 * `src/main/resources/rules` that stores the `.drl` files (rules).
 * `src/main/resources/process` that stores the `.bpmn` files (processes).
 
-[[_creating_a_jboss_brms_project]]
+[id='_creating_a_jboss_brms_project']
 == Creating a Red Hat JBoss BRMS Project
 
 To create a new Red Hat JBoss BRMS project in the Drools perspective, do the following:
@@ -123,7 +123,7 @@ If you checked the default artifacts checkboxes in the Drools Project wizard, yo
 * An example `DecisionTableTest.java` Java class in the `src/main/java` directory to execute the rules in the Drools engine in the `com.sample` package.
 
 
-[[_using_textual_rule_editor]]
+[id='_using_textual_rule_editor']
 == Using Textual Rule Editor
 
 In the *Package Explorer*, you can double-click your existing rule file to open it on a textual rule editor or choose *File* -> *New* -> *Rule Resource* to create a new rule on the textual editor. The textual rule editor has a pattern of a normal text editor and this is where you modify and manage your rules.
@@ -136,7 +136,7 @@ Textual editor provides features like:
 * _Code folding_: Code Folding allows you to hide and show sections of a file use the icons with minus and plus on the left vertical line of the editor.
 * _Sysnchronization with outline view_: The text editor is in sync with the structure of the rules in the outline view as soon as you save your rules. The outline view provides a quick way of navigating around rules by name, or even in a file containing hundreds of rules. The items are sorted alphabetically by default.
 
-[[_jboss_rules_views]]
+[id='_jboss_rules_views']
 == Red Hat JBoss BRMS Views
 
 You can alternate between these views when modifying rules:
@@ -161,7 +161,7 @@ NOTE: The Rete view works only in projects where the rule builder is set in the 
 Kie Navigator View::
 Shows you the contents of your {PRODUCT} projects on your container. See chapter https://access.redhat.com/documentation/en-us/red_hat_jboss_bpm_suite/6.4/html-single/getting_started_guide/#kie_navigator[Kie Navigator] of the _{PRODUCT} Getting Started Guide_ for more information.
 
-[[_sect_debugging_rules]]
+[id='_sect_debugging_rules']
 == Debugging Rules
 
 Drools breakpoints are only enabled if you debug your application as a Drools Application. To do this you should perform one of two actions:
@@ -176,7 +176,7 @@ NOTE: Remember to change the name of your debug configuration to something meani
 . Click the *Debug* button on the bottom to start debugging your application.
 . After enabling the debugging, the application starts executing and will halt if any breakpoint is encountered. This can be a Drools rule breakpoint, or any other standard Java breakpoint. Whenever a Drools rule breakpoint is encountered, the corresponding `.drl` file is opened and the active line is highlighted. The *Variables view* also contains all rule parameters and their value. You can then use the default Java debug actions to decide what to do next (resume, terminate, step over, and others). The debug views can also be used to determine the contents of the working memory and agenda at that time as well (the current executing working memory is automatically shown).
 
-[[_creating_breakpoints2]]
+[id='_creating_breakpoints2']
 === Creating Breakpoints
 
 Create breakpoints to help monitor rules that have been executed. Instead of waiting for the result to appear at the end of the process, you can inspect the details of the execution at each breakpoint you set. This is useful for debugging and ensuring rules are executed as expected.

--- a/docs/product-development-guide/src/main/asciidoc/chap-working-with-processes.adoc
+++ b/docs/product-development-guide/src/main/asciidoc/chap-working-with-processes.adoc
@@ -1,10 +1,10 @@
-[[_chap_working_with_processes]]
+[id='_chap_working_with_processes']
 = Working with Processes
 
-[[_sect_bpmn_2.0_notation]]
+[id='_sect_bpmn_2.0_notation']
 == BPMN 2.0 Notation
 
-[[_business_process_model_and_notation_bpmn_2.0_specification]]
+[id='_business_process_model_and_notation_bpmn_2.0_specification']
 === Business Process Model and Notation (BPMN) 2.0 Specification
 
 The Business Process Model and Notation (BPMN) 2.0 specification defines a standard for graphically representing a business process; it includes execution semantics for the defined elements and an XML format to store and share process definitions.
@@ -1014,7 +1014,7 @@ waypoint::
 |
 |===
 
-[[_bpmn_2.0_process_example]]
+[id='_bpmn_2.0_process_example']
 === BPMN 2.0 Process Example
 
 Here is a BPMN 2.0 process that prints out a "_Hello World_" statement when the process is started:
@@ -1076,7 +1076,7 @@ Here is a BPMN 2.0 process that prints out a "_Hello World_" statement when the 
 </definitions>
 ----
 
-[[_supported_elements_and_attributes_in_bpmn_2.0_specification]]
+[id='_supported_elements_and_attributes_in_bpmn_2.0_specification']
 === Supported Elements and Attributes in BPMN 2.0 Specification
 
 Red Hat JBoss BPM Suite 6 does not implement all elements and attributes as defined in the BPMN 2.0 specification. However, we do support significant node types that you can use inside executable processes. This includes almost all elements and attributes as defined in the Common Executable subclass of the BPMN 2.0 specification, extended with some additional elements and attributes we believe are valuable in that context as well. The full set of elements and attributes that are supported can be found below, but it includes elements like:
@@ -1133,7 +1133,7 @@ Red Hat JBoss BPM Suite 6 does not implement all elements and attributes as defi
 
 * Sequence flow
 
-[[_loading_and_executing_a_bpmn2_process_into_repository]]
+[id='_loading_and_executing_a_bpmn2_process_into_repository']
 === Loading and Executing a BPMN2 Process Into Repository
 
 
@@ -1165,7 +1165,7 @@ KieBase kBase = kContainer.getKieBase();
 For a list of Maven dependencies, see example <<_embedded_jbpm_engine_dependencies>>.
 
 
-[[_sect_what_comprises_a_business_process]]
+[id='_sect_what_comprises_a_business_process']
 == What Comprises a Business Process
 
 A business process is a graph that describes the order in which a series of steps need to be executed using a flow chart. A process consists of a collection of nodes that are linked to each other using connections. Each of the nodes represents one step in the overall process, while the connections specify how to transition from one node to the other. A large selection of predefined node types have been defined.
@@ -1187,7 +1187,7 @@ Processes can be created with the following methods:
 
 NOTE: The Red Hat JBoss Developer Studio Process editor has been deprecated in favor of BPMN2 Modeler for process modeling as it is not being developed any more. However, you can still use it for limited number of supported elements.
 
-[[_process_nodes]]
+[id='_process_nodes']
 === Process Nodes
 
 Executable processes consist of different types of nodes which are connected to each other. The BPMN 2.0 specification defines three main types of nodes:
@@ -1201,7 +1201,7 @@ Activities represent relatively atomic pieces of work that need to be performed 
 Gateways::
 Gateways represent forking or merging of workflows during process execution.
 
-[[_process_properties]]
+[id='_process_properties']
 === Process Properties
 
 Every process has the following properties:
@@ -1213,7 +1213,7 @@ Every process has the following properties:
 * _Variables_ (optional): Variables to store data during the execution of your process.
 * _Swimlanes_: Swimlanes used in the process for assigning human tasks.
 
-[[_defining_processes_using_xml]]
+[id='_defining_processes_using_xml']
 === Defining Processes Using XML
 
 You can create processes directly in XML format using the BPMN 2.0 specifications. The syntax of these XML processes is defined using the BPMN 2.0 XML Schema Definition.
@@ -1295,7 +1295,7 @@ The following XML fragment shows a simple process that contains a sequence of a 
 </definitions>
 ----
 
-[[_sect_activities]]
+[id='_sect_activities']
 == Activities
 
 An activity is an action performed inside a business process. Activities are classified based on the type of tasks they do:
@@ -1377,7 +1377,7 @@ A task is an action that is executed inside a business process. Tasks can be of 
 |A `None` task type is an abstract undefined task type.
 |===
 
-[[_subprocesses]]
+[id='_subprocesses']
 === Subprocesses
 
 A subprocess is a process within another process. When a parent process calls a child process (subprocess), the child process executes in a sequential manner and once complete, the execution control then transfers to the main parent process. Subprocess can be of the following types:
@@ -1496,7 +1496,7 @@ Globals can also be set from inside process scripts using:
 kcontext.getKieRuntime().setGlobal(name,value);.
 ----
 
-[[_sect_events]]
+[id='_sect_events']
 == Events
 
 Events are triggers, which when occur, impact a business process. Events are classified as start events, end events, and intermediate events. A start event indicates the beginning of a business process. An end event indicates the completion of a business process. And intermediate events drive the flow of a business process. Every event has an event ID and a name. You can implement triggers for each of these event types to identify the conditions under which an event is triggered. If the conditions of the triggers are not met, the events are not initialized, and hence the process flow does not complete.
@@ -1568,7 +1568,7 @@ A start event is a flow element in a business process that indicates the beginni
 * A signal object is inserted in a process by a throw signal intermediate event as an action of an activity.
 |===
 
-[[_end_events]]
+[id='_end_events']
 === End Events
 
 An end event marks the end of a business process. Your business process may have more than one end event. An end event has one incoming connection and no outgoing connections. End events are of the following types:
@@ -1613,7 +1613,7 @@ An end event marks the end of a business process. Your business process may have
 |Use the `Terminate` end event to terminate the entire process instance immediately. Note that this terminates all the other parallel execution flows and cancels any running activities.
 |===
 
-[[_sect_intermediate_events]]
+[id='_sect_intermediate_events']
 === Intermediate Events
 
 Intermediate events occur during the execution of a process flow, and they drive the flow of the process. Some specific situations in a process may trigger these intermediate events. Intermediate events can occur in a process with one or no incoming flow and an outgoing flow. Intermediate events can further be classified as:
@@ -1621,7 +1621,7 @@ Intermediate events occur during the execution of a process flow, and they drive
 * _Catching Intermediate Events_;
 * _Throwing Intermediate Events_.
 
-[[_catching_intermediate_events]]
+[id='_catching_intermediate_events']
 ==== Catching Intermediate Events
 
 Catching intermediate events comprises intermediate events which implement a response to specific indication of a situation from the main process workflow. Catching intermediate events are of the following types:
@@ -1634,7 +1634,7 @@ Catching intermediate events comprises intermediate events which implement a res
 * `Compensation`: Use the `Compensation` intermediate event to handle compensation in case of partially failed operations. A `Compensation` intermediate event is a boundary event that is attached to an activity in a transaction subprocess that may finish with a `Compensation` end event or a `Cancel` end event. The `Compensation` intermediate event must have one outgoing flow that connects to an activity that defines the compensation action needed to compensate for the action performed by the activity.
 * `Signal`: Use the `Signal` catching intermediate event to execute a workflow once a specified signal object defined in its properties is received from the main process or any other process.
 
-[[_throwing_intermediate_events]]
+[id='_throwing_intermediate_events']
 ==== Throwing Intermediate Events
 
 Throwing intermediate events comprises events which produce a specified trigger in the form of a message, escalation, or signal, to drive the flow of a process. Throwing intermediate events are of the following types:
@@ -1643,7 +1643,7 @@ Throwing intermediate events comprises events which produce a specified trigger 
 * `Escalation`: Use the `Escalation` throw intermediate event to produce an escalation object. Once it creates an escalation object, the process execution continues. The escalation object can be consumed by an `Escalation` start event or an `Escalation` intermediate catch event, which is looking for this specific escalation object.
 * `Signal`: Use the `Signal` throwing intermediate events to produces a signal object. Once it creates a signal object, the process execution continues. The signal object is consumed by a `Signal` start event or a Signal catching intermediate event, which is looking for this specific signal object.
 
-[[_sect_gateways]]
+[id='_sect_gateways']
 == Gateways
 
 "_Gateways are used to control how Sequence Flows interact as they converge and diverge within a Process_."footnote:[Business Process Model and Notation (BPMN). Version 2.0, OMG Document Number: formal/2011-01-03 http://www.omg.org/spec/BPMN/2.0]
@@ -1660,10 +1660,10 @@ Depending on the gating mechanism you want to apply, you can use the following t
 * _Event-based_: used only in diverging gateways for reacting to events. See <<_event_based_gateway>>.
 * _Data-based Exclusive_: used in both diverging and converging gateways to make decisions based on available data. See <<_complex_gateway>>.
 
-[[_sect_gateway_types]]
+[id='_sect_gateway_types']
 === Gateway Types
 
-[[_event_based_gateway]]
+[id='_event_based_gateway']
 ==== Event-Based Gateway
 
 "_The Event-Based Gateway has pass-through semantics for a set of incoming branches (merging behavior). Exactly one of the outgoing branches is activated afterwards (branching behavior), depending on which of events of the Gateway configuration is first triggered_."footnote:[Business Process Model and Notation (BPMN). Version 2.0, OMG Document Number: formal/2011-01-03 http://www.omg.org/spec/BPMN/2.0]
@@ -1672,7 +1672,7 @@ The Gateway is only diverging and allows you to react to possible events as oppo
 
 The Gateway might act as a start event, where the process is instantiated only if one the Intermediate Events connected to the Event-Based Gateway occurs.
 
-[[_parallel_gateway]]
+[id='_parallel_gateway']
 ==== Parallel Gateway
 
 "_A Parallel Gateway is used to synchronize (combine) parallel flows and to create parallel flows_."footnote:[Business Process Model and Notation (BPMN). Version 2.0, OMG Document Number: formal/2011-01-03 http://www.omg.org/spec/BPMN/2.0]
@@ -1683,7 +1683,7 @@ Once the incoming flow is taken, all outgoing flows are taken simultaneously.
 Converging::
 The Gateway waits until all incoming flows have entered and only then triggers the outgoing flow.
 
-[[_inclusive_gateway]]
+[id='_inclusive_gateway']
 ==== Inclusive Gateway
 
 Diverging::
@@ -1700,7 +1700,7 @@ The Gateway merges all incoming flows previously created by a diverging Inclusiv
 Default gate::
 The outgoing flow taken by default if no other flow can be taken.
 
-[[_complex_gateway]]
+[id='_complex_gateway']
 ==== Data-Based Exclusive Gateway
 
 Diverging::
@@ -1721,7 +1721,7 @@ The Gateway allows a workflow branch to continue to its outgoing flow as soon as
 Default gate::
 The outgoing flow taken by default if no other flow can be taken.
 
-[[_data1]]
+[id='_data1']
 == Variables
 
 Variables are elements that serve for storing a particular type of data during runtime. The type of data a variable contains is defined by its data type.
@@ -1736,7 +1736,7 @@ In Red Hat JBoss BPM Suite, variables can live in the following contexts:
 +
 Values of local variables can be mapped to global or process variables using the assignment mechanism (see <<_assignment1>>). This allows you to maintain relative independence of the parent element that accommodates the local variable. Such isolation may help prevent technical exceptions.
 
-[[_assignment1]]
+[id='_assignment1']
 == Assignment
 
 The assignment mechanism allows you to assign a value to an object, such as a variable, before or after the particular element is executed.
@@ -1753,7 +1753,7 @@ Assignment is defined in the `Assignments` property in case of activity elements
 As parameters of the type String can make use of the assignment mechanism by applying the respective syntax directly in their value, `#{userVariable}`, assignment is rather intended for mapping of properties that are not of type String.
 ====
 
-[[_action_scripts]]
+[id='_action_scripts']
 == Action Scripts
 
 Action scripts are pieces of code that define the `Script` property or an element's interceptor action. Action scripts have access to global variables, process variables, and the predefined variable `kcontext`. Accordingly, `kcontext` is an instance of the `ProcessContext` interface. See the `ProcessContext` http://docs.jboss.org/jbpm/v6.4/javadocs/org/kie/api/runtime/process/ProcessContext.html[Javadoc] for more information.
@@ -1821,7 +1821,7 @@ System.out.println(kcontext.getProcessInstance().getState());
 
 To set a process variable in an action script, use `kcontext.setVariable("_VARIABLE_NAME_", "_VALUE_")`.
 
-[[_constraints]]
+[id='_constraints']
 == Constraints
 
 There are two types of constraints in business processes: _code constraints_ and _rule constraints_.
@@ -1861,7 +1861,7 @@ Person(name == (processInstance.getVariable("name")))
 # add more constraints here ...
 ----
 
-[[_timers]]
+[id='_timers']
 == Timers
 
 Timers wait for a predefined amount of time before triggering, once, or repeatedly. You can use timers to trigger certain logic after a certain period, or to repeat some action at regular intervals.
@@ -1873,7 +1873,7 @@ Timers wait for a predefined amount of time before triggering, once, or repeated
 A Timer node is set up with a delay and a period. The delay specifies the amount of time to wait after node activation before triggering the timer for the first time. The period defines the time between subsequent trigger activations. A period of `0` results in a one-shot timer. The (period and delay) expression must be of the form `[\#d][#h][#m][#s][#[ms]]`. You can specify the amount of days, hours, minutes, seconds, and milliseconds. Milliseconds is the default value. For example, the expression `1h` waits one hour before triggering the timer again.
 
 [float]
-[[_configuring_timer_iso_date_format]]
+[id='_configuring_timer_iso_date_format']
 ==== Configuring Timer ISO-8601 Date Format
 
 Since version 6, you can configure timers with valid _ISO8601_ date format that supports both one shot timers and repeatable timers. You can define timers as date and time representation, time duration or repeating intervals. For example:
@@ -1895,7 +1895,7 @@ In addition to the above mentioned configuration options, you can specify timers
 * You can associate timer with a sub-process or tasks as a boundary event.
 
 [float]
-[[_updating_timer_within_a_running_process_instance]]
+[id='_updating_timer_within_a_running_process_instance']
 ==== Updating Timer Within a Running Process Instance
 
 Sometimes a process requires the possibility to dynamically alter the timer period or delay without the need to restart the entire process workflow. In that case, an already scheduled timer can be rescheduled to meet the new requirements: for example to prolong or shorten the timer expiration time or change the delay, period, and repeat limit.
@@ -1964,17 +1964,17 @@ To resolve this issue:
 Note that the property is not available in previous versions of {PRODUCT}. For further information, see the {URL_ADMIN_GUIDE}#system_properties[System Properties] section of the _{ADMIN_GUIDE}_.
 --
 
-[[_sect_multi_threading]]
+[id='_sect_multi_threading']
 == Multi-Threading
 
-[[_multi_threading]]
+[id='_multi_threading']
 === Multi-Threading
 
 In the following text, we will refer to two types of "multi-threading": _logical_ and _technical_. _Technical multi-threading_ is what happens when multiple threads or processes are started on a computer, for example by a Java or C program. _Logical multi-threading_ is what we see in a BPM process after the process reaches a parallel gateway. From a functional standpoint, the original process will then split into two processes that are executed in a parallel fashion.
 
 The BPM engine supports logical multi-threading; for example, processes that include a parallel gateway are supported. We've chosen to implement logical multi-threading using one thread; accordingly, a BPM process that includes logical multi-threading will only be executed in one technical thread. The main reason for doing this is that multiple (technical) threads need to be be able to communicate state information with each other if they are working on the same process. This requirement brings with it a number of complications. While it might seem that multi-threading would bring performance benefits with it, the extra logic needed to make sure the different threads work together well means that this is not guaranteed. There is also the extra overhead incurred because we need to avoid race conditions and deadlocks.
 
-[[_engine_execution]]
+[id='_engine_execution']
 === Engine Execution
 
 In general, the BPM engine executes actions in serial. For example, when the engine encounters a script task in a process, it will synchronously execute that script and wait for it to complete before continuing execution. Similarly, if a process encounters a parallel gateway, it will sequentially trigger each of the outgoing branches, one after the other. This is possible since execution is almost always instantaneous, meaning that it is extremely fast and produces almost no overhead. As a result, the user will usually not even notice this. Similarly, action scripts in a process are also synchronously executed, and the engine will wait for them to finish before continuing the process. For example, doing a `Thread.sleep(...)` as part of a script will not make the engine continue execution elsewhere but will block the engine thread during that period.
@@ -2050,7 +2050,7 @@ For further information about the `Is Async` node property, see the {URL_USER_GU
 
 For further information about the deployment descriptor hierarchy, see the {URL_ADMIN_GUIDE}#sect_deployment_descriptors[Deployment Descriptors] chapter of the _{ADMIN_GUIDE}_.
 
-[[_job_executor_for_asynchronous_execution]]
+[id='_job_executor_for_asynchronous_execution']
 === Job Executor for Asynchronous Execution
 
 In Red Hat JBoss BPM Suite, the Job Executor component integrates with the runtime engine for processing asynchronous tasks. You can delegate asynchronous execution operations, such as error handling, retry, cancellation, and history logging in a new thread (using custom implementation of `WorkItemHandler`) and use the Job Executor to handle these operations for you. The Job Executor provides an environment for background execution of commands, which are nothing but business logic encapsulated within a simple interface.
@@ -2486,7 +2486,7 @@ public class ProcessMain {
 Hello World from Business Command!
 ----
 
-[[_using_job_executor_in_business_central]]
+[id='_using_job_executor_in_business_central']
 === Using Job Executor in Business Central
 
 `AsyncWorkItemHandler` accepts the following input parameters:
@@ -2614,7 +2614,7 @@ When you are not running the Executor Service in the embedded mode, you can use 
 . [property]``org.kie.executor.interval``: an Integer that specifies the time to wait between checking for waiting jobs. The default value is 3 seconds.
 . [property]``org.kie.executor.timeunit``: `NANOSECONDS`, `MICROSECONDS`, `MILLISECONDS`, `SECONDS`, `MINUTES`, `HOURS`, or `DAYS`. Specifies the unit for the interval property. The default is `SECONDS`.
 
-[[_multiple_sessions_and_persistence]]
+[id='_multiple_sessions_and_persistence']
 === Multiple Sessions and persistence
 
 
@@ -2649,7 +2649,7 @@ From the Business Central, set the *Data Input*
  value of the throw event to async to automatically set the Executor Service on each ksession.
 This ensures that each process instance is signaled in a different transaction.
 
-[[_sect_technical_exceptions]]
+[id='_sect_technical_exceptions']
 === Technical exceptions
 
 
@@ -2721,10 +2721,10 @@ If WorkItemManager signals that the work item has been completed or aborted, mak
 Depending on how your Process definition, calling WorkItemManager.completeWorkItem() or WorkItemManager.abortWorkItem() triggers the completion of the Process instance as these methods trigger further execution of the Process execution flow.
 ====
 
-[[_sect_technical_exception_examples]]
+[id='_sect_technical_exception_examples']
 ==== Technical exception examples
 
-[[_service_task_handlers]]
+[id='_service_task_handlers']
 ===== Service Task handlers
 
 
@@ -2800,7 +2800,7 @@ The following XML is a representation of the process. It contains elements and I
 In the process itself, a `<property>` element (fourth reference) is defined as having the content defined by the initial `<itemDefintion>`. This is helpful because it means that the Event SubProcess can then store the error it receives in that property (5th reference).
 
 
-[[_exception_handling_classes]]
+[id='_exception_handling_classes']
 ===== Exception handling classes
 
 The BPMN process defined in <<_service_task_handlers>> contains two `<serviceTask>` activities. The `org.jbpm.bpmn2.handler.ServiceTaskHandler` class is the default task handler class used for `<serviceTask>` tasks. If you do not specify a Work Item Handler implementation for a `<serviceTask>` activity, the `ServiceTaskHandler` class is used.
@@ -2883,7 +2883,7 @@ return kbase.newKieSession();
 For a list of Maven dependencies, see example _Embedded jBPM Engine Dependencies_ in chapter {URL_DEVELOPMENT_GUIDE}#dependency_management[Dependency Management] of the _{DEVELOPMENT_GUIDE}_.
 ====
 
-[[_exception_service]]
+[id='_exception_service']
 ===== Exception service
 
 
@@ -2926,7 +2926,7 @@ For a list of Maven dependencies, see example _Embedded jBPM Engine Dependencies
 
 You can specify any Java class with the default or another no-argument constructor as the class to provide the exception service so that it is executed as part of a [class]``serviceTask``.
 
-[[_handling_errors_with_signals]]
+[id='_handling_errors_with_signals']
 ===== Handling errors with Signals
 
 
@@ -2970,7 +2970,7 @@ to a ``<signalEventDefinition>``:
 ----
 
 
-[[_extracting_information_from_workflowruntimeexception]]
+[id='_extracting_information_from_workflowruntimeexception']
 ===== Extracting information from WorkflowRuntimeException
 
 
@@ -2980,7 +2980,7 @@ If it is a `scriptTask` element that causes an exception, you can extract the in
 
 The `WorkflowRuntimeException` instance stores the information outlined in <<_workflowruntimeexception>>. Values of all fields listed can be obtained using the standard `get*` methods.
 
-[[_workflowruntimeexception]]
+[id='_workflowruntimeexception']
 .Information in WorkflowRuntimeException instances
 [cols="20%,20%,60%a", frame="all", options="header"]
 |===
@@ -3113,17 +3113,17 @@ Use the following Maven dependencies:
 For the current Maven artifact version, see chapter {URL_INSTALLATION_GUIDE}#supported_comps[Supported Component Versions] of the _{INSTALLATION_GUIDE}_.
 
 
-[[_sect_process_fluent_api]]
+[id='_sect_process_fluent_api']
 == Process Fluent API
 
-[[_using_the_process_fluent_api_to_create_business_process]]
+[id='_using_the_process_fluent_api_to_create_business_process']
 === Using the Process Fluent API to Create Business Process
 
 While it is recommended to define processes using the graphical editor or the underlying XML, you can also create a business process using the Process API directly. The most important process model elements are defined in the packages `org.jbpm.workflow.core` and `org.jbpm.workflow.core.node`.
 
 {PRODUCT} provides you a fluent API that allows you to easily construct processes in a readable manner using factories. You can then validate the process that you were constructing manually.
 
-[[_process_fluent_api_example]]
+[id='_process_fluent_api_example']
 === Process Fluent API Example
 
 Here is an example of a basic process with only a script task:
@@ -3192,7 +3192,7 @@ In the above example, once you add all the nodes, you must connect them by creat
 Finally, you can validate the generated process by calling the `validate()` method and retrieve the created `RuleFlowProcess` object.
 
 
-[[_sect_testing_business_processes]]
+[id='_sect_testing_business_processes']
 == Testing Business Processes
 
 Although business processes should not contain any implementation details and should be as high-level as possible, they have a life cycle similar to other development artefacts. Because business processes can be updated dynamically and modifying them can cause errors, testing a process definition is a part of creating business processes.
@@ -3246,7 +3246,7 @@ public class ProcessPersistenceTest extends JbpmJUnitBaseTestCase {
 
 For a list of Maven dependencies, see section <<_testing_dependencies>>.
 
-[[_JbpmJUnitBaseTestCase]]
+[id='_JbpmJUnitBaseTestCase']
 === JbpmJUnitBaseTestCase
 
 The `JbpmJUnitBaseTestCase` class acts as a base test case class that you can use for Red Hat JBoss BPM Suite-related tests. It provides four usage areas:
@@ -3457,7 +3457,7 @@ public class ProcessHumanTaskTest extends JbpmJUnitBaseTestCase {
 
 For a list of Maven dependencies, see section <<_testing_dependencies>>.
 
-[[_configuring_persistence1]]
+[id='_configuring_persistence1']
 === Configuring Persistence
 
 Persistence allows to store states of all process instances in a database and uses a history log to check assertions related to the execution history. When persistence is not used, process instances are stored in the memory and an in-memory logger is used for history transactions.
@@ -3489,7 +3489,7 @@ public class ProcessHumanTaskTest extends JbpmJUnitBaseTestCase {
 }
 ----
 
-[[_testing_integration_with_external_services]]
+[id='_testing_integration_with_external_services']
 === Testing Integration with External Services
 
 Business processes often include the invocation of external services. Unit testing of a business process allows you to register test handlers that verify whether the specific services are requested correctly, and provide test responses for those services as well.

--- a/docs/product-development-guide/src/main/asciidoc/chap-working-with-rules.adoc
+++ b/docs/product-development-guide/src/main/asciidoc/chap-working-with-rules.adoc
@@ -1,15 +1,15 @@
-[[_chap_working_with_rules]]
+[id='_chap_working_with_rules']
 = Working With Rules
 
-[[_sect_whats_in_a_rule_file]]
+[id='_sect_whats_in_a_rule_file']
 == About Rule Files
 
-[[_a_rule_file]]
+[id='_a_rule_file']
 === Rule File
 
 A rule file is typically a file with a `.drl` extension. In a DRL file you can have multiple rules, queries and functions, as well as some resource declarations like imports, globals, and attributes that are assigned and used by your rules and queries. However, you are also able to spread your rules across multiple rule files (in that case, the extension `.rule` is suggested, but not required) - spreading rules across files can help with managing large numbers of rules. A DRL file is simply a text file.
 
-[[_the_structure_of_a_rule_file]]
+[id='_the_structure_of_a_rule_file']
 === Structure of Rule Files
 
 The overall structure of a rule file is the following:
@@ -34,12 +34,12 @@ rules
 
 The order in which the elements are declared is not important, except for the package name that, if declared, must be the first element in the rules file. All elements are optional, so you will use only those you need.
 
-[[_sect_how_rules_operate_on_facts]]
+[id='_sect_how_rules_operate_on_facts']
 == Operating on Facts
 
 Facts are domain model objects that BRMS uses to evaluate conditions and execute consequences. A rule specifies that when a particular set of conditions occur, then the specified list of actions must be executed. The inference engine matches facts against rules, and when matches are found, rule actions are placed on the agenda. The agenda is the place where rules are queued ready to have their actions fired. The rule engine then determines which eligible rules on the agenda must fire.
 
-[[_rule_files_accessing_the_working_memory]]
+[id='_rule_files_accessing_the_working_memory']
 === Accessing Working Memory
 
 The working memory is a stateful object that provides temporary storage and enables manipulation of facts. The working memory includes an API that contains methods which enable access to the working memory from rule files. The available methods are:
@@ -70,20 +70,20 @@ The whole KIE API is exposed through a predefined `kcontext` variable of type `R
 +
 For example, calling `kcontext.getKieRuntime().halt()` terminates a rule execution immediately.
 
-[[_sect_using_rule_keywords]]
+[id='_sect_using_rule_keywords']
 == Using Rule Keywords
 
-[[_hard_keywords]]
+[id='_hard_keywords']
 === Hard Keywords
 
 _Hard keywords_ are words which you cannot use when naming your domain objects, properties, methods, functions, and other elements that are used in the rule text. The hard keywords are `true`, `false`, and `null`.
 
-[[_soft_keywords]]
+[id='_soft_keywords']
 === Soft Keywords
 
 _Soft keywords_ can be used for naming domain objects, properties, methods, functions, and other elements. The rules engine recognizes their context and processes them accordingly.
 
-[[_list_of_soft_keywords]]
+[id='_list_of_soft_keywords']
 === List of Soft Keywords
 
 Rule attributes can be both simple and complex properties that provide a way to influence the behavior of the rule. They are usually written as one attribute per line and can be optional to the rule. Listed below are various rule attributes:
@@ -175,7 +175,7 @@ If a rule is still `true`, the `duration` attribute will dictate that the rule w
 
 NOTE: The attributes `ruleflow-group` and `agenda-group` have been merged and now behave the same. The GET methods have been left the same, for deprecations reasons, but both attributes return the same underlying data.
 
-[[_sect_adding_comments_to_a_rule_file]]
+[id='_sect_adding_comments_to_a_rule_file']
 == Adding Comments to Rule File
 
 Comments are sections of text that are ignored by the rule engine. They are stripped out when they are encountered, except inside semantic code blocks (like a rule's RHS).
@@ -195,7 +195,7 @@ then
 end
 ----
 
-[[_multi_line_comment_example]]
+[id='_multi_line_comment_example']
 === Multi-Line Comment Example
 
 This is what a multi-line comment looks like. This configuration comments out blocks of text, both in and outside semantic code blocks:
@@ -213,7 +213,7 @@ then
 end
 ----
 
-[[_sect_error_messages_in_rules]]
+[id='_sect_error_messages_in_rules']
 == Error Messages in Rules
 
 Red Hat JBoss BRMS provides standardized error messages. This standardization aims to help users to find and resolve problems in a easier and faster way.
@@ -235,7 +235,7 @@ _4th Block:_ This is the first context. Usually indicates the rule, function, te
 
 _5th Block:_ Identifies the pattern where the error occurred. This block is not mandatory.
 
-[[_error_messages_description]]
+[id='_error_messages_description']
 === Error Message Description
 
 [ERR 101] Line 4:4 no viable alternative at input 'exits' in rule one::
@@ -349,7 +349,7 @@ The recognizer came to a subrule in the grammar that must match an alternative a
 ----
 
 
-[[_sect_packaging]]
+[id='_sect_packaging']
 == Packaging
 
 A _package_ is a collection of rules and other related constructs, such as imports and globals. The package members are typically related to each other, such as HR rules. A package represents a namespace, which ideally is kept unique for a given grouping of rules. The package name itself is the namespace, and is not related to files or folders in any way.
@@ -360,7 +360,7 @@ It is possible to assemble rules from multiple rule sources, and have one top-le
 
 _Import statements_ work like import statements in Java. You need to specify the fully qualified paths and type names for any objects you want to use in the rules. Red Hat JBoss BRMS automatically imports classes from the Java package of the same name, and also from the package `java.lang`.
 
-[[_using_globals]]
+[id='_using_globals']
 === Using Globals
 
 In DRL files, globals represent global variables. To use globals in rules:
@@ -388,12 +388,12 @@ KieSession kieSession = kieBase.newKieSession();
 kieSession.setGlobal("myGlobalList", list);
 ----
 
-[[_the_from_element]]
+[id='_the_from_element']
 === From Element
 
 The `from` element allows you to pass a Hibernate session as a global. It also lets you pull data from a named Hibernate query.
 
-[[_using_globals_with_an_e_mail_service]]
+[id='_using_globals_with_an_e_mail_service']
 === Using Globals with E-Mail Service
 
 .Procedure: Task
@@ -408,7 +408,7 @@ WARNING: Globals are not designed to share data between rules and they should ne
 IMPORTANT: Do not set or change a global value from inside the rules. We recommend to you always set the value from your application using the working memory interface.
 
 
-[[_sect_functions_in_a_rule]]
+[id='_sect_functions_in_a_rule']
 == Functions in Rules
 
 _Functions_ are a way to put semantic code in a rule source file, as opposed to in normal Java classes. The main advantage of using functions in a rule is that you can keep the logic all in one place. You can change the functions as needed.
@@ -426,7 +426,7 @@ function String hello(String name) {
 
 NOTE: Note that the `function` keyword is used, even though it is not technically part of Java. Parameters to the function are defined as for a method. You do not have to have parameters if they are not needed. The return type is defined just like in a regular method.
 
-[[_function_declaration_with_static_method_example]]
+[id='_function_declaration_with_static_method_example']
 === Importing Static Method Example
 
 In the following example, a static method `Foo.hello()` from a helper class is imported as a function. To import a method, enter the following into your DRL file: 
@@ -436,7 +436,7 @@ In the following example, a static method `Foo.hello()` from a helper class is i
 import function my.package.Foo.hello
 ----
 
-[[_calling_a_function_declaration_example]]
+[id='_calling_a_function_declaration_example']
 === Calling Function Declaration Example
 
 Irrespective of the way the function is defined or imported, you use a function by calling it by its name, in the consequence or inside a semantic code block. This is shown below:
@@ -451,7 +451,7 @@ then
 end
 ----
 
-[[_type_declarations]]
+[id='_type_declarations']
 === Type Declarations
 
 _Type declarations_ have two main goals in the rules engine: to allow the declaration of new types, and to allow the declaration of metadata for types.
@@ -469,12 +469,12 @@ _Type declarations_ have two main goals in the rules engine: to allow the declar
 |Facts may have meta information associated to them. Examples of meta information include any kind of data that is not represented by the fact attributes and is consistent among all instances of that fact type. This meta information may be queried at runtime by the engine and used in the reasoning process.
 |===
 
-[[_declaring_new_types]]
+[id='_declaring_new_types']
 === Declaring New Types
 
 To declare a new type, the keyword `declare` is used, followed by the list of fields and the keyword `end`. A new fact must have a list of fields, otherwise the engine will look for an existing fact class in the classpath and raise an error if not found.
 
-[[_declaring_a_new_fact_type_example]]
+[id='_declaring_a_new_fact_type_example']
 === Declaring New Fact Type Example
 
 In this example, a new fact type called `Address` is used. This fact type will have three attributes: `number`, `streetName` and `city`. Each attribute has a type that can be any valid Java type, including any other class created by the user or other fact types previously declared:
@@ -488,7 +488,7 @@ declare Address
 end
 ----
 
-[[_declaring_a_new_fact_type_additional_example]]
+[id='_declaring_a_new_fact_type_additional_example']
 === Declaring New Fact Type Additional Example
 
 This fact type declaration uses a `Person` example. `dateOfBirth` is of the type `java.util.Date` (from the Java API) and `address` is of the fact type `Address`.
@@ -502,7 +502,7 @@ declare Person
 end
 ----
 
-[[_using_import_example]]
+[id='_using_import_example']
 === Using Import Example
 
 To avoid using fully qualified class names, use the `import` statement:
@@ -518,12 +518,12 @@ declare Person
 end
 ----
 
-[[_generated_java_classes]]
+[id='_generated_java_classes']
 === Generated Java Classes
 
 When you declare a new fact type, Red Hat JBoss BRMS generates bytecode that implements a Java class representing the fact type. The generated Java class is a one-to-one Java Bean mapping of the type definition.
 
-[[_generated_java_class_example]]
+[id='_generated_java_class_example']
 === Generated Java Class Example
 
 This is an example of a generated Java class using the `Person` fact type:
@@ -550,7 +550,7 @@ public class Person implements Serializable {
 }
 ----
 
-[[_using_the_declared_types_in_rules_example]]
+[id='_using_the_declared_types_in_rules_example']
 === Using Declared Types in Rules Example
 
 Since the generated class is a simple Java class, it can be used transparently in the rules like any other fact:
@@ -568,7 +568,7 @@ then
 end
 ----
 
-[[_declaring_metadata]]
+[id='_declaring_metadata']
 === Declaring Metadata
 
 Metadata may be assigned to several different constructions in Red Hat JBoss BRMS, such as fact types, fact attributes and rules. Red Hat JBoss BRMS uses the at sign (`@`) to introduce metadata and it always uses the form:
@@ -580,12 +580,12 @@ Metadata may be assigned to several different constructions in Red Hat JBoss BRM
 
 The parenthesized `metadata_value` is optional.
 
-[[_working_with_metadata_attributes]]
+[id='_working_with_metadata_attributes']
 === Working with Metadata Attributes
 
 Red Hat JBoss BRMS allows the declaration of any arbitrary metadata attribute. Some have special meaning to the engine, while others are available for querying at runtime. Red Hat JBoss BRMS allows the declaration of metadata both for fact types and for fact attributes. Any metadata that is declared before the attributes of a fact type are assigned to the fact type, while metadata declared after an attribute are assigned to that particular attribute.
 
-[[_declaring_a_metadata_attribute_with_fact_types_example]]
+[id='_declaring_a_metadata_attribute_with_fact_types_example']
 === Declaring Metadata Attribute with Fact Types Example
 
 This is an example of declaring metadata attributes for fact types and attributes. There are two metadata items declared for the fact type (`@author` and `@dateOfCreation`) and two more defined for the name attribute (`@key` and `@maxLength`). The `@key` metadata has no required value, and so the parentheses and the value were omitted:
@@ -604,12 +604,12 @@ declare Person
 end
 ----
 
-[[_the_position_attribute]]
+[id='_the_position_attribute']
 === @position Attribute
 
 The `@position` attribute can be used to declare the position of a field, overriding the default declared order. This is used for positional constraints in patterns.
 
-[[_position_example]]
+[id='_position_example']
 === @position Example
 
 This is what the @position attribute looks like in use:
@@ -623,7 +623,7 @@ declare Cheese
 end
 ----
 
-[[_predefined_class_level_annotations]]
+[id='_predefined_class_level_annotations']
 === Predefined Class Level Annotations
 
 @role( <fact\|event>)::
@@ -648,7 +648,7 @@ Facts that implement support for property changes as defined in the Javabean spe
 Makes the type property reactive.
 
 
-[[_key_attribute_functions]]
+[id='_key_attribute_functions']
 === @key Attribute Functions
 
 Declaring an attribute as a key attribute has two major effects on generated types:
@@ -656,7 +656,7 @@ Declaring an attribute as a key attribute has two major effects on generated typ
 . The attribute is used as a key identifier for the type, and thus the generated class implements the `equals()` and `hashCode()` methods taking the attribute into account when comparing instances of this type.
 . Red Hat JBoss BRMS generates a constructor using all the key attributes as parameters.
 
-[[_key_declaration_example]]
+[id='_key_declaration_example']
 === @key Declaration Example
 
 This is an example of `@key` declarations for a type. Red Hat JBoss BRMS generates `equals()` and `hashCode()` methods that checks the `firstName` and `lastName` attributes to determine if two instances of `Person` are equal to each other. It does not check the `age` attribute. It also generates a constructor taking `firstName` and `lastName` as parameters:
@@ -670,7 +670,7 @@ declare Person
 end
 ----
 
-[[_creating_an_instance_with_the_key_instructor_example]]
+[id='_creating_an_instance_with_the_key_instructor_example']
 === Creating Instance with Key Constructor Example
 
 This is what creating an instance using the key constructor looks like:
@@ -680,14 +680,14 @@ This is what creating an instance using the key constructor looks like:
 Person person = new Person("John", "Doe");
 ----
 
-[[_positional_arguments]]
+[id='_positional_arguments']
 === Positional Arguments
 
 Patterns support positional arguments on type declarations and are defined by the `@position` attribute.
 
 Positional arguments are when you do not need to specify the field name, as the position maps to a known named field. That is, `Person(name == "mark")` can be rewritten as `Person("mark";)`. The semicolon `;` is important so that the engine knows that everything before it is a positional argument. You can mix positional and named arguments on a pattern by using the semicolon `;` to separate them. Any variables used in a positional that have not yet been bound will be bound to the field that maps to that position.
 
-[[_positional_argument_example]]
+[id='_positional_argument_example']
 === Positional Argument Example
 
 Observe the example below:
@@ -712,12 +712,12 @@ declare Cheese
 end
 ----
 
-[[_the_position_annotation]]
+[id='_the_position_annotation']
 === @position Annotation
 
 The `@position` annotation can be used to annotate original pojos on the classpath. Currently only fields on classes can be annotated. Inheritance of classes is supported, but not interfaces of methods.
 
-[[_example_patterns]]
+[id='_example_patterns']
 === Example Patterns
 
 These example patterns have two constraints and a binding. The semicolon `;` is used to differentiate the positional section from the named argument section. Variables and literals and expressions using just literals are supported in positional arguments, but not variables:
@@ -730,15 +730,15 @@ Cheese("stilton"; shop == "Cheese Shop", p : price)
 Cheese(name == "stilton"; shop == "Cheese Shop", p : price)
 ----
 
-[[_sect_backward_chaining]]
+[id='_sect_backward_chaining']
 == Backward-Chaining
 
-[[_backward_chaining_systems]]
+[id='_backward_chaining_systems']
 === Backward-Chaining Systems
 
 _Backward-Chaining_ is a feature recently added to the BRMS Engine. This process is often referred to as derivation queries, and it is not as common compared to reactive systems since BRMS is primarily reactive forward chaining. That is, it responds to changes in your data. The backward-chaining added to the engine is for product-like derivations.
 
-[[_cloning_transitive_closures]]
+[id='_cloning_transitive_closures']
 === Cloning Transitive Closures
 
 .Reasoning Graph
@@ -771,7 +771,7 @@ image::2941.png[An example transitive closure graph.]
 
 NOTE: Notice compared to the previous graph, there is no "key" item in a "drawer" location. This will become evident in a later topic.
 
-[[_defining_a_query]]
+[id='_defining_a_query']
 === Defining Query
 
 . Create a query to search for data inserted into the rule engine:
@@ -835,7 +835,7 @@ The following holds:
 * The salience ensures that the `go` rule is fired first and the message output is printed.
 * The `go1` rule matches the query and `office is in the house` is printed.
 
-[[_transitive_closure_example]]
+[id='_transitive_closure_example']
 === Transitive Closure Example
 
 .Creating Transitive Closure
@@ -905,7 +905,7 @@ Location(x==drawer, y==desk)
 +
 This matches on the first location and recurses back up, so we know that "drawer" is in the "desk", the "desk" is in the "office", and the "office" is in the "house"; therefore, the "drawer" is in the "house" and returns `true`.
 
-[[_reactive_transitive_queries]]
+[id='_reactive_transitive_queries']
 === Reactive Transitive Queries
 
 .Creating a Reactive Transitive Query
@@ -966,7 +966,7 @@ Key in the Office
 +
 This new location satisfies the transitive closure because it is monitoring the entire graph. In addition, this process now has four recursive levels in which it goes through to match and fire the rule.
 
-[[_queries_with_unbound_arguments]]
+[id='_queries_with_unbound_arguments']
 === Queries with Unbound Arguments
 
 .Creating Unbound Argument Query
@@ -1014,7 +1014,7 @@ thing Chair is in the Office
 +
 When `go4` is inserted, it returns all the previous information that is transitively below "office."
 
-[[_multiple_unbound_arguments]]
+[id='_multiple_unbound_arguments']
 === Multiple Unbound Arguments
 
 .Creating Multiple Unbound Arguments
@@ -1077,15 +1077,15 @@ thing Chair is in Office
 +
 When `go5` is called, it returns everything within everything.
 
-[[_sect_type_declaration]]
+[id='_sect_type_declaration']
 == Type Declaration
 
-[[_declaring_metadata_for_existing_types]]
+[id='_declaring_metadata_for_existing_types']
 === Declaring Metadata for Existing Types
 
 Red Hat JBoss BRMS allows the declaration of metadata attributes for existing types in the same way as when declaring metadata attributes for new fact types. The only difference is that there are no fields in that declaration.
 
-[[_declaring_metadata_for_existing_types_example]]
+[id='_declaring_metadata_for_existing_types_example']
 === Declaring Metadata for Existing Types Example
 
 This example shows how to declare metadata for an existing type:
@@ -1100,7 +1100,7 @@ declare Person
 end
 ----
 
-[[_declaring_metadata_using_a_fully_qualified_class_name_example]]
+[id='_declaring_metadata_using_a_fully_qualified_class_name_example']
 === Declaring Metadata Using Fully Qualified Class Name Example
 
 This example shows how you can declare metadata using the fully qualified class name instead of using the import annotation:
@@ -1113,7 +1113,7 @@ declare org.drools.examples.Person
 end
 ----
 
-[[_parametrized_constructors_for_declared_types_example]]
+[id='_parametrized_constructors_for_declared_types_example']
 === Parametrized Constructors for Declared Types Example
 
 For a declared type like the following:
@@ -1136,17 +1136,17 @@ Person(String firstName, String lastName)
 Person(String firstName, String lastName, int age)
 ----
 
-[[_non_typesafe_classes]]
+[id='_non_typesafe_classes']
 === Non-Typesafe Classes
 
 The `@typesafe(_BOOLEAN_)` annotation has been added to type declarations. By default all type declarations are compiled with type safety enabled. `@typesafe(false)` provides a means to override this behaviour by permitting a fall-back, to type unsafe evaluation where all constraints are generated as MVEL constraints and executed dynamically. This is useful when dealing with collections that do not have any generics or mixed type collections.
 
-[[_accessing_declared_types_from_the_application_code]]
+[id='_accessing_declared_types_from_the_application_code']
 === Accessing Declared Types from Application Code
 
 Sometimes applications need to access and handle facts from the declared types. In such cases, Red Hat JBoss BRMS provides a simplified API for the most common fact handling the application wishes to do. A declared fact belongs to the package where it is declared.
 
-[[_declaring_a_type]]
+[id='_declaring_a_type']
 === Declaring Type
 
 This illustrates the process of declaring a type:
@@ -1170,7 +1170,7 @@ declare Person
 end
 ----
 
-[[_handling_declared_fact_types_through_the_api_example]]
+[id='_handling_declared_fact_types_through_the_api_example']
 === Handling Declared Fact Types Through API Example
 
 This example illustrates the handling of declared fact types through the API:
@@ -1215,12 +1215,12 @@ For a list of Maven dependencies, see example <<_embedded_jbpm_engine_dependenci
 
 The API also includes other helpful methods, like setting all the attributes at once, reading values from a Map, or reading all attributes at once, into a Map.
 
-[[_type_declaration_extends]]
+[id='_type_declaration_extends']
 === Type Declaration Extends
 
 Type declarations support the `extends` keyword for inheritance. To extend a type declared in Java by a DRL declared subtype, repeat the supertype in a declare statement without any fields.
 
-[[_type_declaration_extends_example]]
+[id='_type_declaration_extends_example']
 === Type Declaration Extends Example
 
 This illustrates the use of the `extends` annotation:
@@ -1242,12 +1242,12 @@ declare LongTermStudent extends Student
 end
 ----
 
-[[_traits]]
+[id='_traits']
 === Traits
 
 _Traits_ allow you to model multiple dynamic types which do not fit naturally in a class hierarchy. A trait is an interface that can be applied (and eventually removed) to an individual object at runtime. To create a trait out of an interface, a `@format(trait)` annotation is added to its declaration in DRL.
 
-[[_traits_example]]
+[id='_traits_example']
 === Traits Example
 
 [source]
@@ -1273,12 +1273,12 @@ then
 end
 ----
 
-[[_core_objects_and_traits]]
+[id='_core_objects_and_traits']
 === Core Objects and Traits
 
 When a core object dons a trait, a proxy class is created on the fly (one such class will be generated lazily for each core/trait class combination). The proxy instance, which wraps the core object and implements the trait interface, is inserted automatically and will possibly activate other rules. An immediate advantage of declaring and using interfaces, getting the implementation proxy for free from the engine, is that multiple inheritance hierarchies can be exploited when writing rules. The core classes, however, need not implement any of those interfaces statically, also facilitating the use of legacy classes as cores. Any object can don a trait. For efficiency reasons, however, you can add the @traitable annotation to a declared bean class to reduce the amount of glue code that the compiler will have to generate. This is optional and will not change the behavior of the engine.
 
-[[_traitable_example]]
+[id='_traitable_example']
 === @traitable Example
 
 This illustrates the use of the `@traitable` annotation:
@@ -1292,12 +1292,12 @@ declare Customer
 end
 ----
 
-[[_writing_rules_with_traits]]
+[id='_writing_rules_with_traits']
 === Writing Rules with Traits
 
 The only connection between core classes and trait interfaces is at the proxy level. (That is, a trait is not specifically tied to a core class.) This means that the same trait can be applied to totally different objects. For this reason, the trait does not transparently expose the fields of its core object. When writing a rule using a trait interface, only the fields of the interface will be available, as usual. However, any field in the interface that corresponds to a core object field, will be mapped by the proxy class.
 
-[[_rules_with_traits_example]]
+[id='_rules_with_traits_example']
 === Rules with Traits Example
 
 This example illustrates the trait interface being mapped to a field:
@@ -1312,22 +1312,22 @@ then
 end
 ----
 
-[[_hidden_fields]]
+[id='_hidden_fields']
 === Hidden Fields
 
 Hidden fields are fields in the core class not exposed by the interface.
 
-[[_the_two_part_proxy]]
+[id='_the_two_part_proxy']
 === Two-Part Proxy
 
 The _two-part proxy_ has been developed to deal with soft and hidden fields which are not processed intuitively. Internally, proxies are formed by a proper proxy and a wrapper. The former implements the interface, while the latter manages the core object fields, implementing a name/value map to supports soft fields. The proxy uses both the core object and the map wrapper to implement the interface, as needed.
 
-[[_wrappers]]
+[id='_wrappers']
 === Wrappers
 
 The _wrapper_ provides a looser form of typing when writing rules. However, it has also other uses. The wrapper is specific to the object it wraps, regardless of how many traits have been attached to an object. All the proxies on the same object will share the same wrapper. Additionally, the wrapper contains a back-reference to all proxies attached to the wrapped object, effectively allowing traits to see each other.
 
-[[_wrapper_example]]
+[id='_wrapper_example']
 === Wrapper Example
 
 This is an example of using the wrapper:
@@ -1342,7 +1342,7 @@ then
 end
 ----
 
-[[_wrapper_with_isa_annotation_example]]
+[id='_wrapper_with_isa_annotation_example']
 === Wrapper with isA Annotation Example
 
 This illustrates a wrapper in use with the isA annotation:
@@ -1352,7 +1352,7 @@ This illustrates a wrapper in use with the isA annotation:
 $sc : GoldenCustomer($maxExpense : maxExpense > 1000, this isA "SeniorCustomer")
 ----
 
-[[_removing_traits]]
+[id='_removing_traits']
 === Removing Traits
 
 The business logic may require that a trait is removed from a wrapped object. There are two ways to do so:
@@ -1379,7 +1379,7 @@ then
 +
 This operation returns another proxy implementing the `org.drools.factmodel.traits.Thing` interface, where the `getFields()` and `getCore()` methods are defined. Internally, all declared traits are generated to extend this interface (in addition to any others specified). This allows to preserve the wrapper with the soft fields which would otherwise be lost.
 
-[[_sect_rule_attributes]]
+[id='_sect_rule_attributes']
 == Rule Attributes
 
 For the list of all rule attributes and their description, see <<_soft_keywords>>.
@@ -1395,7 +1395,7 @@ when
   ...
 ----
 
-[[_timer_attribute_example]]
+[id='_timer_attribute_example']
 === Timer Attribute Example
 
 This is what the `timer` attribute looks like:
@@ -1410,7 +1410,7 @@ timer(cron: CRON_EXPRESSION)
 timer(cron:* 0/15 * * * ?)
 ----
 
-[[_timers1]]
+[id='_timers1']
 === Timers
 
 The following timers are available in Red Hat JBoss BRMS:
@@ -1427,7 +1427,7 @@ Consequences are executed even after control returns from a call to `fireUntilHa
 
 Disposing a session puts an end to all timer activity.
 
-[[_cron_timer_example]]
+[id='_cron_timer_example']
 === Cron Timer Example
 
 This is what the Cron timer looks like:
@@ -1443,12 +1443,12 @@ then
 end
 ----
 
-[[_calendars]]
+[id='_calendars']
 === Calendars
 
 Calendars are used to control when rules can fire. Red Hat JBoss BRMS uses the Quartz calendar.
 
-[[_quartz_calendar_example]]
+[id='_quartz_calendar_example']
 === Quartz Calendar Example
 
 This is what the Quartz calendar looks like:
@@ -1458,7 +1458,7 @@ This is what the Quartz calendar looks like:
 Calendar weekDayCal = QuartzHelper.quartzCalendarAdapter(org.quartz.Calendar quartzCal)
 ----
 
-[[_registering_a_calendar]]
+[id='_registering_a_calendar']
 === Registering Calendar
 
 .Procedure: Task
@@ -1494,17 +1494,17 @@ then
 end
 ----
 
-[[_left_hand_side]]
+[id='_left_hand_side']
 === Left Hand Side
 
 The _Left Hand Side_ (LHS) is a common name for the conditional part of the rule. It consists of zero or more conditional elements. If the LHS is empty, it will be considered as a condition element that is always true and it will be activated once, when a new `WorkingMemory` session is created.
 
-[[_conditional_elements1]]
+[id='_conditional_elements1']
 === Conditional Elements
 
 Conditional elements work on one or more _patterns_. The most common conditional element is `and`. It is implicit when you have multiple patterns in the LHS of a rule that is not connected in any way.
 
-[[_rule_without_a_conditional_element_example]]
+[id='_rule_without_a_conditional_element_example']
 === Rule Without Conditional Element Example
 
 This is what a rule without a conditional element looks like:
@@ -1528,7 +1528,7 @@ then
 end
 ----
 
-[[_sect_patterns]]
+[id='_sect_patterns']
 == Patterns
 
 A pattern element is the most important conditional element. It can potentially match on each fact that is inserted in the working memory. A pattern contains constraints and has an optional pattern binding.
@@ -1560,17 +1560,17 @@ end
 
 NOTE: An `and` cannot have a leading declaration binding. This is because a declaration can only reference a single fact at a time, and when the `and` is satisfied it matches both facts.
 
-[[_pattern_matching]]
+[id='_pattern_matching']
 === Pattern Matching
 
 A pattern matches against a fact of the given type. The type need not be the actual class of some fact object. Patterns may refer to superclasses or even interfaces, thereby potentially matching facts from many different classes. The constraints are defined inside parentheses.
 
-[[_pattern_binding]]
+[id='_pattern_binding']
 === Pattern Binding
 
 Patterns can be bound to a matching object. This is accomplished using a pattern binding variable such as `$p`.
 
-[[_pattern_binding_with_variable_example]]
+[id='_pattern_binding_with_variable_example']
 === Pattern Binding with Variable Example
 
 This is what pattern binding using a variable looks like:
@@ -1587,15 +1587,15 @@ end
 
 NOTE: The prefixed dollar symbol (`$`) is not mandatory.
 
-[[_constraints1]]
+[id='_constraints1']
 === Constraints
 
 A constraint is an expression that returns `true` or `false`. For example, you can have a constraint that states "_five is smaller than six_".
 
-[[_sect_elements_and_variables]]
+[id='_sect_elements_and_variables']
 == Elements and Variables
 
-[[_property_access_on_java_beans_pojos]]
+[id='_property_access_on_java_beans_pojos']
 === Property Access on Java Beans (POJOs)
 
 Any bean property can be used directly. A bean property is exposed using a standard Java bean getter: a method `getMyProperty()` (or `isMyProperty()` for a primitive boolean) which takes no arguments and return something.
@@ -1604,7 +1604,7 @@ Red Hat JBoss BRMS uses the standard JDK `Introspector` class to do this mapping
 
 WARNING: Property accessors must not change the state of the object in a way that may effect the rules. The rule engine effectively caches the results of its matching in between invocations to make it faster.
 
-[[_pojo_example]]
+[id='_pojo_example']
 === POJO Example
 
 This is what the bean property looks like:
@@ -1623,7 +1623,7 @@ The age property is written as `age` in DRL instead of the getter `getAge()`.
 Property accessors::
 You can use property access (`age`) instead of getters explicitly (`getAge()`) because of performance enhancements through field indexing.
 
-[[_working_with_pojos]]
+[id='_working_with_pojos']
 === Working with POJOs
 
 .Procedure: Task
@@ -1641,12 +1641,12 @@ public int getAge() {
 . To solve this, insert a fact that wraps the current date into working memory and update that fact between `fireAllRules` as needed.
 
 
-[[_pojo_fallbacks]]
+[id='_pojo_fallbacks']
 === POJO Fallbacks
 
 When working with POJOs, a fallback method is applied. If the getter of a property cannot be found, the compiler will resort to using the property name as a method name and without arguments. Nested properties are also indexed.
 
-[[_fallback_example]]
+[id='_fallback_example']
 === Fallback Example
 
 This is what happens when a fallback is implemented:
@@ -1671,7 +1671,7 @@ Person(getAddress().getHouseNumber() == 50)
 
 WARNING: In a stateful session, care should be taken when using nested accessors as the Working Memory is not aware of any of the nested values and does not know when they change. Consider them immutable while any of their parent references are inserted into the Working Memory. If you wish to modify a nested value you should mark all of the outer facts as updated. In the above example, when the `houseNumber` changes, any `Person` with that `Address` must be marked as updated.
 
-[[_java_expressions]]
+[id='_java_expressions']
 === Java Expressions
 
 .Java Expressions
@@ -1744,14 +1744,14 @@ Person(firstName != "John")
 ----
 ====
 
-[[_comma_separated_operators]]
+[id='_comma_separated_operators']
 === Comma-Separated Operators
 
 The comma character (`,`) is used to separate constraint groups. It has implicit and connective semantics.
 
 The comma operator is used at the top-level constraint as it makes them easier to read and the engine will be able to optimize them.
 
-[[_comma_separated_operator_example]]
+[id='_comma_separated_operator_example']
 === Comma-Separated Operator Example
 
 The following illustrates comma-separated scenarios in implicit and connective semantics:
@@ -1770,12 +1770,12 @@ Person(age > 50, weight > 80, height > 2)
 
 NOTE: The comma (`,`) operator cannot be embedded in a composite constraint expression, such as parentheses.
 
-[[_binding_variables]]
+[id='_binding_variables']
 === Binding Variables
 
 You can bind properties to variables in Red Hat JBoss BRMS. It allows for faster execution and performance.
 
-[[_binding_variable_examples]]
+[id='_binding_variable_examples']
 === Binding Variable Examples
 
 This is an example of a property bound to a variable:
@@ -1804,12 +1804,12 @@ Person(age * 2 < 100, $age : age)
 ----
 ====
 
-[[_unification]]
+[id='_unification']
 === Unification
 
 You can _unify_ arguments across several properties. While positional arguments are always processed with unification, the unification symbol, `:=`, exists for named arguments.
 
-[[_unification_example]]
+[id='_unification_example']
 === Unification Example
 
 This is what unifying two arguments looks like:
@@ -1820,7 +1820,7 @@ Person($age := age)
 Person($age := age)
 ----
 
-[[_options_and_operators_in_jboss_rules]]
+[id='_options_and_operators_in_jboss_rules']
 === Options and Operators in Red Hat JBoss BRMS
 
 
@@ -1982,7 +1982,7 @@ Person(eval(age == girlAge + 2), sex = 'M') // eval() is actually obsolete in th
 ----
 
 
-[[_operator_precedence]]
+[id='_operator_precedence']
 === Operator Precedence
 
 .Operator Precedence
@@ -2055,14 +2055,14 @@ Person(eval(age == girlAge + 2), sex = 'M') // eval() is actually obsolete in th
 
 |===
 
-[[_fine_grained_property_change_listeners]]
+[id='_fine_grained_property_change_listeners']
 === Fine Grained Property Change Listeners
 
 This feature allows the pattern matching to only react to modification of properties actually constrained or bound inside of a given pattern. This helps with performance and recursion and avoid artificial object splitting.
 
 NOTE: By default this feature is off in order to make the behavior of the rule engine backward compatible with the former releases. When you want to activate it on a specific bean you have to annotate it with `@propertyReactive`.
 
-[[_fine_grained_property_change_listener_example]]
+[id='_fine_grained_property_change_listener_example']
 === Fine Grained Property Change Listener Example
 
 DRL example::
@@ -2085,17 +2085,17 @@ Java class example::
  private String lastName;
   }
 ----
-[[_working_with_fine_grained_property_change_listeners]]
+[id='_working_with_fine_grained_property_change_listeners']
 === Working with Fine Grained Property Change Listeners
 
 Using these listeners means you do not need to implement the no-loop attribute to avoid an infinite recursion. The engine recognizes that the pattern matching is done on the property while the RHS of the rule modifies other the properties. On Java classes, you can also annotate any method to say that its invocation actually modifies other properties.
 
-[[_using_patterns_with_watch]]
+[id='_using_patterns_with_watch']
 === Using Patterns with @watch
 
 Annotating a pattern with `@watch` allows you to modify the inferred set of properties for which that pattern will react. The properties named in the `@watch` annotation are added to the ones automatically inferred. You can explicitly exclude one or more of them by beginning their name with a `!` and to make the pattern to listen for all or none of the properties of the type used in the pattern respectively with the wildcards `\*` and `!*`.
 
-[[_watch_example]]
+[id='_watch_example']
 === @watch Example
 
 This is the `@watch` annotation in a rule's LHS:
@@ -2117,7 +2117,7 @@ Person(firstName == $expectedFirstName) @watch(*, !age)
 
 NOTE: Since it does not make sense to use this annotation on a pattern using a type not annotated with `@PropertyReactive` the rule compiler will raise a compilation error if you try to do so. Also the duplicated usage of the same property in `@watch` (for example like in: `@watch(firstName, ! firstName))` will end up in a compilation error.
 
-[[_using_propertyspecificoption]]
+[id='_using_propertyspecificoption']
 === Using @PropertySpecificOption
 
 You can enable `@watch` by default or completely disallow it using the `on` option of the `KnowledgeBuilderConfiguration`. This new `PropertySpecificOption` can have one of the following 3 values:
@@ -2137,7 +2137,7 @@ Alternatively, you can use the `drools.propertySpecific` system property. For ex
 </system-properties>
 ----
 
-[[_basic_conditional_elements]]
+[id='_basic_conditional_elements']
 === Basic Conditional Elements
 
 and::
@@ -2244,14 +2244,14 @@ exists (Bus(color == "red") and
 
 NOTE: The behavior of the Conditional Element `or` is different from the connective `||` for constraints and restrictions in field constraints. The engine cannot interpret the Conditional Element `or`. Instead, a rule with `or` is rewritten as a number of subrules. This process ultimately results in a rule that has a single `or` as the root node and one subrule for each of its CEs. Each subrule can activate and fire like any normal rule; there is no special behavior or interaction between these subrules.
 
-[[_the_conditional_element_forall]]
+[id='_the_conditional_element_forall']
 === Conditional Element forall
 
 This element evaluates to true when all facts that match the first pattern match all the remaining patterns. It is a _scope delimiter_. Therefore, it can use any previously bound variable, but no variable bound inside it will be available for use outside of it.
 
 `forall` can be nested inside other CEs. For instance, `forall` can be used inside a `not` CE. Only single patterns have optional parentheses, so with a nested `forall` parentheses must be used.
 
-[[_forall_examples]]
+[id='_forall_examples']
 === forall Examples
 
 Evaluating to true::
@@ -2307,7 +2307,7 @@ then
 end
 ----
 
-[[_the_conditional_element_from]]
+[id='_the_conditional_element_from']
 === Conditional Element from
 
 The conditional element `from` enables users to specify an arbitrary source for data to be matched by LHS patterns. This allows the engine to reason over data not in the Working Memory. The data source could be a sub-field on a bound variable or the results of a method call. It is a powerful construction that allows out of the box integration with other application components and frameworks. One common example is the integration with data retrieved on-demand from databases using hibernate named queries.
@@ -2325,7 +2325,7 @@ There are several ways to address this issue:
 * Avoid the use of `lock-on-active` when you can explicitly manage how rules within the same rule-flow group place activations on one another.
 ====
 
-[[_from_examples]]
+[id='_from_examples']
 === from Examples
 
 Reasoning and binding on patterns::
@@ -2390,7 +2390,7 @@ then
 end
 ----
 
-[[_the_conditional_element_collect]]
+[id='_the_conditional_element_collect']
 === Conditional Element collect
 
 The conditional element `collect` allows rules to reason over a collection of objects obtained from the given source or from the working memory. In First Oder Logic terms this is the cardinality quantifier.
@@ -2399,7 +2399,7 @@ The result pattern of `collect` can be any concrete class that implements the `j
 
 Variables bound before the `collect` CE are in the scope of both source and result patterns and therefore you can use them to constrain both your source and result patterns. Any binding made inside `collect` is not available for use outside of it.
 
-[[_the_conditional_element_accumulate]]
+[id='_the_conditional_element_accumulate']
 === Conditional Element accumulate
 
 The conditional element `accumulate` is a more flexible and powerful form of the `collect` element and allows a rule to iterate over a collection of objects while executing custom actions for each of the elements. The `accumulate` element returns a result object.
@@ -2709,14 +2709,14 @@ end
 ----
 ====
 
-[[_conditional_element_eval]]
+[id='_conditional_element_eval']
 === Conditional Element eval
 
 The conditional element `eval` is essentially a catch-all which allows any semantic code (that returns a primitive boolean) to be executed. This code can refer to variables that were bound in the LHS of the rule, and functions in the rule package. Overuse of eval reduces the declarativeness of your rules and can result in a poorly performing engine. While `eval` can be used anywhere in the patterns, the best practice is to add it as the last conditional element in the LHS of a rule.
 
 Evals cannot be indexed and thus are not as efficient as field constraints. However this makes them ideal for being used when functions return values that change over time, which is not allowed within field constraints.
 
-[[_conditional_element_eval_examples]]
+[id='_conditional_element_eval_examples']
 === eval Conditional Element Examples
 
 This is what `eval` looks like in use:
@@ -2736,14 +2736,14 @@ p2 : Parameter()
 eval(isValid( p1, p2))
 ----
 
-[[_the_right_hand_side]]
+[id='_the_right_hand_side']
 === Right Hand Side
 
 The Right Hand Side (RHS) is a common name for the consequence part of a rule. The main purpose of the RHS is to insert, retract (delete), or modify working memory data. The RHS usually contains a list of actions to be executed and should be kept small, thus keeping it declarative and readable.
 
 NOTE: In case you need imperative or conditional code in the RHS, divide the rule into more rules.
 
-[[_rhs_convenience_methods]]
+[id='_rhs_convenience_methods']
 === RHS Convenience Methods
 
 See the following list of the RHS convenience methods:
@@ -2756,7 +2756,7 @@ See the following list of the RHS convenience methods:
 
 For more information, see <<_rule_files_accessing_the_working_memory>>.
 
-[[_convenience_methods_using_the_drools_variable]]
+[id='_convenience_methods_using_the_drools_variable']
 === Convenience Methods Using Drools Variable
 
 * The call `drools.halt()` terminates rule execution immediately. This is required for returning control to the point whence the current session was put to work with `fireUntilHalt()`.
@@ -2767,7 +2767,7 @@ For more information, see <<_rule_files_accessing_the_working_memory>>.
 * `drools.getTuple()` returns the Tuple that matches the currently executing rule, and `drools.getActivation()` delivers the corresponding Activation. (These calls are useful for logging and debugging purposes.)
 
 
-[[_convenience_methods_using_the_kcontext_variable]]
+[id='_convenience_methods_using_the_kcontext_variable']
 === Convenience Methods Using kcontext Variable
 
 * The call `kcontext.getKieRuntime().halt()` terminates rule execution immediately.
@@ -2789,7 +2789,7 @@ You can achieve the same using `drools.setFocus("CleanUp")`.
 * Method `getEnvironment()` returns the runtime's `Environment`.
 
 
-[[_the_modify_statement]]
+[id='_the_modify_statement']
 === Modify Statement
 
 modify::
@@ -2819,7 +2819,7 @@ end
 ----
 
 
-[[_query_examples]]
+[id='_query_examples']
 === Query Examples
 
 NOTE: To return the results use `ksession.getQueryResults("name")`, where `"name"` is the query's name. This returns a list of query results, which allow you to retrieve the objects that matched the query.
@@ -2842,7 +2842,7 @@ query "People over the age of x"  (int x, String y)
 end
 ----
 
-[[_queryresults_example]]
+[id='_queryresults_example']
 === QueryResults Example
 
 We iterate over the returned `QueryResults` using a standard `for` loop. Each element is a `QueryResultsRow` which we can use to access each of the columns in the tuple. These columns can be accessed by bound declaration name or index position:
@@ -2860,14 +2860,14 @@ for (QueryResultsRow row : results) {
 }
 ----
 
-[[_queries_calling_other_queries]]
+[id='_queries_calling_other_queries']
 === Queries Calling Other Queries
 
 Queries can call other queries. This combined with optional query arguments provides derivation query style backward chaining. Positional and named syntax is supported for arguments. It is also possible to mix both positional and named, but positional must come first, separated by a semi colon. Literal expressions can be passed as query arguments, but you cannot mix expressions with variables.
 
 NOTE: Using the `?` symbol in this process means the query is pull only and once the results are returned you will not receive further results as the underlying data changes.
 
-[[_queries_calling_other_queries_example]]
+[id='_queries_calling_other_queries_example']
 === Queries Calling Other Queries Example
 
 Query calling another query::
@@ -2904,17 +2904,17 @@ then
 end
 ----
 
-[[_unification_for_derivation_queries]]
+[id='_unification_for_derivation_queries']
 === Unification for Derivation Queries
 
 Red Hat JBoss BRMS supports unification for derivation queries. This means that arguments are optional. It is possible to call queries from Java leaving arguments unspecified using the static field `org.drools.runtime.rule.Variable.v`. You must use `v` and not an alternative instance of `Variable`. These are referred to as `out` arguments.
 
 NOTE: The query itself does not declare at compile time whether an argument is in or an out. This can be defined purely at runtime on each use.
 
-[[_sect_searching_the_working_memory_using_query]]
+[id='_sect_searching_the_working_memory_using_query']
 == Searching Working Memory Using Query
 
-[[_queries]]
+[id='_queries']
 === Queries
 
 _Queries_ are used to retrieve fact sets based on patterns, as they are used in rules. Patterns may make use of optional parameters. Queries can be defined in the Knowledge Base, from where they are called up to return the matching results. While iterating over the result collection, any identifier bound in the query can be used to access the corresponding fact or fact field by calling the `get` method with the binding variable's name as its argument. If the binding refers to a fact object, its FactHandle can be retrieved by calling `getFactHandle`, again with the variable's name as the parameter. Illustrated below is a query example:
@@ -2927,14 +2927,14 @@ for (QueryResultsRow row : results) {
 }
 ----
 
-[[_live_queries]]
+[id='_live_queries']
 === Live Queries
 
 Invoking queries and processing the results by iterating over the returned set is not a good way to monitor changes over time.
 
 To alleviate this, Red Hat JBoss BRMS provides live queries, which have a listener attached instead of returning an iterable result set. These live queries stay open by creating a view and publishing change events for the contents of this view. To activate, start your query with parameters and listen to changes in the resulting view. The `dispose` method terminates the query and discontinues this reactive scenario.
 
-[[_viewchangedeventlistener_implementation_example]]
+[id='_viewchangedeventlistener_implementation_example']
 === ViewChangedEventListener Implementation Example
 
 [source,java]
@@ -2965,26 +2965,26 @@ query.dispose() // calling dispose to terminate the live query
 
 NOTE: For an example of Glazed Lists integration for live queries, read the http://blog.athico.com/2010/07/glazed-lists-examples-for-drools-live.html[Glazed Lists examples for Drools Live Querries] article.
 
-[[_sect_domain_specific_languages_dsls]]
+[id='_sect_domain_specific_languages_dsls']
 == Domain Specific Languages (DSLs)
 
 _Domain Specific Languages_ (or DSLs) are a way of creating a rule language that is dedicated to your problem domain. A set of DSL definitions consists of transformations from DSL "sentences" to DRL constructs, which lets you use of all the underlying rule language and engine features. You can write rules in DSL rule (or DSLR) files, which will be translated into DRL files.
 
 DSL and DSLR files are plain text files and you can use any text editor to create and modify them. There are also DSL and DSLR editors you can use, both in the IDE as well as in the web based BRMS, although they may not provide you with the full DSL functionality.
 
-[[_the_dsl_editor]]
+[id='_the_dsl_editor']
 === DSL Editor
 
 The DSL editor provides a tabular view of the mapping of Language to Rule Expressions. The Language Expression feeds the content assistance for the rule editor so that it can suggest Language Expressions from the DSL configuration. The rule editor loads the DSL configuration when the rule resource is loaded for editing.
 
 NOTE: DSL feature is useful for simple use cases for non technical users to easily define rules based on sentence snippets. For more complex use cases, we recommend you to use other advanced features like decision tables and DRL rules, that are more expressive and flexible.
 
-[[_using_dsls]]
+[id='_using_dsls']
 === Using DSLs
 
 DSLs can serve as a layer of separation between rule authoring (and rule authors) and the technical intricacies resulting from the modeling of domain object and the rule engine's native language and methods. A DSL hides implementation details and focuses on the rule logic proper. DSL sentences can also act as "templates" for conditional elements and consequence actions that are used repeatedly in your rules, possibly with minor variations. You may define DSL sentences as being mapped to these repeated phrases, with parameters providing a means for accommodating those variations.
 
-[[_dsl_example]]
+[id='_dsl_example']
 === DSL Example
 
 
@@ -2999,7 +2999,7 @@ The part after the bracketed keyword is the expression that you use in the rule.
 
 The part to the right of the equal sign (`=`) is the mapping of the expression into the rule language. The form of this string depends on its destination, RHS or LHS. If it is for the LHS, then it ought to be a term according to the regular LHS syntax; if it is for the RHS then it might be a Java statement.
 
-[[_how_the_dsl_parser_works]]
+[id='_how_the_dsl_parser_works']
 === About DSL Parser
 
 Whenever the DSL parser matches a line from the rule file written in the DSL with an expression in the DSL definition, it performs three steps of string manipulation:
@@ -3010,12 +3010,12 @@ Whenever the DSL parser matches a line from the rule file written in the DSL wit
 
 NOTE: You can use (for instance) a `?` to indicate that the preceding character is optional. One good reason to use this is to overcome variations in natural language phrases of your DSL. But, given that these expressions are regular expression patterns, this means that all wildcard characters in Java's pattern syntax have to be escaped with a preceding backslash (`\`).
 
-[[_the_dsl_compiler]]
+[id='_the_dsl_compiler']
 === About DSL Compiler
 
 The DSL compiler transforms DSL rule files line by line. If you do not wish for this to occur, ensure that the captures are surrounded by characteristic text (words or single characters). As a result, the matching operation done by the parser plucks out a substring from somewhere within the line. In the example below, quotes are used as distinctive characters. The characters that surround the capture are not included during interpolation, just the contents between them.
 
-[[_dsl_syntax_examples]]
+[id='_dsl_syntax_examples']
 === DSL Syntax Examples
 
 
@@ -3063,12 +3063,12 @@ There is a person with name of "Bob" and Person is at least 30 years old and liv
 
 NOTE: If you are capturing plain text from a DSL rule line and want to use it as a string literal in the expansion, you must provide the quotes on the right hand side of the mapping.
 
-[[_chaining_dsl_expressions]]
+[id='_chaining_dsl_expressions']
 === Chaining DSL Expressions
 
 DSL expressions can be chained together one one line to be used at once. It must be clear where one ends and the next one begins and where the text representing a parameter ends. Otherwise you risk getting all the text until the end of the line as a parameter value. The DSL expressions are tried, one after the other, according to their order in the DSL definition file. After any match, all remaining DSL expressions are investigated, too.
 
-[[_adding_constraints_to_facts]]
+[id='_adding_constraints_to_facts']
 === Adding Constraints to Facts
 
 Expressing LHS conditions::
@@ -3141,7 +3141,7 @@ Cheese(age<42, rating > 50, type=='stilton')
 
 NOTE: The order of the entries in the DSL is important if separate DSL expressions are intended to match the same line, one after the other.
 
-[[_tips_for_developing_dsls]]
+[id='_tips_for_developing_dsls']
 === Tips for Developing DSLs
 
 * Write representative samples of the rules your application requires and test them as you develop.
@@ -3153,7 +3153,7 @@ NOTE: The order of the entries in the DSL is important if separate DSL expressio
 * Keep the number of DSL entries small. Using parameters lets you apply the same DSL sentence for similar rule patterns or constraints.
 
 
-[[_dsl_and_dslr_reference]]
+[id='_dsl_and_dslr_reference']
 === DSL and DSLR Reference
 
 A DSL file is a text file in a line-oriented format. Its entries are used for transforming a DSLR file into a file according to DRL syntax:
@@ -3162,7 +3162,7 @@ A DSL file is a text file in a line-oriented format. Its entries are used for tr
 * Any line starting with an opening bracket (`[`) is assumed to be the first line of a DSL entry definition.
 * Any other line is appended to the preceding DSL entry definition, with the line end replaced by a space.
 
-[[_the_make_up_of_a_dsl_entry]]
+[id='_the_make_up_of_a_dsl_entry']
 === DSL Entry Description
 
 A DSL entry consists of the following four parts:
@@ -3179,7 +3179,7 @@ Note that all characters that are "magic" in regular expressions must be escaped
 +
 Note that braces (`{` and `}`) must be escaped with a preceding backslash (`\`) if they should occur literally within the replacement string.
 
-[[_debug_options_for_dsl_expansion]]
+[id='_debug_options_for_dsl_expansion']
 === Debug Options for DSL Expansion
 
 .Debug Options for DSL Expansion
@@ -3207,7 +3207,7 @@ Note that braces (`{` and `}`) must be escaped with a preceding backslash (`\`) 
 |Displays a usage statistic of all DSL entries.
 |===
 
-[[_dsl_definition_example]]
+[id='_dsl_definition_example']
 === DSL Definition Example
 
 This is what a DSL definition looks like:
@@ -3228,7 +3228,7 @@ This is what a DSL definition looks like:
 [then][]update {entity:\w+}=modify(${entity!lc})\{ \}
 ----
 
-[[_transformation_of_a_dslr_file]]
+[id='_transformation_of_a_dslr_file']
 === Transformation of DSLR File
 
 The transformation of a DSLR file proceeds as follows:
@@ -3251,7 +3251,7 @@ If a DSLR line in a consequence is written with a leading hyphen, the expanded r
 
 NOTE: It is currently _not_ possible to use a line with a leading hyphen to insert text into other conditional element forms (for example `accumulate`) or it may only work for the first insertion (for example `eval`).
 
-[[_string_transformation_functions]]
+[id='_string_transformation_functions']
 === String Transformation Functions
 
 .String Transformation Functions
@@ -3277,7 +3277,7 @@ NOTE: It is currently _not_ possible to use a line with a leading hyphen to inse
 |Compares the string with string `a`, and if they are equal, replaces it with `b`, otherwise with `c`. But `c` can be another triplet `a`, `b`, `c`, so that the entire structure is, in fact, a translation table.
 |===
 
-[[_stringing_dsl_transformation_functions]]
+[id='_stringing_dsl_transformation_functions']
 === Stringing DSL Transformation Functions
 
 {empty}.dsl::

--- a/docs/product-getting-started-guide/src/main/asciidoc/task_business-process.adoc
+++ b/docs/product-getting-started-guide/src/main/asciidoc/task_business-process.adoc
@@ -1,4 +1,4 @@
-[[_modeling_a_business_process]]
+[id='_modeling_a_business_process']
 = Modeling a Business Process
 
 The following chapter instructs you how to create a business process in {PRODUCT}.

--- a/docs/product-getting-started-guide/src/main/asciidoc/task_business-rules.adoc
+++ b/docs/product-getting-started-guide/src/main/asciidoc/task_business-rules.adoc
@@ -1,4 +1,4 @@
-[[_defining_business_rules]]
+[id='_defining_business_rules']
 = Defining Business Rules
 
 The following chapter instructs you how to create business rules in {PRODUCT} using:

--- a/docs/product-getting-started-guide/src/main/asciidoc/task_data-model.adoc
+++ b/docs/product-getting-started-guide/src/main/asciidoc/task_data-model.adoc
@@ -1,4 +1,4 @@
-[[_defining_a_data_model]]
+[id='_defining_a_data_model']
 = Defining a Data Model
 
 The following chapter instructs you how to create a data model in {PRODUCT}.

--- a/docs/product-getting-started-guide/src/main/asciidoc/task_new-project.adoc
+++ b/docs/product-getting-started-guide/src/main/asciidoc/task_new-project.adoc
@@ -1,4 +1,4 @@
-[[_importing_a_getting_started_business_project]]
+[id='_importing_a_getting_started_business_project']
 = Importing a Getting Started Business Project
 
 The following chapter instructs you how to import an incomplete business process application. You will extend the application in later chapters.

--- a/docs/product-getting-started-guide/src/main/asciidoc/task_process-forms.adoc
+++ b/docs/product-getting-started-guide/src/main/asciidoc/task_process-forms.adoc
@@ -1,4 +1,4 @@
-[[_creating_forms]]
+[id='_creating_forms']
 = Creating Forms
 
 The following chapter instructs you how to create forms for your business process in {PRODUCT}.
@@ -90,7 +90,7 @@ image::applicantForm.png[]
 . Click *Save*, then *Save*, to confirm your changes.
 . Click on the *X* in the upper-right corner to close the editor.
 
-[[_editing_data_object_forms]]
+[id='_editing_data_object_forms']
 == Editing Data Object Forms
 
 The business process uses three data objects:
@@ -132,7 +132,7 @@ image::propertyForm.png[]
 .. Click *Save*, then click *Save* to confirm your changes.
 .. Click the *process-app-start* label to return to the *Assets* view of the project.
 
-[[_editing_business_process_forms]]
+[id='_editing_business_process_forms']
 == Editing Business Process Forms
 
 The `MortgageApprovalProcess` business process requires the following process task forms:

--- a/docs/product-ibm-websphere-installation-and-configuration-guide/src/main/asciidoc/chap-configure.adoc
+++ b/docs/product-ibm-websphere-installation-and-configuration-guide/src/main/asciidoc/chap-configure.adoc
@@ -1,4 +1,4 @@
-[[_chap_configure]]
+[id='_chap_configure']
 = Configure
 
 Before you can deploy {PRODUCT} as a web archive on IBM WebSphere Application Server, configure the server to accept the deployable WAR files. Follow the steps outlined in this section to deploy {PRODUCT} on IBM WebSphere Application Server.
@@ -40,7 +40,7 @@ image::process_definition3.png[]
 image::messages_popup.png[]
 . Restart the server at this point or wait till other configuration changes have been made.
 
-[[_modify_security_settings]]
+[id='_modify_security_settings']
 == Modifying Security Settings
 
 For the Business Central application to work, you need to modify several security settings on IBM WebSphere Application Server. To enable the container-managed authentication mechanisms provided by the server:
@@ -59,7 +59,7 @@ This property instructs the server to invalidate LTPA tokens on session invalida
 
 . Click *Apply* and then *OK*.
 
-[[_create_users_and_groups]]
+[id='_create_users_and_groups']
 == Creating Users and Groups
 
 ifdef::BPMS[]
@@ -124,7 +124,7 @@ You may assign this user to any of the groups you have just created. In the prod
 * *Value*: `true`
 . Click *Apply* and then *OK*.
 
-[[_setup_datasource]]
+[id='_setup_datasource']
 == Setting up Data Source
 
 The Business Central application requires a data source which must be created prior to the deployment of the actual WAR file. This means that you must have access to an underlying database to which the data source connects. Whatever your underlying database, make sure you have the data source ready. Follow the steps below to set the data source.
@@ -246,7 +246,7 @@ Once all the connection properties have been defined, click *Test Connection* to
 The test connection operation for data source DATA_SOURCE_NAME on server SERVER_NAME at node NODE_NAME was successful.
 ----
 
-[[_setting_up_jms_resources]]
+[id='_setting_up_jms_resources']
 == Setting up JMS Resources
 
 IBM WebSphere Application Server must be configured to send and receive JMS messages through {PRODUCT}. However, before you do this, a service bus must be present. Follow the steps below to create a service bus if one does not already exist.
@@ -421,7 +421,7 @@ endif::BRMS[]
 
 You have now successfully completed the JMS configurations required for setting up {PRODUCT} on IBM WebSphere Application Server.
 
-[[_add_custom_jvm_properties]]
+[id='_add_custom_jvm_properties']
 == Adding Custom JVM Properties
 
 You must add custom properties to the JVM that is used to start IBM WebSphere Application Server. These custom properties take into consideration the configuration changes that have been outlined in previous sections of this guide.

--- a/docs/product-ibm-websphere-installation-and-configuration-guide/src/main/asciidoc/chap-download-and-extract.adoc
+++ b/docs/product-ibm-websphere-installation-and-configuration-guide/src/main/asciidoc/chap-download-and-extract.adoc
@@ -1,9 +1,9 @@
-[[_chap_download_and_extract]]
+[id='_chap_download_and_extract']
 = Download and Extract
 
 Follow the steps outlined in this chapter to download and extract {PRODUCT} for IBM WebSphere Application Server.
 
-[[_download_red_hat_jboss_bpm_suitebrms_for_ibm_websphere_8]]
+[id='_download_red_hat_jboss_bpm_suitebrms_for_ibm_websphere_8']
 == Downloading {PRODUCT} for IBM WebSphere Application Server
 
 To download the deployable {PRODUCT} package file for IBM WebSphere Application Server from the Red Hat Customer Portal:
@@ -14,7 +14,7 @@ To download the deployable {PRODUCT} package file for IBM WebSphere Application 
 . From the *Version* drop-down menu, select *{PRODUCT_VERSION}*.
 . Navigate to *{PRODUCT} {PRODUCT_VERSION}.0 Deployable for WebSphere 8.5* and click *Download*.
 
-[[_extract_product_for_ibm_websphere_8]]
+[id='_extract_product_for_ibm_websphere_8']
 == Extracting {PRODUCT} for IBM WebSphere Application Server
 
 ifdef::BPMS[]

--- a/docs/product-ibm-websphere-installation-and-configuration-guide/src/main/asciidoc/chap-install-red-hat-jboss-bpm-suite-on-ibm-websphere-8.adoc
+++ b/docs/product-ibm-websphere-installation-and-configuration-guide/src/main/asciidoc/chap-install-red-hat-jboss-bpm-suite-on-ibm-websphere-8.adoc
@@ -1,4 +1,4 @@
-[[_chap_installation_on_ibm_websphere_8]]
+[id='_chap_installation_on_ibm_websphere_8']
 = Install
 :doctype: book
 :sectnums:
@@ -17,7 +17,7 @@ ifdef::BRMS[]
 both Business Central and {KIE_SERVER}.
 endif::BRMS[]
 
-[[_installing_business_central]]
+[id='_installing_business_central']
 == Installing Business Central
 
 Business Central is uploaded as a web archive and can then be accessed at `http://_TARGET_SERVER:PORT_/business-central`. Start the deployment by installing the Business Central WAR as a WebSphere application.
@@ -159,7 +159,7 @@ To start the application, go back to *Applications* -> *Application Types* -> *W
 To access the application, navigate to `http://_TARGET_SERVER:PORT_/business-central` in your web browser.
 
 ifdef::BPMS[]
-[[_installing_dashbuilder]]
+[id='_installing_dashbuilder']
 == Installing Dashbuilder
 
 Dashbuilder for IBM WebSphere Application Server is distributed as a deployable WAR file (`dashbuilder.war`) as a part of the Red Hat JBoss BPM Suite download.
@@ -245,7 +245,7 @@ To start the application, go back to *Applications* -> *Application Types* -> *W
 You can now log in to Dashbuilder at `http://_TARGET_SERVER:PORT_/dashbuilder` using the user that you have created in the previous steps.
 endif::BPMS[]
 
-[[_install_the_realtime_decision_server]]
+[id='_install_the_realtime_decision_server']
 == Installing {KIE_SERVER}
 
 The {KIE_SERVER} is distributed as a web application archive file (`kie-execution-server.war`) and is present in your {PRODUCT} {PRODUCT_VERSION}.0 Deployable for WebSphere 8.5 download.

--- a/docs/product-ibm-websphere-installation-and-configuration-guide/src/main/asciidoc/chap-introduction.adoc
+++ b/docs/product-ibm-websphere-installation-and-configuration-guide/src/main/asciidoc/chap-introduction.adoc
@@ -1,7 +1,7 @@
-[[_chap_introduction]]
+[id='_chap_introduction']
 = Introduction
 
-[[_jboss_brms]]
+[id='_jboss_brms']
 == About {PRODUCT}
 
 ifdef::BPMS[]
@@ -26,7 +26,7 @@ endif::BPMS[]
 
 {PRODUCT} is supported for use with Red Hat Enterprise Linux 7 (RHEL7).
 
-[[_supported_platforms]]
+[id='_supported_platforms']
 == Supported Platforms
 
 Red Hat JBoss BPM Suite and Red Hat JBoss BRMS are fully supported and tested on the following platforms:
@@ -38,7 +38,7 @@ Red Hat JBoss BPM Suite and Red Hat JBoss BRMS are fully supported and tested on
 * Red Hat JBoss Fuse 6.2._x_
 
 ifdef::BPMS[]
-[[_use_cases1]]
+[id='_use_cases1']
 == Use Case: Process­-Based Solutions in Loan Industry
 
 This section describes a use case of deploying Red Hat JBoss BPM Suite to automate business processes (such as loan approval process) at a retail bank. This use case is a typical process-based specific deployment that might be the first step in a wider adoption of Red Hat JBoss BPM Suite throughout an enterprise. It leverages features of both business rules and processes of Red Hat JBoss BPM Suite.
@@ -60,7 +60,7 @@ image::ibm-websphere-installation-and-configuration-guide-3443.png[]
 The entire loan process and rules can be modified at any time by the bank's business analysts. The bank is able to maintain constant compliance with changing regulations, and is able to quickly introduce new loan products and improve loan policies in order to compete effectively and drive profitability.
 endif::BPMS[]
 
-[[about_ibm_websphere_as]]
+[id='about_ibm_websphere_as']
 == About IBM WebSphere Application Server
 
 IBM WebSphere Application Server (hereinafter referred to as WAS) is a flexible and secure web application server that hosts Java-based web applications and provides Java EE-certified runtime environments. WAS 8.5.5 supports Java SE 8 and is fully compliant with Java EE 7 since version 8.5.5.6.
@@ -126,7 +126,7 @@ Do not forget to stop the server after you are no longer using it. Log out of th
 
 For further information, see https://www.ibm.com/support/knowledgecenter/SSEQTP_8.5.5/as_ditamaps/was855_welcome_base_dist_iseries.html[WebSphere Application Server, version 8.5.5 documentation].
 
-[[_about_red_hat_jboss_bpm_suitebrms_for_ibm_websphere_8]]
+[id='_about_red_hat_jboss_bpm_suitebrms_for_ibm_websphere_8']
 == About {PRODUCT} for IBM WebSphere Application Server
 
 ifdef::BPMS[]

--- a/docs/product-installation-guide/src/main/asciidoc/asciidoc/bxms-rn-introduction-con.adoc
+++ b/docs/product-installation-guide/src/main/asciidoc/asciidoc/bxms-rn-introduction-con.adoc
@@ -1,6 +1,6 @@
 
-[[_bxms_rn_introduction_con.adoc]]
-[[_jboss_brms]]
+[id='_bxms_rn_introduction_con.adoc']
+[id='_jboss_brms']
 = About {PRODUCT}
 
 ifdef::BPMS[]

--- a/docs/product-installation-guide/src/main/asciidoc/asciidoc/bxms-rn-whats-new-con.adoc
+++ b/docs/product-installation-guide/src/main/asciidoc/asciidoc/bxms-rn-whats-new-con.adoc
@@ -1,5 +1,5 @@
 
-[[_bxms_rn_whats_new_con.adoc]]
+[id='_bxms_rn_whats_new_con.adoc']
 = What's New
 
 This section highlights changes between releases of {PRODUCT} {PRODUCT_VERSION} Limited Availability.

--- a/docs/product-installation-guide/src/main/asciidoc/assembly_installing-on-eap.adoc
+++ b/docs/product-installation-guide/src/main/asciidoc/assembly_installing-on-eap.adoc
@@ -1,4 +1,4 @@
-[#assembly_installing_on_eap]
+[id='assembly_installing_on_eap']
 = {PRODUCT} on EAP
 
 Red Hat JBoss Enterprise Application Platform 7.0 (JBoss EAP 7) is a certified implementation of the Java Enterprise Edition 7 (Java EE 7) Full and Web profile specifications. JBoss EAP provides preconfigured options for features such as high-availability clustering, messaging, and distributed caching. It also enables users to write, deploy, and run applications using the various APIs and services that JBoss EAP provides.

--- a/docs/product-installation-guide/src/main/asciidoc/assembly_installing-on-openshift.adoc
+++ b/docs/product-installation-guide/src/main/asciidoc/assembly_installing-on-openshift.adoc
@@ -1,4 +1,4 @@
-[#openshift_bxms_con]
+[id='openshift_bxms_con']
 = {PRODUCT} on OpenShift
 
 OpenShift Container Platform is a platform as a service (PaaS) offering from Red Hat that brings together Docker and Kubernetes, and provides an API to manage these services. With OpenShift, you can create and manage containers that enable you to scale your stateless {PRODUCT} services so that you can reduce resource overheads.

--- a/docs/product-installation-guide/src/main/asciidoc/bxms-installing-con.adoc
+++ b/docs/product-installation-guide/src/main/asciidoc/bxms-installing-con.adoc
@@ -1,5 +1,5 @@
 
-[#bxms_installing_con{chapter}]
+[id='bxms_installing_con']
 [preface]
 = Introduction
 
@@ -16,4 +16,3 @@ endif::[]
 {PRODUCT} uses a centralized repository for storing all resources. This ensures consistency, transparency, and the ability to audit across the business. Business users can modify business logic and business processes without requiring assistance from IT personnel.
 
 ifdef::BPMS[To accommodate the Business Rules component, {PRODUCT} includes integrated Red Hat JBoss BRMS.]
-

--- a/docs/product-installation-guide/src/main/asciidoc/eap-execution-server-configure-proc.adoc
+++ b/docs/product-installation-guide/src/main/asciidoc/eap-execution-server-configure-proc.adoc
@@ -1,4 +1,4 @@
-[#eap_execution_server_configure_proc]
+[id='eap_execution_server_configure_proc']
 = Configuring Execution Server
 After you have installed Execution Server, you must configure it as described in this section.
 

--- a/docs/product-installation-guide/src/main/asciidoc/eap-execution-server-download-install-proc.adoc
+++ b/docs/product-installation-guide/src/main/asciidoc/eap-execution-server-download-install-proc.adoc
@@ -1,4 +1,4 @@
-[[eap_execution_server_download_install_proc]]
+[id='eap_execution_server_download_install_proc']
 
 = Downloading and Installing Execution Server
 

--- a/docs/product-installation-guide/src/main/asciidoc/openshift-bxms-con.adoc
+++ b/docs/product-installation-guide/src/main/asciidoc/openshift-bxms-con.adoc
@@ -1,4 +1,4 @@
-[#openshift_bxms_con]
+[id='openshift_bxms_con']
 = Installing on OpenShift
 OpenShift Container Platform is a platform as a service (PaaS) offering from Red Hat that brings together Docker and Kubernetes, and provides an API to manage these services. With OpenShift, you can create and manage containers that enable you to scale your stateless {PRODUCT} services so that you can reduce resource overheads.
 

--- a/docs/product-installation-guide/src/main/asciidoc/openshift-ext-repo-create-proc.adoc
+++ b/docs/product-installation-guide/src/main/asciidoc/openshift-ext-repo-create-proc.adoc
@@ -1,4 +1,4 @@
-[#openshift_ext_repo_create_proc]
+[id='openshift_ext_repo_create_proc']
 
 = Uploading the Product Image to an External Docker Registry
 The simplest way to make your product image available to OpenShift is to upload it to an external Docker registry. After you have uploaded your product image, you can use an image stream file to upload it to any OpenShift instance that you have access to.

--- a/docs/product-installation-guide/src/main/asciidoc/openshift-image-install-proc.adoc
+++ b/docs/product-installation-guide/src/main/asciidoc/openshift-image-install-proc.adoc
@@ -1,4 +1,4 @@
-[#openshift_image_install_proc]
+[id='openshift_image_install_proc']
 
 = Installing the OpenShift Product Image
 After you have uploaded your product image file to an external Docker repository or an internal OpenShift registry, you must use the OpenShift CLI to install the product image file in OpenShift.

--- a/docs/product-installation-guide/src/main/asciidoc/openshift-int-reg-create-proc.adoc
+++ b/docs/product-installation-guide/src/main/asciidoc/openshift-int-reg-create-proc.adoc
@@ -1,4 +1,4 @@
-[#openshift_int_reg_create_proc]
+[id='openshift_int_reg_create_proc']
 
 = Uploading the Product Image to the OpenShift Internal Registry
 If you do not have access to an external Docker registry, you can upload the product image directly to the OpenShift registry. However, you must upload the product image again if you want to use it in another OpenShift registry.

--- a/docs/product-installation-guide/src/main/asciidoc/openshift-temp-bpmsuite-mysql-install-proc.adoc
+++ b/docs/product-installation-guide/src/main/asciidoc/openshift-temp-bpmsuite-mysql-install-proc.adoc
@@ -1,4 +1,4 @@
-[#openshift_temp_bpmsuite_mysql_install_proc]
+[id='openshift_temp_bpmsuite_mysql_install_proc']
 
 = Using the OpenShift Application Template for {PRODUCT} and MySQL
 Use this template to install {PRODUCT} {PRODUCT_VERSION} {RELEASE} and MySQL (Ephemeral plus https) in your OpenShift project. 

--- a/docs/product-installation-guide/src/main/asciidoc/openshift-temp-bpmsuite-mysql-persistent-install-proc.adoc
+++ b/docs/product-installation-guide/src/main/asciidoc/openshift-temp-bpmsuite-mysql-persistent-install-proc.adoc
@@ -1,4 +1,4 @@
-[#openshift_temp_bpmsuite_mysql_persistent_install_proc]
+[id='openshift_temp_bpmsuite_mysql_persistent_install_proc']
 
 = Using the OpenShift Application Template for {PRODUCT} and MySQL with Persistent Storage
 Use this template to install {PRODUCT} {PRODUCT_VERSION} {RELEASE} and MySQL (Ephemeral plus https) with persistent storage in your OpenShift project. 

--- a/docs/product-installation-guide/src/main/asciidoc/openshift-temp-bpmsuite-s2i-install-proc.adoc
+++ b/docs/product-installation-guide/src/main/asciidoc/openshift-temp-bpmsuite-s2i-install-proc.adoc
@@ -1,4 +1,4 @@
-[#openshift_temp_bpmsuite_s2i_install_proc]
+[id='openshift_temp_bpmsuite_s2i_install_proc']
 
 = Using the OpenShift Application Template for {PRODUCT} with Source-to-Image
 Use this template to install {PRODUCT} {PRODUCT_VERSION} {RELEASE} with Source-to-Image (S2I) (Ephemeral plus https) in your OpenShift project. 

--- a/docs/product-installation-guide/src/main/asciidoc/openshift-temp-businesscentral-monitoring-install-proc.adoc
+++ b/docs/product-installation-guide/src/main/asciidoc/openshift-temp-businesscentral-monitoring-install-proc.adoc
@@ -1,4 +1,4 @@
-[#openshift_temp_businesscentral_monitoring_install_proc]
+[id='openshift_temp_businesscentral_monitoring_install_proc']
 
 = Using the OpenShift Application Template for Business Central Monitoring
 Use this template to install {PRODUCT} {PRODUCT_VERSION} {RELEASE} Business Central Monitoring in your OpenShift project. 

--- a/docs/product-installation-guide/src/main/asciidoc/openshift-temp-businesscentral-monitoring-smartrouter-install-proc.adoc
+++ b/docs/product-installation-guide/src/main/asciidoc/openshift-temp-businesscentral-monitoring-smartrouter-install-proc.adoc
@@ -1,4 +1,4 @@
-[#openshift_temp_businesscentral_monitoring_smart_router_install_proc]
+[id='openshift_temp_businesscentral_monitoring_smart_router_install_proc']
 
 = Using the OpenShift Application Template for Business Central Monitoring and Smart Router
 Use this template to install {PRODUCT} {PRODUCT_VERSION} {RELEASE} Business Central Monitoring and Smart Router in your OpenShift project. 

--- a/docs/product-installation-guide/src/main/asciidoc/openshift-temp-businesscentral-mysql-install-proc.adoc
+++ b/docs/product-installation-guide/src/main/asciidoc/openshift-temp-businesscentral-mysql-install-proc.adoc
@@ -1,4 +1,4 @@
-[#openshift_temp_businesscentral_mysql_install_proc]
+[id='openshift_temp_businesscentral_mysql_install_proc']
 
 = Using the OpenShift Application Template for Business Central
 Use this template to install {PRODUCT} {PRODUCT_VERSION} {RELEASE} Business Central in your OpenShift project. 

--- a/docs/product-installation-guide/src/main/asciidoc/openshift-temp-executionserver-install-proc.adoc
+++ b/docs/product-installation-guide/src/main/asciidoc/openshift-temp-executionserver-install-proc.adoc
@@ -1,4 +1,4 @@
-[#openshift_temp_executionserver_install_proc]
+[id='openshift_temp_executionserver_install_proc']
 
 = Using the OpenShift Application Template for Execution Server
 Use this template to install {PRODUCT} {PRODUCT_VERSION} {RELEASE} Execution Server in your OpenShift project. 

--- a/docs/product-installation-guide/src/main/asciidoc/openshift-temp-executionserver-postgresql-install-proc.adoc
+++ b/docs/product-installation-guide/src/main/asciidoc/openshift-temp-executionserver-postgresql-install-proc.adoc
@@ -1,4 +1,4 @@
-[#openshift_temp_executionserver_postgresql_install_proc]
+[id='openshift_temp_executionserver_postgresql_install_proc']
 
 = Using the OpenShift Application Template for Execution Server with PostgreSQL
 Use this template to install {PRODUCT} {PRODUCT_VERSION} {RELEASE} Execution Server with PostgreSQL in your OpenShift project. 

--- a/docs/product-migration-guide/src/main/asciidoc/advanced-migration.adoc
+++ b/docs/product-migration-guide/src/main/asciidoc/advanced-migration.adoc
@@ -1,9 +1,9 @@
 
-[[_chap_advanced_migration]]
+[id='_chap_advanced_migration']
 = Advanced Migration
 
 
-[[_rest_api_migration]]
+[id='_rest_api_migration']
 == REST API Migration
 
 As you know, there are two ways you can use Red Hat JBoss BRMS/{PRODUCT}: in an embedded mode, or in a remote mode.
@@ -310,7 +310,7 @@ While the basic functionality is provided by both APIs--JBoss BRMS{nbsp}5 and JB
 If in doubt, consult the corresponding documentation of the REST API.
 ====
 
-[[_knowledgeagent_to_kiescanner_migration]]
+[id='_knowledgeagent_to_kiescanner_migration']
 == KnowledgeAgent to KieScanner Migration
 
 
@@ -345,7 +345,7 @@ If you want to configure KieScanner in a way that it scans other repositories be
 
 A KCS article which discuss various scenarios and configurations is available at https://access.redhat.com/solutions/710763.
 
-[[_database_migration]]
+[id='_database_migration']
 == Database Migration
 
 

--- a/docs/product-migration-guide/src/main/asciidoc/chap-eap-migration.adoc
+++ b/docs/product-migration-guide/src/main/asciidoc/chap-eap-migration.adoc
@@ -1,4 +1,4 @@
-[[_chap_eap_migration]]
+[id='_chap_eap_migration']
 = Red Hat JBoss EAP Migration
 
 == Migrating Red Hat JBoss BPM Suite from Red Hat JBoss EAP 6.4.x to 7.0 

--- a/docs/product-migration-guide/src/main/asciidoc/chap-migrating-from-6.adoc
+++ b/docs/product-migration-guide/src/main/asciidoc/chap-migrating-from-6.adoc
@@ -1,7 +1,7 @@
-[[_chap_migrating_from_6]]
+[id='_chap_migrating_from_6']
 = Migrating from {PRODUCT} 6.x to a later version
 
-[[_migrating_to_6.4]]
+[id='_migrating_to_6.4']
 == Migrating from 6._X_ to 6.4
 
 The `org.drools.core.command.runtime.rule.ModifyCommand` API is no longer backward compatible in case you create the XML form manually and the Drools engine is using JAXB for unmarshalling. This problem does not occur when the Drools engine uses XStream for unmarshalling. Because the `FactHandle` object is marshalled differently into the XML, you need to modify the content of the `<modify>` element in your XML accordingly.
@@ -58,7 +58,7 @@ NOTE: Starting with {PRODUCT} 6.4 the default for `org.jbpm.rule.task.waitstate`
 |===
 
 
-[[_migrating_to_6.3]]
+[id='_migrating_to_6.3']
 == Migrating from 6._X_ to 6.3
 
 === Migrating Client Application APIs from 6._X_ to 6.3
@@ -106,7 +106,7 @@ There are certain measures you need to take when migrating to {PRODUCT} 6.3, dep
 |===
 
 
-[[_migrating_from_6.x_to_6.3_with_upgrade_tool]]
+[id='_migrating_from_6.x_to_6.3_with_upgrade_tool']
 === Migrating from 6._X_ to 6.3 Using Upgrade Tool
 
 [WARNING]
@@ -126,7 +126,7 @@ In case your runtime data and audit data are in separate databases in {PRODUCT},
 ====
 
 
-[[_migrating_business_central_project_repository_and_artifacts_from_6.x_to_6.3_manually]]
+[id='_migrating_business_central_project_repository_and_artifacts_from_6.x_to_6.3_manually']
 === Migrating Business Central Project, Repository, and Artifacts from 6._X_ to 6.3 Manually
 
 [NOTE]
@@ -158,7 +158,7 @@ cp -R ./ $BPM_6.3_INSTALLATION/repositories/
 ----
 
 
-[[_upgrading_db_to_6.3]]
+[id='_upgrading_db_to_6.3']
 === Upgrading the Database from 6._X_ to 6.3
 
 
@@ -170,10 +170,10 @@ Regardless of whether you chose to upgrade the {PRODUCT} distribution files manu
 If you are migrating from {PRODUCT} 6.2 to a higher version, the {KIE_SERVER} templates are automatically migrated. The controller configuration resides in the system GIT repository and is migrated automatically. However, if you are migrating from {PRODUCT} 6.1 to 6.3 or above, the container data is not automatically migrated due to the difference in controller data structure in version 6.1. To retain the container data, first upgrade to {PRODUCT} 6.2 and then to {PRODUCT} 6.3. Optionally, you can recreate the container data in your upgraded version of {PRODUCT}.
 
 
-[[_migrating_from_6.1.x_to_6.2]]
+[id='_migrating_from_6.1.x_to_6.2']
 == Migrating from 6.1._X_ to 6.2
 
-[[_migrating_client_application_apis_from_6.1.x_to_6.2]]
+[id='_migrating_client_application_apis_from_6.1.x_to_6.2']
 === Migrating Client Application APIs from 6.1._X_ to 6.2
 
 In this section, we will discuss the migration steps that are specific to migrating from {PRODUCT} 6.1._X_ to 6.2. While the majority of settings and API have remained the same, the differences are highlighted below.
@@ -203,7 +203,7 @@ org.kie.api.task.model.TaskData.getOutputContentId();
 org.kie.api.task.TaskService.addComment();
 ----
 
-[[_migrating_business_central_project_repository_and_artifacts_from_6.1.x_to_6.2]]
+[id='_migrating_business_central_project_repository_and_artifacts_from_6.1.x_to_6.2']
 === Migrating Business Central Project, Repository, and Artifacts from 6.1._X_ to 6.2
 
 
@@ -233,16 +233,16 @@ cp -R ./$BPM_6.2_INSTALLATION/repositories/
 ----
 
 
-[[_upgrading_the_database_6.1.x_to_6.2]]
+[id='_upgrading_the_database_6.1.x_to_6.2']
 === Upgrading the Database from 6.1._X_ to 6.2
 
 Ensure the database has been upgraded as documented in <<_sect_database_migration_for_6.x_instances>>.
 
 
-[[_migrating_from_6.0.x_to_6.1]]
+[id='_migrating_from_6.0.x_to_6.1']
 == Migrating from 6.0._X_ to 6.1
 
-[[_migrating_client_application_apis_from_6.0.x_to_6.1]]
+[id='_migrating_client_application_apis_from_6.0.x_to_6.1']
 === Migrating Client Application APIs from 6.0._X_ to 6.1
 
 In this section, we will discuss the migration steps that are specific to migrating from {PRODUCT} 6.0._X_ to 6.1.
@@ -427,7 +427,7 @@ If you were using the [class]``AuditLogService`` in 6.0._X_ branch, migrate that
 Method names have changed accordingly: `remoteRuntimeEngine.getAuditLogService()` should be changed to ``remoteRuntimeEngine.getAuditService()``.
 
 
-[[_migrating_business_central_project_repository_and_artifacts_from_6.0.x_to_6.1]]
+[id='_migrating_business_central_project_repository_and_artifacts_from_6.0.x_to_6.1']
 === Migrating Business Central Project, Repository and Artifacts from 6.0._X_ to 6.1
 
 Use the following procedure to move your existing {PRODUCT} 6.0._X_ Git projects (`.niogit` folder) and Maven local dependencies (`bin/repositories`) to a new {PRODUCT} 6.1 installation.
@@ -555,22 +555,22 @@ $ ./standalone.sh -Dorg.uberfire.nio.git.dir=/path/to/6.0.3/.niogit
 ----
 
 
-[[_upgrading_the_database_6.0.x_to_6.1]]
+[id='_upgrading_the_database_6.0.x_to_6.1']
 === Upgrading the Database from 6.0._X_ to 6.1
 
 Ensure that the database has been upgraded as documented in <<_sect_database_migration_for_6.x_instances>>.
 
 
-[[_sect_migrating_from_6.0.x_to_6.2]]
+[id='_sect_migrating_from_6.0.x_to_6.2']
 == Migrating from 6.0._X_ to 6.2
 
-[[_migrating_client_application_apis_from_6.0.x_to_6.2]]
+[id='_migrating_client_application_apis_from_6.0.x_to_6.2']
 === Migrating Client Application APIs from 6.0._X_ to 6.2
 
 To migrate client applications from {PRODUCT} 6.0._X_ to 6.2 the applications must incorporate all of the changes mentioned in both <<_migrating_client_application_apis_from_6.0.x_to_6.1>> and <<_migrating_client_application_apis_from_6.1.x_to_6.2>>.
 
 
-[[_migrating_business_central_project_repository_and_artifacts_from_6.0.x_to_6.2]]
+[id='_migrating_business_central_project_repository_and_artifacts_from_6.0.x_to_6.2']
 === Migrating Business Central Project, Repository, and Artifacts from 6.0._X_ to 6.2
 
 Use the following procedure to move your existing {PRODUCT} 6.0._X_ Git projects (`.niogit` folder) and Maven local dependencies (`bin/repositories`) to a new {PRODUCT} 6.2 installation.
@@ -689,13 +689,13 @@ $ ./standalone.sh -Dorg.uberfire.nio.git.dir=/path/to/6.0.3/.niogit
 ----
 
 
-[[_upgrading_the_database_6.0.x_to_6.2]]
+[id='_upgrading_the_database_6.0.x_to_6.2']
 === Upgrading the Database from 6.0._X_ to 6.2
 
 Ensure that the database has been upgraded as documented in <<_sect_database_migration_for_6.x_instances>>.
 
 
-[[_sect_database_migration_for_6.x_instances]]
+[id='_sect_database_migration_for_6.x_instances']
 == Database Migration for 6.x Instances
 
 Due to data model changes the database schema has also changed between minor versions of {PRODUCT}. A set of scripts has been included to ease this migration process; these scripts will generate the new tables and columns necessary, in addition to populating these columns where appropriate.
@@ -747,7 +747,7 @@ It is strongly recommended to backup the database before attempting any update, 
 . Start the new {PRODUCT} server.
 
 
-[[_running_processes]]
+[id='_running_processes']
 == Migrating Running Processes
 
 

--- a/docs/product-migration-guide/src/main/asciidoc/chap-migration-examples.adoc
+++ b/docs/product-migration-guide/src/main/asciidoc/chap-migration-examples.adoc
@@ -1,7 +1,7 @@
-[[_chap_migration_examples]]
+[id='_chap_migration_examples']
 = Migration Examples
 
-[[_hello_world_project_migration]]
+[id='_hello_world_project_migration']
 == Hello World Project Migration
 
 Let us start with the simplest migration example, a simple Hello World kind of process.
@@ -50,7 +50,7 @@ This is what it should look like once successfully imported.
 image::6306.png[]
 
 
-[[_cool_store_project_migration]]
+[id='_cool_store_project_migration']
 == Cool Store Project Migration
 
 The 'Hello World' scenario is a useful migration demo to get your hands dirty. Let us make it more interesting by trying on a real-life project, such as the https://github.com/jbossdemocentral/brms-coolstore-demo[Cool Store Demo by Eric Schabell] which is a reasonably complex project mimicking an online web shopping cart example.

--- a/docs/product-migration-guide/src/main/asciidoc/chap-the-migration-process.adoc
+++ b/docs/product-migration-guide/src/main/asciidoc/chap-the-migration-process.adoc
@@ -1,8 +1,8 @@
-[[_chap_the_migration_process]]
+[id='_chap_the_migration_process']
 = Migrating from JBoss Enterprise BRMS Platform 5.3.1 to {PRODUCT} 6.x
 
 
-[[_what_has_changed]]
+[id='_what_has_changed']
 == What has changed?
 
 Before starting the migration process, let us find out what exactly has changed between the 5 and 6 branches of Red Hat JBoss BRMS/{PRODUCT}.
@@ -118,7 +118,7 @@ Since the TaskService API is part of the public API you will now need to refacto
 Besides the API name change, logging is now implemented through the `org.kie.api.logger` package, which contains the factory class [class]``KieLoggers`` that can be used to create instances of the [class]``KieRuntimeLogger``.
 
 
-[[_sect_how_to_migrate]]
+[id='_sect_how_to_migrate']
 == How To Migrate
 
 Migrating your projects from {PRODUCT} 5 to {PRODUCT} 6 requires careful planning and step by step evaluation of the various issues.
@@ -208,7 +208,7 @@ To import the repository in JBoss Developer Studio, do the following
 . Import the project as a general project in the next window and click next. Name this project and click Finish.
 
 
-[[_runtime_migration]]
+[id='_runtime_migration']
 === Runtime Migration
 
 To run {PRODUCT} 5 processes in {PRODUCT} 6, do the following:
@@ -233,7 +233,7 @@ ksession.signalEvent("SomeEvent", null);
 ----
 
 
-[[_api_and_backwards_compatibility]]
+[id='_api_and_backwards_compatibility']
 === API and Backwards Compatibility
 
 [float]

--- a/docs/product-migration-guide/src/main/asciidoc/chap-why-migrate.adoc
+++ b/docs/product-migration-guide/src/main/asciidoc/chap-why-migrate.adoc
@@ -1,4 +1,4 @@
-[[_chap_why_migrate]]
+[id='_chap_why_migrate']
 = Why Migrate?
 
 

--- a/docs/product-openshift-kie-server-bpms/src/main/asciidoc/before_you_begin/before_you_begin.adoc
+++ b/docs/product-openshift-kie-server-bpms/src/main/asciidoc/before_you_begin/before_you_begin.adoc
@@ -14,7 +14,7 @@ There are several major functionality differences between the regular release of
 * Authoring of any content through the {PRODUCT} Console or API is not supported.
 * There is no support for the `Singleton` strategy for maintaining a single instance of the `RuntimeEngine`.
 
-[[Managing-OpenShift-Intelligent-Process-Server-xPaaS-Images]]
+[id='Managing-OpenShift-Intelligent-Process-Server-xPaaS-Images']
 == Managing {xpaasproduct-shortname}
 
 As {xpaasproduct-shortname} is built off EAP for OpenShift, the JBoss EAP Management CLI
@@ -36,7 +36,7 @@ $ /opt/eap/bin/jboss-cli.sh
 [WARNING]
 Any configuration changes made using the JBoss EAP Management CLI on a running container will be lost when the container restarts.
 
-[[Security-Openshift-IPS-xPaaS-Image]]
+[id='Security-Openshift-IPS-xPaaS-Image']
 = Security in {xpaasproduct-shortname}
 
 Access is limited to users with the *_kie-server_* authorization role.  A user with this role

--- a/docs/product-openshift-kie-server-bpms/src/main/asciidoc/get_started/get_started.adoc
+++ b/docs/product-openshift-kie-server-bpms/src/main/asciidoc/get_started/get_started.adoc
@@ -146,7 +146,7 @@ For example:
 KIE_CONTAINER_DEPLOYMENT=ApplicationTest=com.example.openshift:example_workflow:1.0
 ----
 
-[[ds-updating-processes]]
+[id='ds-updating-processes']
 = Updating Processes
 
 Each image is built from a snapshot of a specific Maven repository. When a new process is added, or an existing process modified, a new image must be created and deployed for the modifications to take effect.
@@ -174,7 +174,7 @@ The {KIE_SERVER} will be inactive during the Recreate update process, until the 
 [IMPORTANT]
 The https://docs.openshift.com/enterprise/3.2/dev_guide/deployments.html#rolling-strategy[Rolling Update Strategy] is not supported for {xpaasproduct-shortname}. Although multiple concurrent versions of an application are supported in a deployment, a cluster can only support valid routing to pods of the same version.
 
-[[Multiple-versions]]
+[id='Multiple-versions']
 = Multiple Concurrent Versions
 
 An application may contain multiple concurrent KIE containers of different versions. Each container has a classloader environment and a unique identifier. The unique identifier is one of either a container ID or a deployment ID, which are synonymous.
@@ -264,7 +264,7 @@ KIE_CONTAINER_DEPLOYMENT_OVERRIDE=ApplicationTest=com.example.openshift:example_
 See link:#Tutorial-Adding_Updgraded_Version[Example Workflow: Deploying an Updated Version Concurrently with Original Application] for an example on deploying an updated application alongside the older version.
 
 
-[[Request-Targeting]]
+[id='Request-Targeting']
 == Request Targeting for Multiple Versions
 
 In most cases, clients must target a particular container by name to execute server-side functions. This can be done by specifying the full deployment name, the container ID hash, or the deployment alias.
@@ -277,7 +277,7 @@ For example:
 
 Specifying either the full deployment name or the container ID targets the appropriate container. Specifying the deployment alias, which is used by all the containers in the KIE server, requires a multi-stage resolution process to target the correct version container.
 
-[[Alias-Redirection]]
+[id='Alias-Redirection']
 == Alias Redirection
 
 In a multi-version deployment, all applications share the same deployment alias. Requests that use the deployment alias of the application require a resolution process in order to redirect the request to the container of the correct version.
@@ -432,7 +432,7 @@ $ mvn clean package
 [INFO] ------------------------------------------------------------------------
 ----
 
-[[directory-structure-binary-builds]]
+[id='directory-structure-binary-builds']
 [upperalpha, start=2]
 . *Prepare the directory structure on the local file system.*
 +
@@ -461,7 +461,7 @@ $ cp library/target/processserver-library-1.4.0.Final.jar ps-bin-demo/deployment
 $ cp library-client/target/processserver-library-client-1.4.0.Final.war ps-bin-demo/deployments/
 ----
 +
-[[standard-deployments-folder]]
+[id='standard-deployments-folder']
 [NOTE]
 ====
 Location of the standard deployments directory depends on the underlying base image, that was used to deploy the application. See the following table:
@@ -508,7 +508,7 @@ jboss-processserver63-openshift
 You can change the default user name and password to access the REST interface of the KIE server by providing custom values for *_KIE_SERVER_USER_* and *_KIE_SERVER_PASSWORD_* environment variables.
 ====
 +
-[[kie-server-credentials]]
+[id='kie-server-credentials']
 [subs="verbatim,macros"]
 ----
 $ oc new-build --binary=true \

--- a/docs/product-openshift-kie-server-bpms/src/main/asciidoc/reference/reference.adoc
+++ b/docs/product-openshift-kie-server-bpms/src/main/asciidoc/reference/reference.adoc
@@ -1,4 +1,4 @@
-[[ips-artifact-repository-mirrors-section]]
+[id='ips-artifact-repository-mirrors-section']
 = Artifact Repository Mirrors
 
 // Define required 'bcname' attribute for xpaas_maven_mirror_url.adoc page
@@ -145,24 +145,24 @@ console:
 $ oc logs -f <pass:quotes[_pod-name_]>
 ----
 
-[[ds-endpoints]]
+[id='ds-endpoints']
 = Endpoints
 
 Clients can access {xpaasproduct-shortname} via multiple endpoints; by default the provided templates include support for REST, HornetQ, and ActiveMQ.
 
-[[ds-rest]]
+[id='ds-rest']
 == REST
 
 Clients can use the https://access.redhat.com/documentation/en-US/Red_Hat_JBoss_BPM_Suite/6.3/html/Development_Guide/index.html#realtime_decision_server[REST API] in various ways:
 
-[[ds-browser]]
+[id='ds-browser']
 === Browser
 
 . Current server state: \http://host/kie-server/services/rest/server
 . List of containers: \http://host/kie-server/services/rest/server/containers
 . Specific container state: \http://host/kie-server/services/rest/server/containers/processserver-library
 
-[[ds-java]]
+[id='ds-java']
 === Java
 
 [source,java]
@@ -181,12 +181,12 @@ Long processInstanceId = client.startProcess("processserver-library", "LibraryPr
 ----
 
 
-[[ds-jms]]
+[id='ds-jms']
 == JMS
 
 Client can also use the Java Messaging Service, as demonstrated below:
 
-[[ds-java-hornetq]]
+[id='ds-java-hornetq']
 === Java (HornetQ)
 
 [source,java]
@@ -211,7 +211,7 @@ params.put("loanRequest", loanRequest);
 Long processInstanceId = client.startProcess("processserver-library", "LibraryProcess", params);
 ----
 
-[[ds-java-activemq]]
+[id='ds-java-activemq']
 === Java (ActiveMQ)
 
 [source,java]
@@ -238,7 +238,7 @@ params.put("loanRequest", loanRequest);
 Long processInstanceId = client.startProcess("processserver-library", "LibraryProcess", params);
 ----
 
-[[ds-troubleshooting]]
+[id='ds-troubleshooting']
 = Troubleshooting
 
 In addition to viewing the OpenShift logs, you can troubleshoot a running {xpaasproduct-shortname} container by viewing its logs. These are outputted to the container's standard out, and are accessible with the following command:

--- a/docs/product-openshift-kie-server-bpms/src/main/asciidoc/tutorials/tutorials.adoc
+++ b/docs/product-openshift-kie-server-bpms/src/main/asciidoc/tutorials/tutorials.adoc
@@ -1,5 +1,5 @@
 
-[[Tutorial-Deploying-IPS]]
+[id='Tutorial-Deploying-IPS']
 = Example Workflow: Deploying a {PRODUCT} Project as {xpaasproduct-shortname} image
 
 Business Central, the {PRODUCT} console that provides a unified web-based environment for managing projects, is not part of {xpaasproduct-shortname}. An external repository is required to integrate projects between Business Central and OpenShift. This tutorial presumes that a project has already been set up in Business Central.
@@ -128,7 +128,7 @@ During the build, the Maven repository is downloaded and build into the containe
 The application is available once the pod is running. 
 
 
-[[Tutorial-Adding_Updated_Version]]
+[id='Tutorial-Adding_Updated_Version']
 = Example Workflow: Deploying an Updated Version Concurrently with Original Application
 
 This example workflow follows on from link:#Tutorial-Deploying-IPS[Example Workflow: Deploying a {PRODUCT} Project as an xPaaS {KIE_SERVER} xPaaS Image], in which the _1.0_ version of the _example_workflow_ artifact was deployed with a deployment alias of _ipsDemo_. This example deploys a _1.1_ version of the of the _example_workflow_ artifact alongside the _1.0_ version so that both versions of the _example_workflow_ artifact are running simultaneously, both with the _ipsDemo_ deployment alias. 

--- a/docs/product-openshift-kie-server-brms/src/main/asciidoc/before_you_begin/before_you_begin.adoc
+++ b/docs/product-openshift-kie-server-brms/src/main/asciidoc/before_you_begin/before_you_begin.adoc
@@ -19,7 +19,7 @@ There are several major functionality differences in {xpaasproduct-shortname}:
 * To connect to the {KIE_SERVER} web console, click the *Connect* button in the {KIE_SERVER} pod of the OpenShift web console, or the *Open Java Console* button in OpenShift 3.2.
 * Authoring of any content through the {PRODUCT} Console or API is not supported.
 
-[[Managing-OpenShift-Decision-Server-xPaaS-Images]]
+[id='Managing-OpenShift-Decision-Server-xPaaS-Images']
 == Managing {xpaasproduct-shortname}
 
 As {xpaasproduct-shortname} is built off EAP for OpenShift, the JBoss EAP Management CLI
@@ -44,7 +44,7 @@ Any configuration changes made using the JBoss EAP Management CLI on a running c
 link:#Making-Configuration-Changes-Decision-Server[Making configuration changes to the
 JBoss EAP instance inside EAP for OpenShift] is different from the process you may be used to for a regular release of JBoss EAP.
 
-[[Security-Openshift-Decision-Server-xPaaS-Image]]
+[id='Security-Openshift-Decision-Server-xPaaS-Image']
 = Security in {xpaasproduct-shortname}
 
 Access is limited to users with the *_kie-server_* authorization role.  A user with this role

--- a/docs/product-openshift-kie-server-brms/src/main/asciidoc/get_started/get_started.adoc
+++ b/docs/product-openshift-kie-server-brms/src/main/asciidoc/get_started/get_started.adoc
@@ -51,7 +51,7 @@ $ oc policy add-role-to-user view system:serviceaccount:<pass:quotes[_project-na
 $ oc secret add sa/<pass:quotes[_service-account-name_]> secret/<pass:quotes[_secret-name_]>
 ----
 
-[[Making-Configuration-Changes-Decision-Server]]
+[id='Making-Configuration-Changes-Decision-Server']
 = Preparing a {PRODUCT} Project Repository for OpenShift
 
 == Stateless Sessions
@@ -138,7 +138,7 @@ KIE_CONTAINER_DEPLOYMENT=RulesTest=com.example.openshift:example_workflow:1.0
 Defining the container name here is necessary because the default behavior of the KIE server is to search for the default stateful session and fail if it does not find one.
 
 
-[[ds-updating-rules]]
+[id='ds-updating-rules']
 = Updating Rules
 
 Each image is built from a snapshot of a specific Maven repository. When a new rule is added, or an existing rule modified, a new image must be created and deployed for the rule modifications to take effect.
@@ -252,7 +252,7 @@ KIE_CONTAINER_DEPLOYMENT_OVERRIDE=RulesTest=com.example.openshift:example_workfl
 ----
 
 See link:#Tutorial-Adding_Updgraded_Version[Example Workflow: Deploying an Updated Version Concurrently with Original Application] for an example on deploying an updated application alongside the older version.
-[[Request-Targeting]]
+[id='Request-Targeting']
 == Request Targeting for Multiple Versions
 
 In most cases, clients must target a particular container by name to execute server-side functions. This can be done by specifying the full deployment name, the container ID hash, or the deployment alias.
@@ -265,7 +265,7 @@ For example:
 
 Specifying either the full deployment name or the container ID targets the appropriate container. Specifying the deployment alias, which is used by all the containers in the KIE server, requires a multi-stage resolution process to target the correct version container.
 
-[[Alias-Redirection]]
+[id='Alias-Redirection']
 == Alias Redirection
 
 In a multi-version deployment, all applications share the same deployment alias. Requests that use the deployment alias of the application require a resolution process in order to redirect the request to the container of the correct version.
@@ -398,7 +398,7 @@ $ mvn clean package
 [INFO] ------------------------------------------------------------------------
 ----
 
-[[directory-structure-binary-builds]]
+[id='directory-structure-binary-builds']
 [upperalpha, start=2]
 . *Prepare the directory structure on the local file system.*
 +
@@ -427,7 +427,7 @@ $ cp hellorules/target/decisionserver-hellorules-1.4.0.Final.jar ocp/deployments
 $ cp hellorules-client/target/decisionserver-hellorules-client-1.4.0.Final.war ocp/deployments/
 ----
 +
-[[standard-deployments-folder]]
+[id='standard-deployments-folder']
 [NOTE]
 ====
 Location of the standard deployments directory depends on the underlying base image, that was used to deploy the application. See the following table:
@@ -480,7 +480,7 @@ Since the images from *jboss-decisionserver62-openshift* image stream are obsole
 You can change the default user name and password to access the REST interface of the KIE server by providing custom values for *_KIE_SERVER_USER_* and *_KIE_SERVER_PASSWORD_* environment variables.
 ====
 +
-[[kie-server-credentials]]
+[id='kie-server-credentials']
 [subs="verbatim,macros"]
 ----
 $ oc new-build --binary=true \

--- a/docs/product-openshift-kie-server-brms/src/main/asciidoc/reference/reference.adoc
+++ b/docs/product-openshift-kie-server-brms/src/main/asciidoc/reference/reference.adoc
@@ -1,4 +1,4 @@
-[[ds-artifact-repository-mirrors-section]]
+[id='ds-artifact-repository-mirrors-section']
 = Artifact Repository Mirrors
 
 // Define required 'bcname' attribute for xpaas_maven_mirror_url.adoc page
@@ -42,24 +42,24 @@ include::../../topics/product-shared-docs/xpaas_maven_mirror_url.adoc[bcname]
 |The password to access the KIE Server REST or JMS interface. Must be different than username; must not be root, admin, or administrator; must contain at least 8 characters, 1 alphabetic character(s), 1 digit(s), and 1 non-alphanumeric symbol(s).
 |===
 
-[[ds-endpoints]]
+[id='ds-endpoints']
 = Endpoints
 
 Clients can access {xpaasproduct-shortname} via multiple endpoints; by default the provided templates include support for REST, HornetQ, and ActiveMQ.
 
-[[ds-rest]]
+[id='ds-rest']
 == REST
 
 Clients can use the https://access.redhat.com/documentation/en-US/Red_Hat_JBoss_BRMS/6.3/html-single/User_Guide/index.html#The_REST_API_for_Managing_the_Realtime_Decision_Server[REST API] in various ways:
 
-[[ds-browser]]
+[id='ds-browser']
 === Browser
 
 . Current server state: \http://host/kie-server/services/rest/server
 . List of containers: \http://host/kie-server/services/rest/server/containers
 . Specific container state: \http://host/kie-server/services/rest/server/containers/HelloRulesContainer
 
-[[ds-java]]
+[id='ds-java']
 === Java
 
 [source,java]
@@ -73,7 +73,7 @@ RuleServicesClient client =
 ServiceResponse<String> response = client.executeCommands("HelloRulesContainer", myCommands);
 ----
 
-[[ds-command-line]]
+[id='ds-command-line']
 === Command Line
 
 [source,bash]
@@ -104,12 +104,12 @@ http://host/kie-server/services/rest/server/containers/instances/HelloRulesConta
 </batch-execution>
 ----
 
-[[ds-jms]]
+[id='ds-jms']
 == JMS
 
 Client can also use the Java Messaging Service, as demonstrated below:
 
-[[ds-java-hornetq]]
+[id='ds-java-hornetq']
 === Java (HornetQ)
 
 [source,java]
@@ -130,7 +130,7 @@ RuleServicesClient client =
 ServiceResponse<String> response = client.executeCommands("HelloRulesContainer", myCommands);
 ----
 
-[[ds-java-activemq]]
+[id='ds-java-activemq']
 === Java (ActiveMQ)
 
 [source,java]
@@ -153,7 +153,7 @@ RuleServicesClient client =
 ServiceResponse<String> response = client.executeCommands("HelloRulesContainer", myCommands);
 ----
 
-[[ds-troubleshooting]]
+[id='ds-troubleshooting']
 = Troubleshooting
 
 In addition to viewing the OpenShift logs, you can troubleshoot a running {KIE_SERVER} xPaaS Image container by viewing its logs.  These are outputted to the container's standard out, and are accessible with the following command:

--- a/docs/product-openshift-kie-server-brms/src/main/asciidoc/tutorials/tutorials.adoc
+++ b/docs/product-openshift-kie-server-brms/src/main/asciidoc/tutorials/tutorials.adoc
@@ -1,4 +1,4 @@
-[[Tutorial-Deploying-RDS]]
+[id='Tutorial-Deploying-RDS']
 = Example Workflow: Deploying {PRODUCT} Application on {xpaasproduct-shortname}
 This tutorial prepares a {PRODUCT} application to be deployed as {xpaasproduct-shortname}. The {PRODUCT} application may require modification to be deployed as an image. 
 
@@ -113,7 +113,7 @@ During the build, the Maven repository is downloaded and build into the containe
 
 The application is available once the pod is running. To connect to the {KIE_SERVER} web console, navigate to the pod and click *Open Java Console* button.
 
-[[Tutorial-Adding_Updgraded_Version]]
+[id='Tutorial-Adding_Updgraded_Version']
 = Example Workflow: Deploying an Upgraded Version Concurrently with Original Application
 
 This example workflow follows on from link:#Tutorial-Deploying-RDS[Example Workflow: Deploying {PRODUCT} Application on {KIE_SERVER} xPaaS], in which the _1.0_ version of the _example_workflow_ artifact was deployed with a deployment alias of _DemoContainer_. This example deploys a _1.1_ version of the of the _example_workflow_ artifact alongside the _1.0_ version so that both versions of the _example_workflow_ artifact are running simultaneously, both with the _DemoContainer_ deployment alias. 
@@ -135,7 +135,7 @@ $ oc start-build rds-app-demo
 
 Once the build has completed, the two different versions of the application will be running simultaneously using the same deployment alias. See link:#Request-Targeting[Request Targeting for Multiple Versions] for more information on how client requests are redirected to the correct version of the application.
 
-[[tutorial-deploying-brms-on-openshift]]
+[id='tutorial-deploying-brms-on-openshift']
 = Example Workflow: Deploying {PRODUCT} Application on Openshift with Webhooks Enabled for Automatic Application Updates
 
 This workflow details how to configure {PRODUCT}, GitHub, and OpenShift to have your
@@ -156,7 +156,7 @@ configuration changes automatically push to OpenShift. This example covers:
 Make sure you are running {PRODUCT} on your local machine. 
 ====
 
-[[tutorial-deploying-brms-on-openshift-forking]]
+[id='tutorial-deploying-brms-on-openshift-forking']
 == Forking the Repository
 
 . Visit the https://github.com/rettori/decisionserver[{KIE_SERVER} example]
@@ -171,7 +171,7 @@ specified as *master* in the rules file, then the user is recognized and greeted
 as the master user. If the name does not match, then the user is recognized as
 an intruder.
 
-[[tutorial-deploying-brms-on-openshift-cloning]]
+[id='tutorial-deploying-brms-on-openshift-cloning']
 == Cloning the Repository
 
 From the {PRODUCT} workbench:
@@ -185,7 +185,7 @@ From the {PRODUCT} workbench:
 + 
 Once cloned, the repository displays the commit history.
 
-[[tutorial-deploying-brms-on-openshift-create-hook]]
+[id='tutorial-deploying-brms-on-openshift-create-hook']
 == Creating a Hook to Automate GitHub Updates
 
 To make {PRODUCT} automatically update your GitHub repository any time a file in this project changes:
@@ -237,7 +237,7 @@ The hook is now configured, meaning that any change to the files in this {PRODUC
 project will automatically update your forked *decisionserver* GitHub
 repository.
 
-[[tutorial-deploying-brms-on-openshift-modify-example]]
+[id='tutorial-deploying-brms-on-openshift-modify-example']
 == Modifying the Example {KIE_SERVER} Rules
 
 From the {PRODUCT} workbench:
@@ -274,7 +274,7 @@ The hook you created earlier will automatically update your forked GitHub
 repository with these saved changes.
 
 
-[[tutorial-deploying-brms-on-openshift-create-decision-service]]
+[id='tutorial-deploying-brms-on-openshift-create-decision-service']
 == Creating a Decision Service on OpenShift
 
 From the OpenShift web console:
@@ -305,7 +305,7 @@ https://github.com/<your_github_username>/decisionserver.git
 While your application builds, you can click *View Log* from the Overview page
 to see the build progress. 
 
-[[tutorial-deploying-brms-on-openshift-improve-build-time]]
+[id='tutorial-deploying-brms-on-openshift-improve-build-time']
 == Improving Build Time Using Maven
 
 Follow the details in
@@ -313,7 +313,7 @@ link:https://blog.openshift.com/improving-build-time-java-builds-openshift/[this
 to configure the Maven proxy, which improves the build times of java
 builds on OpenShift.
 
-[[tutorial-deploying-brms-on-openshift-maven-proxy]]
+[id='tutorial-deploying-brms-on-openshift-maven-proxy']
 == Integrating the Maven Proxy
 
 To change the build configuration so that it uses the Maven proxy, complete the following from the OpenShift web console:
@@ -347,7 +347,7 @@ will be shorter for all future builds. This is because subsequent builds only
 need to download updated files, which are then combined with the previously
 loaded files.
 
-[[tutorial-deploying-brms-on-openshift-test-service]]
+[id='tutorial-deploying-brms-on-openshift-test-service']
 == Test the Service
 
 After integrating the Maven proxy, you can test that service is working and see
@@ -371,7 +371,7 @@ Maven proxy in use.
 . Click *Overview* to see the status of the pod. It displays a `Not Ready` status while it is checked with readiness probes. 
 . Click *Browse* -> *Pods* to follow its progress. The status of the *Containers Ready* column will change to `1/1` when the pod has passed the readiness probes.
 
-[[tutorial-deploying-brms-on-openshift-config-openshift-webhook]]
+[id='tutorial-deploying-brms-on-openshift-config-openshift-webhook']
 == Configure the OpenShift Webhook
 
 From the OpenShift web console:
@@ -393,7 +393,7 @@ Hover your cursor over the check mark to view the status of the last ping.
 The next time you push a code change to your forked repository, your application
 will automatically rebuild.
 
-[[tutorial-deploying-brms-on-openshift-test-configured-hooks]]
+[id='tutorial-deploying-brms-on-openshift-test-configured-hooks']
 == Testing the Configured Hooks
 
 From the {PRODUCT} workbench:

--- a/docs/product-oracle-weblogic-installation-and-configuration-guide/src/main/asciidoc/appe-additional-notes.adoc
+++ b/docs/product-oracle-weblogic-installation-and-configuration-guide/src/main/asciidoc/appe-additional-notes.adoc
@@ -1,7 +1,7 @@
 :sectnums!:
 
 [appendix]
-[[_appe_additional_notes]]
+[id='_appe_additional_notes']
 = Additional Notes
 
 * The Oracle WebLogic Server class-loading mechanism does not provide access to the application JARs located in you application's `WEB-INF/lib` directory, which can cause problems when looking to inject KIE-CDI classes. As a workaround, {PRODUCT} includes a CDI extension that temporarily swaps class loaders to load the application: `org.kie.workbench.backend.weblogic.SwapClassloaderExtension`.

--- a/docs/product-oracle-weblogic-installation-and-configuration-guide/src/main/asciidoc/chap-configure.adoc
+++ b/docs/product-oracle-weblogic-installation-and-configuration-guide/src/main/asciidoc/chap-configure.adoc
@@ -1,7 +1,7 @@
-[[_chap_configure]]
+[id='_chap_configure']
 = Configure
 
-[[_setting_environment_variables]]
+[id='_setting_environment_variables']
 == Setting Environment Variables
 
 Certain environment variables on your Oracle WebLogic Server require configuration before deploying the application.
@@ -94,7 +94,7 @@ JAVA_OPTIONS="-Dkie.server.jms.queues.response=jms/KIE.SERVER.RESPONSE
 ----
 endif::BRMS[]
 
-[[_configuring_security_settings]]
+[id='_configuring_security_settings']
 == Configuring Security Settings
 
 Several security settings on Oracle WebLogic Server must be set for the Business Central application to work. The following settings enable the container managed authentication mechanisms provided by the WebLogic server:
@@ -124,7 +124,7 @@ For example, if there is a role called `admin`, you should _not_ create a user w
 
 NOTE: You may assign this user to any of the groups previously created and in actual production systems you are likely to create separate users for separate groups that align with business roles. The admin group is all encompassing and is therefore useful for the purposes of this setup.
 
-[[_creating_a_data_source]]
+[id='_creating_a_data_source']
 == Creating Data Source
 
 The Business Central application requires a data source which must be created prior to the deployment of the actual WAR file. This also means that you must have access to an underlying database that the data source connects to. Whatever your underlying database, make sure you have the data source ready.
@@ -188,7 +188,7 @@ Save the file when complete.
 ====
 endif::BPMS[]
 
-[[_configuring_java_message_service_jms]]
+[id='_configuring_java_message_service_jms']
 == Configuring Java Message Service (JMS)
 
 Oracle WebLogic Server must be configured to send and receive JMS messages through {PRODUCT} {KIE_SERVER}.

--- a/docs/product-oracle-weblogic-installation-and-configuration-guide/src/main/asciidoc/chap-download-and-extract.adoc
+++ b/docs/product-oracle-weblogic-installation-and-configuration-guide/src/main/asciidoc/chap-download-and-extract.adoc
@@ -1,4 +1,4 @@
-[[_chap_download_and_extract]]
+[id='_chap_download_and_extract']
 = Download and Extract
 :doctype: book
 :sectnums:
@@ -7,7 +7,7 @@
 :experimental:
 :sourcedir: .
 
-[[_download_red_hat_jboss_bpm_suite_for_oracle_weblogic_server]]
+[id='_download_red_hat_jboss_bpm_suite_for_oracle_weblogic_server']
 == Download {PRODUCT} for Oracle WebLogic Server
 
 You can download the deployable {PRODUCT} package file for Oracle WebLogic Server from Red Hat Customer Portal:
@@ -19,7 +19,7 @@ You can download the deployable {PRODUCT} package file for Oracle WebLogic Serve
 . On the  *Releases* tab, navigate to *{PRODUCT} {PRODUCT_VERSION}.0 Deployable for Oracle Weblogic 12c* and click *Download*.
 . On the *Patches* tab, download the latest patch (if applicable).  
 
-[[_extract_red_hat_jboss_bpm_suite_for_oracle_weblogic_server]]
+[id='_extract_red_hat_jboss_bpm_suite_for_oracle_weblogic_server']
 == Extract {PRODUCT} for Oracle WebLogic Server
 
 The installation ZIP file for {PRODUCT} that you have downloaded contains all necessary WAR deployable archives mentioned in <<_about_red_hat_jboss_bpm_suite_for_oracle_weblogic_server>>.

--- a/docs/product-oracle-weblogic-installation-and-configuration-guide/src/main/asciidoc/chap-install.adoc
+++ b/docs/product-oracle-weblogic-installation-and-configuration-guide/src/main/asciidoc/chap-install.adoc
@@ -1,4 +1,4 @@
-[[_chap_install]]
+[id='_chap_install']
 = Install
 
 Now that the basic configuration is done, the Oracle WebLogic Server is set to deploy {PRODUCT}.
@@ -26,7 +26,7 @@ Business Central is uploaded as a web archive and then accessed by a familiar th
 You have now successfully installed Business Central on Oracle WebLogic Server. To access the application, navigate to `http://_TARGET_SERVER_:7001/business-central`.
 
 ifdef::BPMS[]
-[[_install_dashbuilder]]
+[id='_install_dashbuilder']
 == Installing Dashbuilder
 
 Dashbuilder is distributed as a deployable WAR. Follow the steps below to install Dashbuilder:
@@ -42,7 +42,7 @@ You can now login to dashbuilder at `http://_TARGET_SERVER_:7001/dashbuilder`.
 endif::BPMS[]
 
 ifdef::BPMS[]
-[[_installing_intelligent_process_server]]
+[id='_installing_intelligent_process_server']
 == Installing {KIE_SERVER}
 
 The {KIE_SERVER} is distributed as a deployable WAR. Follow the steps below to install the server:
@@ -59,7 +59,7 @@ You can now access the {KIE_SERVER} at `http://_TARGET_SERVER_:7001/kie-server`.
 endif::BPMS[]
 
 ifdef::BRMS[]
-[[_installing_realtime_decision_server]]
+[id='_installing_realtime_decision_server']
 == Installing {KIE_SERVER}
 
 The {KIE_SERVER} is distributed as a deployable WAR. Follow the steps below to install the server:

--- a/docs/product-oracle-weblogic-installation-and-configuration-guide/src/main/asciidoc/chap-introduction.adoc
+++ b/docs/product-oracle-weblogic-installation-and-configuration-guide/src/main/asciidoc/chap-introduction.adoc
@@ -1,4 +1,4 @@
-[[_chap_introduction]]
+[id='_chap_introduction']
 = Introduction
 :doctype: book
 :sectnums:
@@ -7,7 +7,7 @@
 :experimental:
 :sourcedir: .
 
-[[_about_red_hat_jboss_bpm_suite_for_oracle_weblogic_server]]
+[id='_about_red_hat_jboss_bpm_suite_for_oracle_weblogic_server']
 == About {PRODUCT} for Oracle WebLogic Server
 
 {PRODUCT} for Oracle WebLogic Server is provided as

--- a/docs/product-oracle-weblogic-installation-and-configuration-guide/src/main/asciidoc/chap-next-steps.adoc
+++ b/docs/product-oracle-weblogic-installation-and-configuration-guide/src/main/asciidoc/chap-next-steps.adoc
@@ -1,4 +1,4 @@
-[[_chap_next_steps]]
+[id='_chap_next_steps']
 = Next Steps
 
 Now that you have completed the installation, use the following guides to start using {PRODUCT}:

--- a/docs/product-release-notes/src/main/asciidoc/bxms-rn-introduction-con.adoc
+++ b/docs/product-release-notes/src/main/asciidoc/bxms-rn-introduction-con.adoc
@@ -1,6 +1,6 @@
 
-[[_bxms_rn_introduction_con.adoc]]
-[[_jboss_brms]]
+[id='_bxms_rn_introduction_con.adoc']
+[id='_jboss_brms']
 = About {PRODUCT}
 
 ifdef::BPMS[]

--- a/docs/product-release-notes/src/main/asciidoc/bxms-rn-whats-new-con.adoc
+++ b/docs/product-release-notes/src/main/asciidoc/bxms-rn-whats-new-con.adoc
@@ -1,5 +1,5 @@
 
-[[_bxms_rn_whats_new_con.adoc]]
+[id='_bxms_rn_whats_new_con.adoc']
 = What's New
 
 This section highlights changes between releases of {PRODUCT} {PRODUCT_VERSION} Limited Availability.

--- a/docs/product-user-guide/src/main/asciidoc/AuthoringPlanningAssets-chapter.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/AuthoringPlanningAssets-chapter.adoc
@@ -1,4 +1,4 @@
-[[_planner.authoringPlanningAssets]]
+[id='_planner.authoringPlanningAssets']
 = Authoring Planning Assets
 :imagesdir: ..
 

--- a/docs/product-user-guide/src/main/asciidoc/DomainEditor-section.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/DomainEditor-section.adoc
@@ -1,4 +1,4 @@
-[[_optaplanner.domainEditor]]
+[id='_optaplanner.domainEditor']
 = Domain Editor
 :imagesdir: ../..
 

--- a/docs/product-user-guide/src/main/asciidoc/GuidedRuleEditor-section.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/GuidedRuleEditor-section.adoc
@@ -1,4 +1,4 @@
-[[_optaplanner.guidedRuleEditor]]
+[id='_optaplanner.guidedRuleEditor']
 = Guided Rule Editor
 :imagesdir: ../..
 

--- a/docs/product-user-guide/src/main/asciidoc/INTERNAL-content-repo.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/INTERNAL-content-repo.adoc
@@ -4,7 +4,7 @@ This is an INTERNAL FILE ONLY containing segments of the BRMS/BPMS User Guides t
 
 [From chap-business-central]
 
-[[_sect_project_authoring]]
+[id='_sect_project_authoring']
 == Project Authoring
 
 
@@ -22,7 +22,7 @@ The project authoring screen is divided into 3 sections:
 * _Problems_: The problems area shows the validation errors of the project that occur while saving or validating a particular asset.
 
 
-[[_changing_the_layout]]
+[id='_changing_the_layout']
 === Changing the Layout
 
 The layout of any panel can be changed by the user.
@@ -54,10 +54,10 @@ To reposition the layout, do the following:
 
 
 
-[[_sect_project_editor]]
+[id='_sect_project_editor']
 == Project Editor
 
-[[_the_project_editor]]
+[id='_the_project_editor']
 === The Project Editor
 
 
@@ -72,7 +72,7 @@ To access the Project Editor:
 . Select your project.
 . Click *Open Project Editor*.
 
-[[_project_settings]]
+[id='_project_settings']
 === Project Settings
 
 .Project General Settings
@@ -106,7 +106,7 @@ You can add metadata to a project, a knowledge base (kmodule) and project import
 .Knowledge Base Settings - Metadata
 image::5799.png[A screenshot of the BRMS Project Editor - Metadata Screen]
 
-[[_knowledge_base_settings]]
+[id='_knowledge_base_settings']
 === Knowledge Base Settings
 
 .Knowledge Bases and Sessions
@@ -169,7 +169,7 @@ By clicking the image:5798.png[Add Icon] button, you are able to add a new knowl
 .Metadata
 See <<_project_settings>> for more information about metadata.
 
-[[_imports1]]
+[id='_imports1']
 === Imports
 
 .External Data Objects
@@ -198,7 +198,7 @@ Each import needs to be added into each file.
 .Metadata
 See <<_project_settings>> for more information about Metadata.
 
-[[_repos]]
+[id='_repos']
 === Repositories
 .Validation
 The *Validation* section enables you to select which maven repositories are used to check the uniqueness of your project's GAV (group ID, artifact ID, and version).
@@ -224,7 +224,7 @@ Alternatively, click *Source* tab to edit the *persistence.xml* directly.
 .Persistence descriptor
 image::5794.png[A screenshot of the BRMS Project Editor - Persistence Descriptor]
 
-[[_administration_menu]]
+[id='_administration_menu']
 == Administration menu
 
 
@@ -237,7 +237,7 @@ image::3391.png[ A screenshot of the BRMS Administration menu]
 
 
 
-[[_administrative_view]]
+[id='_administrative_view']
 == Deployment Menu: The Artifact Repository
 
 
@@ -280,10 +280,10 @@ Guided Decision Tree is a Technology Preview feature, and therefore _not_ curren
 ====
 
 
-[[_sect_scorecards]]
+[id='_sect_scorecards']
 == Scorecards
 
-[[_scorecards]]
+[id='_scorecards']
 === Scorecards
 
 
@@ -308,7 +308,7 @@ To explain it in detail, following is an example:
 image::2657.png[]
 
 
-[[_creating_a_scorecard]]
+[id='_creating_a_scorecard']
 === Creating a Scorecard
 
 .Procedure: Creating a new Score Card (Spreadsheet)
@@ -338,7 +338,7 @@ Scorecard is a Technology Preview feature, and therefore _not_ currently support
 
 // Removed until a better use is found. Very product centric.
 
-[[_the_asset_editor1]]
+[id='_the_asset_editor1']
 === Editing Rules Using the Asset Editor
 
 
@@ -376,7 +376,7 @@ image::3625.png[A screen shot of the asset editor - config tab]
 
 // All of the options need to be defined. Until we do so, having just this one is odd.
 
-[[_saliance]]
+[id='_saliance']
 === Salience
 
 Each rule has a salience value which is an integer value that defaults to zero.

--- a/docs/product-user-guide/src/main/asciidoc/PhaseConfiguration-section.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/PhaseConfiguration-section.adoc
@@ -1,4 +1,4 @@
-[[_optaplanner.phaseConfiguration]]
+[id='_optaplanner.phaseConfiguration']
 = Phase Configuration
 :imagesdir: ../..
 

--- a/docs/product-user-guide/src/main/asciidoc/PlanningEntityDifficultyComparator-section.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/PlanningEntityDifficultyComparator-section.adoc
@@ -1,4 +1,4 @@
-[[_optaplanner.planningEntityDifficultyComparator]]
+[id='_optaplanner.planningEntityDifficultyComparator']
 = Planning Entity Difficulty Comparator
 :imagesdir: ../..
 

--- a/docs/product-user-guide/src/main/asciidoc/Quickstart-chapter.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/Quickstart-chapter.adoc
@@ -1,4 +1,4 @@
-[[_planner.quickstart]]
+[id='_planner.quickstart']
 = Quickstart
 :imagesdir: ..
 

--- a/docs/product-user-guide/src/main/asciidoc/ScoreDirectorFactory-section.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/ScoreDirectorFactory-section.adoc
@@ -1,4 +1,4 @@
-[[_optaplanner.scoreDirectorFactory]]
+[id='_optaplanner.scoreDirectorFactory']
 = Score Director Factory
 :imagesdir: ../..
 

--- a/docs/product-user-guide/src/main/asciidoc/SolverEditor-section.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/SolverEditor-section.adoc
@@ -1,4 +1,4 @@
-[[_drools.solverEditor]]
+[id='_drools.solverEditor']
 = Solver Editor
 :imagesdir: ../..
 

--- a/docs/product-user-guide/src/main/asciidoc/TerminationEditor-section.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/TerminationEditor-section.adoc
@@ -1,4 +1,4 @@
-[[_optaplanner.terminationEditor]]
+[id='_optaplanner.terminationEditor']
 = Termination Editor
 :imagesdir: ../..
 

--- a/docs/product-user-guide/src/main/asciidoc/about-product-con.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/about-product-con.adoc
@@ -1,4 +1,4 @@
-[[_about_product_con]]
+[id='_about_product_con']
 
 ifdef::BPMS[]
 = About {PRODUCT}

--- a/docs/product-user-guide/src/main/asciidoc/appe-process-elements.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/appe-process-elements.adoc
@@ -1,6 +1,6 @@
 
 [appendix]
-[[_appe_process_elements]]
+[id='_appe_process_elements']
 = Process Elements
 
 .Disclaimer
@@ -28,7 +28,7 @@ Name::
 The display name of the element.
 
 
-[[_process1]]
+[id='_process1']
 == Process
 
 
@@ -156,7 +156,7 @@ Base Currency::
 Identifies the currency in simulation scenarios. Uses the ISO 4217 standard, for example `EUR`, `GBP`, or `USD`.
 
 
-[[_events_mechanism]]
+[id='_events_mechanism']
 == Events mechanism
 
 During process execution, the Process Engine ensures that all the relevant tasks are executed according to the process definition, the underlying work items, and other resources.
@@ -205,7 +205,7 @@ You can also use events to start a process. When a Message Start Event defines a
 
 This mechanism is used for implementation of the Intermediate Events, and can be used to define custom events.
 
-[[_sect_collaboration_mechanisms]]
+[id='_sect_collaboration_mechanisms']
 == Collaboration mechanisms
 
 Elements with execution semantics use collaboration mechanisms. Different elements use the collaboration mechanism differently. For example, if you use signaling, the Throw Signal Intermediate Event element sends a signal, and the Catch Signal Intermediate Event element receives the signal. That means {PRODUCT} provides you with two elements with execution semantics that make use of the same signal mechanism in a collaborative way.
@@ -221,7 +221,7 @@ Errors:: Used as inter-process signaling of escalation to trigger escalation han
 
 All the events are managed by the signaling mechanism. To distinguish individual objects of individual mechanism the signal use different signal codes or names.
 
-[[_signals]]
+[id='_signals']
 === Signals
 
 Signals in {PRODUCT} correspond to the Signal Event in the specification BPMN 2.0, and are the most flexible of the listed mechanisms. Signals can be consumed by an arbitrary number of elements both within its process instance and outside of it. Signals can also be consumed by any element in any session within or cross the current deployment, depending on the scope of the event that throws the signal.
@@ -340,7 +340,7 @@ The message-driven bean should look like the following:
 
 This setting ensures that all messages, even the ones that were sent concurrently, will be processed serially and that notifications sent to the parent process instance will be delivered and will not cause any conflicts.
 
-[[_catching_and_processing_signals]]
+[id='_catching_and_processing_signals']
 ==== Catching and Processing Signals
 
 Signals are caught by the following catch event types:
@@ -444,7 +444,7 @@ The process for catching messages does not differ from receiving signals, with t
 
 WARNING: When catching messages through the API, the *MessageRef* property of the catching event is not the same as the `eventType` parameter of the API call. See <<sending_messages_using_api>> for further information.
 
-[[_sending_messages_using_api]]
+[id='_sending_messages_using_api']
 ==== Sending Messages Using API
 
 To send a message using the API, use the following method:
@@ -486,7 +486,7 @@ The usage of the arguments `eventType` and `data` is the same as above.
 --
 
 
-[[_escalation]]
+[id='_escalation']
 === Escalation
 
 [quote]
@@ -509,10 +509,10 @@ string with the escalation code
 
 
 
-[[_sect_transaction_mechanisms]]
+[id='_sect_transaction_mechanisms']
 == Transaction Mechanisms
 
-[[_errors]]
+[id='_errors']
 === Errors
 
 
@@ -530,7 +530,7 @@ Every Error defines its error code, which is unique in the respective process.
 Error Code::
 Error code defined as a String unique within the process.
 
-[[_compensation]]
+[id='_compensation']
 === Compensation
 
 
@@ -561,7 +561,7 @@ The activity to which the Compensation Intermediate Event points may be a sub-pr
 
 If running over a multi-instance sub-process, compensation mechanism of individual instances do not influence each other.
 
-[[_timing]]
+[id='_timing']
 == Timing
 
 
@@ -649,7 +649,7 @@ Drive the flow of a business process.
 
 Every event has an event ID and a name. You can implement triggers for each of these event types to identify the conditions under which an event is triggered. If the conditions of the triggers are not met, the events are not initialized, and the process flow does not complete.
 
-[[_sect_start_event]]
+[id='_sect_start_event']
 === Start Event
 
 
@@ -671,10 +671,10 @@ All start events, except for the None Start Event, define a trigger.
 When you start a process, the trigger needs to be fulfilled.
 If no start event can be triggered, the process is never instantiated.
 
-[[_sect_start_event_types]]
+[id='_sect_start_event_types']
 ==== Start Event types
 
-[[_none_start_event]]
+[id='_none_start_event']
 ===== None Start Event
 
 
@@ -682,7 +682,7 @@ The None Start Event is a start event without a trigger condition. A process or 
 
 When used in a sub-process, the execution is transferred from the parent process into the sub-process and the None Start Event is triggered. That means that the token is taken from the parent sub-process activity and the None Start Event of the sub-process generates a token.
 
-[[_message_start_event]]
+[id='_message_start_event']
 ===== Message Start Event
 
 
@@ -697,7 +697,7 @@ As a message can be consumed by an arbitrary number of processes and process ele
 MessageRef::
 ID of the expected Message object
 
-[[_timer_start_event]]
+[id='_timer_start_event']
 ===== Timer Start Event
 
 
@@ -728,7 +728,7 @@ Marks the timer as a one-time expiration timer. It is the delay after which the 
 Time Date::
 Starts the process at the specified date and time in the ISO-8601 date format.
 
-[[_escalation_start_event]]
+[id='_escalation_start_event']
 ===== Escalation Start Event
 
 
@@ -742,7 +742,7 @@ Process can contain multiple Escalation Start Events. The process instance with 
 Escalation Code::
 Expected escalation Code.
 
-[[_conditional_start_event]]
+[id='_conditional_start_event']
 ===== Conditional Start Event
 
 
@@ -759,7 +759,7 @@ A Boolean condition that starts the process execution when evaluated to `true`.
 Language::
 A language of the `Expression` attribute.
 
-[[_error_start_event]]
+[id='_error_start_event']
 ===== Error Start Event
 
 
@@ -772,13 +772,13 @@ The error object can be produced by an Error End Event, and it signalizes an inc
 ErrorRef::
 A code of the expected error object.
 
-[[_compensation_start_event]]
+[id='_compensation_start_event']
 ===== Compensation Start Event
 
 
 A Compensation Start Event is used to start a Compensation Event sub-process when using a sub-process as the target activity of a Compensation Intermediate Event.
 
-[[_signal_start_event]]
+[id='_signal_start_event']
 ===== Signal Start Event
 
 
@@ -792,10 +792,10 @@ A process can contain multiple Signal Start Events. The Signal Start Event only 
 SignalRef::
 The expected Signal Code.
 
-[[_sect_intermediate_events]]
+[id='_sect_intermediate_events']
 === Intermediate Events
 
-[[_intermediate_events]]
+[id='_intermediate_events']
 ==== Intermediate Events
 
 "`$$...$$ the Intermediate Event indicates where something happens (an Event) somewhere between the start and end of a Process. It will affect the flow of the Process, but will not start or (directly) terminate the Process.footnote:[Business Process Model and Notation (BPMN). Version 2.0, OMG Document Number: formal/2011-01-03 http://www.omg.org/spec/BPMN/2.0]`"
@@ -845,11 +845,11 @@ Has two subtypes:
 * Catching Compensation Intermediate Event, which is triggered by a compensation object.
 * Throwing Compensation Intermediate Event, which produces a compensation object when executed.
 
-[[_sect_intermediate_event_types]]
+[id='_sect_intermediate_event_types']
 ==== Intermediate Event types
 
 
-[[_timer_intermediate_event]]
+[id='_timer_intermediate_event']
 ===== Timer Intermediate Event
 
 
@@ -880,7 +880,7 @@ Time Date::
 Triggers the timer at the specified date and time in the ISO-8601 date format.
 
 
-[[_conditional_intermediate_event]]
+[id='_conditional_intermediate_event']
 ===== Conditional Intermediate Event
 
 
@@ -897,7 +897,7 @@ A Boolean condition that triggers the execution when evaluated to `true`.
 Language::
 A language of the `Expression` attribute.
 
-[[_compensation_intermediate_event]]
+[id='_compensation_intermediate_event']
 ===== Compensation Intermediate Event
 
 
@@ -905,7 +905,7 @@ A compensation intermediate event is a boundary event attached to an activity in
 
 The activity associated with the boundary compensation intermediate event is executed if the transaction sub-process finishes with the compensation end event. The execution continues with the respective flow.
 
-[[_message_intermediate_event]]
+[id='_message_intermediate_event']
 ===== Message Intermediate Event
 
 
@@ -915,7 +915,7 @@ A Message Intermediate Event is an intermediate event that allows you to manage 
 * *Catching Message Intermediate Event* listens for a message object with the defined properties.
 
 [float]
-[[_throwing_message_intermediate_event]]
+[id='_throwing_message_intermediate_event']
 ====== Throwing Message Intermediate Event
 
 When reached during execution, a Throwing Message Intermediate Event produces a message object and the execution continues to its outgoing Flow.
@@ -926,7 +926,7 @@ MessageRef::
 ID of the produced Message object.
 
 [float]
-[[_catching_message_intermediate_event]]
+[id='_catching_message_intermediate_event']
 ====== Catching Message Intermediate Event
 
 When reached during execution, a Catching Message Intermediate Event awaits a message object defined in its properties.
@@ -941,7 +941,7 @@ ID of the expected Message object.
 CancelActivity::
 If the event is placed on the boundary of an activity and `Cancel Activity` property is set to ``true``, the activity execution is canceled when the event receives its escalation object.
 --
-[[_escalation_intermediate_event1]]
+[id='_escalation_intermediate_event1']
 ===== Escalation Intermediate Event
 
 
@@ -951,7 +951,7 @@ An Escalation Intermediate Event is an intermediate event that allows you to pro
 * *Catching Escalation Intermediate Event* listens for an escalation object with the defined properties.
 
 [float]
-[[_throwing_escalation_intermediate_event]]
+[id='_throwing_escalation_intermediate_event']
 ====== Throwing Escalation Intermediate Event
 
 When reached during execution, a Throwing Escalation Intermediate Event produces an escalation object and the execution continues to its outgoing flow.
@@ -962,7 +962,7 @@ EscalationCode::
 ID of the produced escalation object.
 
 [float]
-[[_catching_escalation_intermediate_event]]
+[id='_catching_escalation_intermediate_event']
 ====== Catching Escalation Intermediate Event
 
 When reached during execution, a Catching Escalation Intermediate Event awaits an escalation object defined in its properties. When the object is received, the event triggers execution of its outgoing Flow.
@@ -976,14 +976,14 @@ Code of the expected Escalation object.
 CancelActivity::
 If the event is placed on the boundary of an activity and `Cancel Activity` property is set to ``true``, the activity execution is canceled when the event receives its escalation object.
 --
-[[_error_intermediate_event]]
+[id='_error_intermediate_event']
 ===== Error Intermediate Event
 
 
 An Error Intermediate Event is an intermediate event that can be used only on an activity boundary. It allows the process to react to an Error End Event in the respective activity.
 The activity must not be atomic. When the activity finishes with an Error End Event that produces an error object with the respective `ErrorCode` property, the Error Intermediate Event catches the error object and execution continues to its outgoing flow.
 
-[[_catching_error_intermediate_event]]
+[id='_catching_error_intermediate_event']
 ====== Catching Error Intermediate Event
 
 When reached during execution, a Catching Error Intermediate Event awaits an error object defined in its properties. Once the object is received, the event triggers execution of its outgoing Flow.
@@ -995,7 +995,7 @@ The reference number of the expected error object.
 
 
 
-[[_signal_intermediate_event1]]
+[id='_signal_intermediate_event1']
 ===== Signal Intermediate Event
 
 
@@ -1005,7 +1005,7 @@ A Signal Intermediate Event enables you to produce or consume a signal object. U
 * *Catching Signal Intermediate Event* listens for a signal object with the defined properties.
 
 [float]
-[[_throwing_signal_intermediate_event]]
+[id='_throwing_signal_intermediate_event']
 ====== Throwing Signal Intermediate Event
 
 When reached on execution, a Throwing Signal Intermediate Event produces a signal object and the execution continues to its outgoing flow.
@@ -1026,7 +1026,7 @@ You can choose one of the following scopes:
 * `Project`: Signal reaches only active process instances of a given deployment and starts processes with a Signal Start Event.
 * `External`: Enables the signal to reach the same process instances as with the `Project` scope, as well as process instances across deployments. To send the signal to a process instance across deployments, create a `SignalDeploymentId` process variable that provides information about what deployment or project should be the target of the signal. Broadcasting the signal would have negative impact on performance in larger environments. 
 
-[[_catching_signal_intermediate_event]]
+[id='_catching_signal_intermediate_event']
 ====== Catching Signal Intermediate Event
 
 When reached during execution, a Catching Signal Intermediate Event awaits a signal object defined in its properties.
@@ -1040,7 +1040,7 @@ Reference code of the expected signal object.
 CancelActivity::
 If the event is placed on the boundary of an activity and `Cancel Activity` property is set to ``true``, the activity execution is canceled when the event receives its Escalation object.
 
-[[_sect_end_events]]
+[id='_sect_end_events']
 === End Events
 
 
@@ -1050,10 +1050,10 @@ A process must contain at least one end event.
 
 During runtime, an end event finishes the process workflow. The end event can finish only the workflow that reached it, or all workflows in the process instance, depending on the end event type.
 
-[[_sect_end_event_types]]
+[id='_sect_end_event_types']
 ==== End Event types
 
-[[_simple_end_event]]
+[id='_simple_end_event']
 ===== Simple End Event
 
 
@@ -1066,23 +1066,23 @@ In {PRODUCT}, the Simple End Event has the [property]``Terminate`` property in i
 This is a Boolean property that turns a Simple End Event into a Terminate End Event when set to ``true``.
 ====
 
-[[_message_end_event]]
+[id='_message_end_event']
 ===== Message End Event
 
 When a flow enters a Message End Event, the flow finishes and the end event produces a message as defined in its properties.
 
-[[_escalation_end_event]]
+[id='_escalation_end_event']
 ===== Escalation End Event
 
 
 The Escalation End Event finishes the incoming workflow, that means consumes the incoming token, and produces an escalation signal as defined in its properties, triggering the escalation process.
 
-[[_terminate_end_event]]
+[id='_terminate_end_event']
 ===== Terminate End Event
 
 The Terminate End Event finishes all execution flows in the given process instance. Activities being executed are canceled. If a Terminate End Event is reached in a sub-process, the entire process instance is terminated.
 
-[[_error_end_event]]
+[id='_error_end_event']
 ===== Throwing Error End Event
 
 The Throwing Error End Event finishes the incoming workflow, that means consumes the incoming token, and produces an error object. Any other running workflows in the process or sub-process remain uninfluenced.
@@ -1093,17 +1093,17 @@ The Throwing Error End Event finishes the incoming workflow, that means consumes
 ErrorRef::
 The reference code of the produced error object.
 
-[[_cancel_end_event]]
+[id='_cancel_end_event']
 ===== Cancel End Event
 
 The Cancel End Event triggers compensation events defined for the namespace, and the process or sub-process finishes as `CANCELED`.
 
-[[_compensation_end_event]]
+[id='_compensation_end_event']
 ===== Compensation End Event
 
 A Compensation End Event is used to finish a transaction sub-process and trigger the compensation defined by the Compensation Intermediate Event attached to the boundary of the sub-process activities.
 
-[[_signal_end_event]]
+[id='_signal_end_event']
 ===== Signal End Event
 
 
@@ -1125,10 +1125,10 @@ The Scope data input is an optional property implemented to provide the followin
 * `External`: Enables the signal to reach the same process instances as with the `Project` scope, as well as process instances across deployments. To send the signal to a process instance across deployments, create a `SignalDeploymentId` process variable that provides information about what deployment or project should be the target of the signal. Broadcasting the signal would have negative impact on performance in larger environments. 
 
 
-[[_sect_gateways]]
+[id='_sect_gateways']
 == Gateways
 
-[[_gateways1]]
+[id='_gateways1']
 === Gateways
 
 "`Gateways are used to control how Sequence Flows interact as they converge and diverge within a Process.footnote:[Business Process Model and Notation (BPMN). Version 2.0, OMG Document Number: formal/2011-01-03 http://www.omg.org/spec/BPMN/2.0]`"
@@ -1155,10 +1155,10 @@ You can use the following types of gateways:
 * Event-based gateways, which can only be diverging, and are used for reacting to events. For further information, see <<_event_based_gateway>>.
 
 
-[[_sect_gateway_types]]
+[id='_sect_gateway_types']
 === Gateway types
 
-[[_event_based_gateway]]
+[id='_event_based_gateway']
 ==== Event-based Gateway
 
 "`The Event-Based Gateway has pass-through semantics for a set of incoming branches (merging behavior). Exactly one of the outgoing branches is activated afterwards (branching behavior), depending on which of Events of the Gateway configuration is first triggered. footnote:[Business Process Model and Notation (BPMN). Version 2.0, OMG Document Number: formal/2011-01-03 http://www.omg.org/spec/BPMN/2.0]`"
@@ -1170,7 +1170,7 @@ image::event-based-gw.png[]
 
 The gateway might act as a start event, where the process is instantiated only if one the intermediate events connected to the Event-Based Gateway occurs.
 
-[[_parallel_gateway]]
+[id='_parallel_gateway']
 ==== Parallel Gateway
 
 "`A Parallel Gateway is used to synchronize (combine) parallel flows and to create parallel flows.footnote:[Business Process Model and Notation (BPMN). Version 2.0, OMG Document Number: formal/2011-01-03 http://www.omg.org/spec/BPMN/2.0]`"
@@ -1181,7 +1181,7 @@ Once the incoming flow is taken, all outgoing flows are taken simultaneously.
 Converging::
 The gateway waits until all incoming flows have entered and only then triggers the outgoing flow.
 
-[[_inclusive_gateway]]
+[id='_inclusive_gateway']
 ==== Inclusive Gateway
 
 Diverging::
@@ -1203,7 +1203,7 @@ The gateway merges all incoming Flows previously created by a diverging Inclusiv
 Default gate::
 The outgoing flow taken by default if no other flow can be taken.
 
-[[_complex_gateway]]
+[id='_complex_gateway']
 ==== Data-based Exclusive Gateway
 
 
@@ -1224,10 +1224,10 @@ The gateway allows a workflow branch to continue to its outgoing flow as soon as
 Default gate::
 The outgoing flow taken by default if no other flow can be taken.
 
-[[_sect_activities_tasks_and_sub_processes]]
+[id='_sect_activities_tasks_and_sub_processes']
 == Activities, Tasks and Sub-Processes
 
-[[_activity]]
+[id='_activity']
 === Activity
 
 [quote]
@@ -1246,10 +1246,10 @@ An activity in Red Hat JBoss BPM Suite expects one incoming and one outgoing flo
 
 Activities share properties `ID` and `Name`. Note that activities, that is all tasks and sub-processes, have additional properties specific for the given activity or task type.
 
-[[_sect_activity_mechanisms]]
+[id='_sect_activity_mechanisms']
 === Activity Mechanisms
 
-[[_multiple_instances1]]
+[id='_multiple_instances1']
 ==== Multiple Instances
 
 
@@ -1257,10 +1257,10 @@ You can run activities in multiple instances during execution. Individual instan
 
 Every multiple-instance activity has the [property]``Collection Expression`` attribute that maps the input collection of elements to a single element. The multiple-instance activity then iterates through all the elements of the collection.
 
-[[_sect_activity_types]]
+[id='_sect_activity_types']
 ==== Activity Types
 
-[[_reusable_sub_process]]
+[id='_reusable_sub_process']
 ===== Call Activity
 
 "`A Call Activity identifies a point in the Process where a global Process or a Global Task is used. The Call Activity acts as a 'wrapper' for the invocation of a global Process or Global Task within the execution. The activation of a call Activity results in the transfer of control to the called global Process or Global Task. footnote:[Business Process Model and Notation (BPMN). Version 2.0, OMG Document Number: formal/2011-01-03 http://www.omg.org/spec/BPMN/2.0]`"
@@ -1274,12 +1274,12 @@ When the execution flow reaches the activity, the activity creates an instance o
 Called Element::
 The ID of the process to be called and instantiated by the activity.
 
-[[_sect_tasks]]
+[id='_sect_tasks']
 === Tasks
 
 A task is the smallest unit of work in a process flow. Red Hat JBoss BPM Suite uses the BPMN guidelines to separate tasks based on the types of inherent behavior that the tasks represent. This section defines all task types available in {PRODUCT} except for the User Task. For more information about the User Task, see <<_sect_user_task>>. 
 
-[[_abstract_task]]
+[id='_abstract_task']
 ==== None Task
 
 [quote]
@@ -1287,7 +1287,7 @@ A task is the smallest unit of work in a process flow. Red Hat JBoss BPM Suite u
 "Abstract Task: Upon activation, the Abstract Task completes.
 This is a conceptual model only; an Abstract Task is never actually executed by an IT system." footnote:[Business Process Model and Notation (BPMN). Version 2.0, OMG Document Number: formal/2011-01-03 http://www.omg.org/spec/BPMN/2.0]
 
-[[_send_task]]
+[id='_send_task']
 ==== Send Task
 
 [quote]
@@ -1306,7 +1306,7 @@ The ID of the generated message object.
 In {PRODUCT} 6.x, the Send Task is not supported. A custom `WorkItemHandler` implementation is needed to use the Send task.
 ====
 
-[[_receive_task]]
+[id='_receive_task']
 ==== Receive Task
 
 [quote]
@@ -1320,7 +1320,7 @@ When the Message arrives, the data in the Data Output of the Receive Task is ass
 MessageRef::
 ID of the associated message object.
 
-[[_manual]]
+[id='_manual']
 ==== Manual Task
 
 [quote]
@@ -1329,7 +1329,7 @@ ID of the associated message object.
 When the work has been done, the Manual Task completes.
 This is a conceptual model only; a Manual Task is never actually executed by an IT system." footnote:[Business Process Model and Notation (BPMN). Version 2.0, OMG Document Number: formal/2011-01-03 http://www.omg.org/spec/BPMN/2.0]
 
-[[_service_task]]
+[id='_service_task']
 ==== Service Task
 
 Use a Service Task to invoke web services and Java methods.
@@ -1590,7 +1590,7 @@ ksession.startProcess("demo-package.demo-service-task", arguments);
 --
 .. Click *Save*.
 
-[[_business_rule_task]]
+[id='_business_rule_task']
 ==== Business Rule Task
 
 "`A Business Rule Task provides a mechanism for the Process to provide input to a Business Rules Engine and to get the output of calculations that the Business Rules Engine might provide. footnote:[Business Process Model and Notation (BPMN). Version 2.0, OMG Document Number: formal/2011-01-03 http://www.omg.org/spec/BPMN/2.0]`"
@@ -1610,7 +1610,7 @@ If the ruleflow group was already active, the ruleflow group remains active and 
 Ruleflow Group::
 The name of the ruleflow group that includes the set of rules to be evaluated by the task. This attribute refers to the `ruleflow-group` keyword in your `DRL` file.
 
-[[_script_task]]
+[id='_script_task']
 ==== Script Task
 
 
@@ -1650,7 +1650,7 @@ image::Script_Task_JavaScript.png[]
 
 ====
 
-[[_sect_sub_process]]
+[id='_sect_sub_process']
 === Sub-Process
 
 "`A Sub-Process is an Activity whose internal details have been modeled using Activities, Gateways, Events, and Sequence Flows. A Sub-Process is a graphical object within a Process, but it also can be 'opened up'to show a lower-level Process. footnote:[Business Process Model and Notation (BPMN). Version 2.0, OMG Document Number: formal/2011-01-03 http://www.omg.org/spec/BPMN/2.0]`"
@@ -1675,7 +1675,7 @@ An embedded sub-process encapsulates a part of the process.
 
 It must contain a start event and at least one end event. Note that the element allows you to define local sub-process variables, that are accessible to all elements inside this container.
 
-[[_adhoc_sub_process]]
+[id='_adhoc_sub_process']
 ==== AdHoc Sub-Process
 
 "`An Ad-Hoc Sub-Process is a specialized type of Sub-Process that is a group of Activities that have no REQUIRED sequence relationships. A set of Activities can be defined for the Process, but the sequence and number of performances for the Activities is determined by the performers of the Activities. footnote:[Business Process Model and Notation (BPMN). Version 2.0, OMG Document Number: formal/2011-01-03 http://www.omg.org/spec/BPMN/2.0]`"
@@ -1696,7 +1696,7 @@ Variable Definitions::
 Enables you to define process variables available only for elements of the sub-process.
 --
 
-[[_multiple_instances]]
+[id='_multiple_instances']
 ==== Multi-instance Sub-Process
 
 A Multiple Instances Sub-Process is instantiated multiple times when its execution is triggered. The instances are created in a sequential manner, that means a new sub-process instance is created only after the previous instance has finished.
@@ -1721,7 +1721,7 @@ A variable name for each element from the collection that will be used in the pr
 MI data output::
 An optional variable name for the collection of the results. 
 --
-[[_event_sub_process]]
+[id='_event_sub_process']
 ==== Event Sub-Process
 
 
@@ -1738,7 +1738,7 @@ For example, while booking a flight, two events may occur:
 
 Both these events can be modeled using the event sub-process.
 
-[[_sect_user_task]]
+[id='_sect_user_task']
 === User Task
 
 [quote]
@@ -1812,7 +1812,7 @@ See the User Task lifecycle:
 Note that the User Task lifecycle can include other statuses if the User Task is reassigned (delegated or escalated), revoked, suspended, stopped, or skipped.
 For further details, on the User Task lifecycle see the http://download.boulder.ibm.com/ibmdl/pub/software/dw/specs/ws-bpel4people/WS-HumanTask_v1.pdf[Web Services Human Task] specification.
 
-[[_reassignment]]
+[id='_reassignment']
 ==== Reassignment
 
 
@@ -1834,7 +1834,7 @@ Reassignment is defined in the `Reassignment` property of User Task elements. Th
 * [parameter]``Type``: A state in which the task needs to be at the given `Expires At` time so that the escalation is triggered.
 
 
-[[_notification]]
+[id='_notification']
 ==== Notification
 
 
@@ -1907,10 +1907,10 @@ In addition to custom task variables, the notification mechanism can use the fol
 ----
 ====
 
-[[_sect_connecting_objects]]
+[id='_sect_connecting_objects']
 == Connecting objects
 
-[[_connecting_objects]]
+[id='_connecting_objects']
 === Connecting Objects
 
 
@@ -1920,10 +1920,10 @@ Connecting object connect two elements. There are two main types of Connecting o
 * Association Flow, which connect any Process elements but have no execution semantics
 
 
-[[_sect_connecting_objects_types]]
+[id='_sect_connecting_objects_types']
 === Connecting Objects types
 
-[[_sequence_flow]]
+[id='_sequence_flow']
 ==== Sequence Flow
 
 A sequence flow represents the transition between two flow elements. It establishes an oriented relationship between activities, events, and gateways, and defines their execution order.
@@ -1954,7 +1954,7 @@ When defining a Condition Expression, make sure to call process and global varia
 You can also call the [var]``kcontext`` variable, which holds the process instance information.
 ====
 
-[[_sect_swimlanes]]
+[id='_sect_swimlanes']
 == Swimlanes
 
 Swimlanes visually group tasks related to one group or user. For example, you can create a marketing task swimlane to group all User Tasks related to marketing activities into one Lane.
@@ -1982,15 +1982,15 @@ This user must be eligible for claiming a task, that is, this user must be a pot
 
 For example, suppose there are two User Tasks, UT1 and UT2, located in the same lane. UT1 and UT2 have group field set to the `analyst` value. When the process is started, and UT1 is claimed, started, or completed by an `analyst` user, UT2 gets claimed and assigned to the user who completed UT1. If only UT1 has the `analyst` group assigned, and UT2 has no user or group assignments, the process stops after UT1 had been completed.
 
-[[_sect_artifacts]]
+[id='_sect_artifacts']
 == Artifacts
 
-[[_artifacts]]
+[id='_artifacts']
 === Artifacts
 
 Any object in the BPMN diagram that is not a part of the process workflow is an artifact. Artifacts have no incoming or outgoing flow objects. The purpose of artifacts is to provide additional information needed to understand the diagram.
 
-[[_data_objects]]
+[id='_data_objects']
 === Data Objects
 
 Data objects are visualizations of process or sub-process variables. Note that not every process or sub-process variable must be depicted as a data object in the BPMN diagram. Data Objects have separate visualization properties and variable properties.

--- a/docs/product-user-guide/src/main/asciidoc/appe-service-tasks.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/appe-service-tasks.adoc
@@ -1,5 +1,5 @@
 [appendix]
-[[_appe_service_tasks]]
+[id='_appe_service_tasks']
 = Service Tasks: WS Task, Email Task, REST Task
 
 Service task is a task that uses a service, such as a mail service, web service, or another service.
@@ -26,7 +26,7 @@ For more information about service tasks, see <<_ws_task>>, <<_email_task>>, and
 
 If you require other task types, implement your task as instructed in <<_sect_domain_specific_tasks>>.
 
-[[_ws_task]]
+[id='_ws_task']
 == WS Task
 
 The Web Service task implements the `WebServiceWorkItemHandler` class. The Web Service task serves as a web service client with the web service response stored as `String`. To invoke a Web Service task from a BPMN process, the correct task type must be used.
@@ -123,7 +123,7 @@ The method name to call.
 Result::
 An object with the result.
 
-[[_email_task]]
+[id='_email_task']
 == Email Task
 
 The Email task sends an email based on the task properties.
@@ -253,7 +253,7 @@ A boolean value related to the execution of the Email work item. For example:
 
 The Email task is completed immediately and cannot be aborted.
 
-[[_rest_task]]
+[id='_rest_task']
 == REST Task
 
 The REST task performs REST calls and outputs the response as an object.
@@ -362,7 +362,7 @@ If the service returned an error response, this variable will contain the error 
 All output attributes are `String` by default.
 
 [float]
-[[_handling_rest_response_error]]
+[id='_handling_rest_response_error']
 === Handling REST Response Error
 
 `HandleResponseErrors` can be handled in two ways:

--- a/docs/product-user-guide/src/main/asciidoc/appe-simulation-data.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/appe-simulation-data.adoc
@@ -1,8 +1,8 @@
 [appendix]
-[[_appe_simulation_data]]
+[id='_appe_simulation_data']
 = Simulation Data
 
-[[_process2]]
+[id='_process2']
 == Process
 
 [float]
@@ -13,7 +13,7 @@ The currency used for simulation.
 Base time unit::
 The time unit to apply to all the time definitions in the process.
 
-[[_activity1]]
+[id='_activity1']
 == Activities
 
 All the activities available in {PRODUCT}, except for the human task, share the following properties. See <<_human_tasks1>> for properties specific to human tasks.
@@ -27,7 +27,7 @@ The cost for every time unit lapsed during simulation.
 Distribution Type::
 For information about the `Distribution type` property, and the `Processing time` property if applicable, see <<_sect_distribution_types>>.
 
-[[_start_event1]]
+[id='_start_event1']
 == Start Event
 
 [float]
@@ -40,7 +40,7 @@ Probability (Boundary Event only)::
 The probability of triggering the element.
 
 
-[[_catching_intermediate_events1]]
+[id='_catching_intermediate_events1']
 == Catching Intermediate Events
 
 [float]
@@ -52,7 +52,7 @@ For information about the `Distribution type` property, and the `Processing time
 Probability (Boundary Event only)::
 The probability of triggering the element.
 
-[[_sequence_flow1]]
+[id='_sequence_flow1']
 == Sequence Flow
 
 [float]
@@ -65,7 +65,7 @@ The probability value is applied only if the flow's source element is a gateway 
 When defining flow probabilities, ensure their sum is 100.
 
 
-[[_throwing_intermediate_events1]]
+[id='_throwing_intermediate_events1']
 == Throwing Intermediate Events
 
 [float]
@@ -74,7 +74,7 @@ When defining flow probabilities, ensure their sum is 100.
 Distribution Type::
 For information about the `Distribution type` property, and the `Processing time` property if applicable, see <<_sect_distribution_types>>.
 
-[[_human_tasks1]]
+[id='_human_tasks1']
 == Human Tasks
 
 [float]
@@ -108,7 +108,7 @@ That results in the following:
 Working hours::
 A time period after which the task completes in a simulation. If the task should take an hour to complete, set this property to `1`.
 
-[[_end_events1]]
+[id='_end_events1']
 == End Events
 
 [float]
@@ -118,7 +118,7 @@ Distribution Type::
 For information about the `Distribution type` property, and the `Processing time` property if applicable, see <<_sect_distribution_types>>.
 
 
-[[_sect_distribution_types]]
+[id='_sect_distribution_types']
 == Distribution Types
 
 
@@ -131,7 +131,7 @@ The elements might use one of the following score distribution types on simulati
 * `Poisson`: the values are distributed on a negatively-skewed normal distribution curve.
 
 
-[[_normal]]
+[id='_normal']
 === Normal
 
 The element values are picked based on the normal distribution type, which is bell-shaped and symmetrical.
@@ -148,7 +148,7 @@ The standard deviation of the processing time. The value uses the time unit defi
 
 
 
-[[_uniform]]
+[id='_uniform']
 === Uniform
 
 The Uniform distribution or rectangular distribution returns the possible values with the same levels of probability.
@@ -163,7 +163,7 @@ Processing time (min)::
 The minimum processing time of the element.
 
 
-[[_poisson]]
+[id='_poisson']
 === Poisson
 
 The Poisson distribution returns the possible values similarly as normal distribution. However, the distribution is negatively skewed, not symmetrical. The mean and the variant are equal.

--- a/docs/product-user-guide/src/main/asciidoc/assets-DSLs-gloss.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/assets-DSLs-gloss.adoc
@@ -1,4 +1,4 @@
-[[_assets_DSLs_gloss]]
+[id='_assets_DSLs_gloss']
 = Domain Specific Languages (DSLs)
 
 Domain specific languages, or DSLs, are rule languages that are dedicated to problem domains.

--- a/docs/product-user-guide/src/main/asciidoc/assets-business-processes-gloss.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/assets-business-processes-gloss.adoc
@@ -1,4 +1,4 @@
-[[_assets_business_processes_gloss]]
+[id='_assets_business_processes_gloss']
 = Business Processes
 
 Business Processes are flow charts that describe the steps necessary to achieve business goals (see the https://access.redhat.com/documentation/en-US/JBoss_Enterprise_BRMS_Platform/5/html-single/BRMS_Business_Process_Management_Guide/index.html[_{PRODUCT} Business Process Management Guide_] for more details).

--- a/docs/product-user-guide/src/main/asciidoc/assets-business-rules-gloss.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/assets-business-rules-gloss.adoc
@@ -1,4 +1,4 @@
-[[_assets_business_rules_gloss]]
+[id='_assets_business_rules_gloss']
 = Business Rules
 
 Business Rules define a particular aspect of a business that is intended to assert business structure or influence the behaviour of a business.

--- a/docs/product-user-guide/src/main/asciidoc/assets-con.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/assets-con.adoc
@@ -1,4 +1,4 @@
-[[_assets_con]]
+[id='_assets_con']
 = Assets
 
 Business rules, process definition files, and other assets and resources created in Business Central are stored in the Artifact Repository (Knowledge Store) that is accessed by the {KIE_SERVER}.

--- a/docs/product-user-guide/src/main/asciidoc/assets-creating-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/assets-creating-proc.adoc
@@ -1,4 +1,4 @@
-[#creating_assets_proc_{context}]
+[id='creating_assets_proc_{context}']
 = Creating Assets
 
 You can create business processes, rules, DRL files, and other assets directly in Business Central and associate them with the projects that you create.

--- a/docs/product-user-guide/src/main/asciidoc/assets-data-models-gloss.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/assets-data-models-gloss.adoc
@@ -1,4 +1,4 @@
-[#_assets_data_models_gloss_{context}]
+[id='_assets_data_models_gloss_{context}']
 = Data Models
 
 Data models are models of data objects. A data object is a custom complex data type (for example, a Person object with data fields Name, Address, and Date of Birth).

--- a/docs/product-user-guide/src/main/asciidoc/assets-decision-tables-gloss.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/assets-decision-tables-gloss.adoc
@@ -1,4 +1,4 @@
-[[_assets_decision_tables_gloss]]
+[id='_assets_decision_tables_gloss']
 = Decision Tables
 
 Decision tables are collections of rules stored in either a spreadsheet or in the {PRODUCT_BRMS} user interface as guided decision tables.

--- a/docs/product-user-guide/src/main/asciidoc/assets-filtering-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/assets-filtering-proc.adoc
@@ -1,4 +1,4 @@
-[[_assets_filtering_proc]]
+[id='_assets_filtering_proc']
 = Filtering Assets by Tag
 
 You can apply tags in the metadata of each asset and then group assets by tags in the Project Explorer. This feature helps you quickly search through assets of a specific category.

--- a/docs/product-user-guide/src/main/asciidoc/assets-metadata-managing-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/assets-metadata-managing-proc.adoc
@@ -1,4 +1,4 @@
-[[_assets_metadata_managing_proc]]
+[id='_assets_metadata_managing_proc']
 = Managing Asset Metadata and Version History
 
 Most assets within Business Central have metadata and version information associated with them to help you identify and organize them within your projects. You can manage asset metadata and version history from the asset editor in Business Central.

--- a/docs/product-user-guide/src/main/asciidoc/assets-packages-gloss.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/assets-packages-gloss.adoc
@@ -1,4 +1,4 @@
-[[_assets_packages_gloss]]
+[id='_assets_packages_gloss']
 = Packages
 
 Packages are deployable collections of assets. Rules and other assets must be collected into a package before they can be deployed.

--- a/docs/product-user-guide/src/main/asciidoc/assets-projects-gloss.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/assets-projects-gloss.adoc
@@ -1,4 +1,4 @@
-[#_assets_projects_gloss_{context}]
+[id='_assets_projects_gloss_{context}']
 
 = Projects
 

--- a/docs/product-user-guide/src/main/asciidoc/assets-renaming-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/assets-renaming-proc.adoc
@@ -1,4 +1,4 @@
-[[_assets_renaming_proc]]
+[id='_assets_renaming_proc']
 = Renaming, Copying, or Deleting Assets
 
 After an asset has been created and defined, you can use the *Repository View* of the *Project Explorer* to copy, rename, delete, or archive assets as needed.

--- a/docs/product-user-guide/src/main/asciidoc/assets-rules-gloss.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/assets-rules-gloss.adoc
@@ -1,4 +1,4 @@
-[[_assets_rules_gloss]]
+[id='_assets_rules_gloss']
 = Rules
 
 Rules provide the logic for the rule engine to execute against.

--- a/docs/product-user-guide/src/main/asciidoc/assets-types-ref.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/assets-types-ref.adoc
@@ -1,4 +1,4 @@
-[[_assets_types_ref]]
+[id='_assets_types_ref']
 = Types of Assets
 
 Anything that can be stored as a version in the Business Central artifact repository is an asset. This includes rules, packages, business processes, decision tables, fact models, and domain specific languages (DSLs).

--- a/docs/product-user-guide/src/main/asciidoc/assets-unlocking-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/assets-unlocking-proc.adoc
@@ -1,4 +1,4 @@
-[[_assets_unlocking_proc]]
+[id='_assets_unlocking_proc']
 = Unlocking Assets
 
 By default, whenever you open and modify an asset in Business Central, that asset is automatically locked for your exclusive use in order to avoid conflicts in a multiuser setup. This lock is automatically released when your session ends or when you save or close the asset. This lock feature ensures that users do not overwrite each other's changes.

--- a/docs/product-user-guide/src/main/asciidoc/bpms-and-brms-con.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/bpms-and-brms-con.adoc
@@ -1,4 +1,4 @@
-[[_bpms_and_brms_con]]
+[id='_bpms_and_brms_con']
 = {PRODUCT_BPMS} and {PRODUCT_BRMS}
 
 {PRODUCT_BPMS} comes with integrated {PRODUCT_BRMS}, a rule engine and rule tooling, so you can define rules governing processes or tasks.

--- a/docs/product-user-guide/src/main/asciidoc/business-central-con.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/business-central-con.adoc
@@ -1,4 +1,4 @@
-[[_business_central_con]]
+[id='_business_central_con']
 = Business Central
 
 ifdef::BPMS[]

--- a/docs/product-user-guide/src/main/asciidoc/business-central-embedding-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/business-central-embedding-proc.adoc
@@ -1,4 +1,4 @@
-[[_embedding_business_central_proc]]
+[id='_embedding_business_central_proc']
 = Embedding Business Central
 
 You can embed Business Central in your own applications using standalone mode so that you can edit rules, processes, decision tables, and other assets directly from your applications without switching to Business Central.

--- a/docs/product-user-guide/src/main/asciidoc/business-central-home-con.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/business-central-home-con.adoc
@@ -1,4 +1,4 @@
-[[_business_central_home_con]]
+[id='_business_central_home_con']
 = Business Central Home
 
 ifdef::BPMS[]
@@ -165,7 +165,7 @@ After you create a perspective, you must manually add it to the Business Dashboa
 
 
 ifdef::BPMS[]
-[[_projects_and_teams_metrics_dashboard]]
+[id='_projects_and_teams_metrics_dashboard']
 
 == Projects Metrics Dashboard
 

--- a/docs/product-user-guide/src/main/asciidoc/business-central-login-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/business-central-login-proc.adoc
@@ -1,4 +1,4 @@
-[[_business_central_login_proc]]
+[id='_business_central_login_proc']
 = Logging in to Business Central
 ifdef::BPMS[]
 After you have successfully installed and configured {EAP} and {Product}, and have started the {EAP} server, you can then access Business Central from a web browser to begin creating or managing business processes and rules.

--- a/docs/product-user-guide/src/main/asciidoc/business-central-settings-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/business-central-settings-proc.adoc
@@ -1,4 +1,4 @@
-[[_business_central_settings_proc]]
+[id='_business_central_settings_proc']
 = Business Central Settings
 
 You can customize several {PRODUCT} settings.

--- a/docs/product-user-guide/src/main/asciidoc/business-central-settings-security-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/business-central-settings-security-proc.adoc
@@ -1,4 +1,4 @@
-[[_business_central_settings_security_proc]]
+[id='_business_central_settings_security_proc']
 = Security Settings
 
 You can manage roles, groups, and users on the Security perspective. 

--- a/docs/product-user-guide/src/main/asciidoc/chap-advanced-process-modeling.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/chap-advanced-process-modeling.adoc
@@ -1,7 +1,7 @@
-[[_chap_advanced_process_modeling]]
+[id='_chap_advanced_process_modeling']
 = Advanced Process Modeling
 
-[[_sect_process_modeling_options]]
+[id='_sect_process_modeling_options']
 == Process modeling options
 
 
@@ -25,7 +25,7 @@ You can use the {PRODUCT} API directly. The most important process model element
 See the {URL_DEVELOPMENT_GUIDE}#sect_process_fluent_api[Process Fluent API] chapter of the _{DEVELOPMENT_GUIDE}_ for further information.
 
 
-[[_sect_workflow_patterns]]
+[id='_sect_workflow_patterns']
 == Workflow patterns
 
 
@@ -37,7 +37,7 @@ To attach a pattern to an element on the canvas, select the element and drag-and
 Multiple predefined workflow patterns are provided by default and you can define your own workflow patterns as necessary.
 The definitions are defined as JSON objects in the `_EAP_HOME_/standalone/deployments/business-central.war/org.kie.workbench.KIEWebapp/defaults/patterns.json` file.
 
-[[_defining_process_patterns]]
+[id='_defining_process_patterns']
 === Defining workflow patterns
 
 

--- a/docs/product-user-guide/src/main/asciidoc/chap-assets.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/chap-assets.adoc
@@ -1,4 +1,4 @@
-[[_chap_assets]]
+[id='_chap_assets']
 
 include::assets-con.adoc[]
 

--- a/docs/product-user-guide/src/main/asciidoc/chap-basic-concepts.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/chap-basic-concepts.adoc
@@ -1,4 +1,4 @@
-[[_chap_basic_concepts]]
+[id='_chap_basic_concepts']
 = Basic concepts
 
 Red Hat JBoss BPM Suite provides tools for creating, editing, running, and runtime management of BPMN process models.

--- a/docs/product-user-guide/src/main/asciidoc/chap-business-central.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/chap-business-central.adoc
@@ -1,4 +1,4 @@
-[[_chap_business_central]]
+[id='_chap_business_central']
 
 include::business-central-con.adoc[]
 

--- a/docs/product-user-guide/src/main/asciidoc/chap-case-management.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/chap-case-management.adoc
@@ -1,4 +1,4 @@
-[#chap-case-management]
+[id='chap-case-management']
 = Case Management
 
 [IMPORTANT]

--- a/docs/product-user-guide/src/main/asciidoc/chap-data-sets.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/chap-data-sets.adoc
@@ -1,3 +1,5 @@
+include::data-sets-con.adoc[]
+
 include::data-sets-add-proc.adoc[leveloffset=+1]
 
 include::data-sets-edit-proc.adoc[leveloffset=+1]

--- a/docs/product-user-guide/src/main/asciidoc/chap-deploying-projects.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/chap-deploying-projects.adoc
@@ -1,4 +1,4 @@
-[[_chap_deploying_projects]]
+[id='_chap_deploying_projects']
 = Deploying and Managing Projects
 
 After you have created a project with your process definition and relevant resources, you must build it and deploy it to the process engine.
@@ -59,7 +59,7 @@ The process definition view contains two main sections:
 The process definition list shows all the available process definitions that are deployed into the platform. If you click on any of the process definition listed in the Process Definitions List, the corresponding Process Definition details displays information about the process definition such as if there is a sub-process associated with it, or how many users and groups exist in the process definition.
 In the Process Definition details section, you can navigate to *Options* -> *View Process Instances* to view associated process instances.
 
-[[_sect_process_instances]]
+[id='_sect_process_instances']
 === Process Instances
 
 You can create new process instances from the *Process Definition List*, from the *Process Definition Detail* view or from the *Process Instance* view. When you create a new Process Instance, a new window opens that requires you to provide information required by the process to be started. After you provide the required information and click *Submit*, the instance is created and the details of the process instance are displayed in *Process Instance Details* on the right.
@@ -168,7 +168,7 @@ image::New_Process_Instance_List.png[New Process Instance List]
 A new tab is created that displays your custom process instance list.
 
 ifdef::BPMS[]
-[[sect-process-instance-filtering]]
+[id='sect-process-instance-filtering']
 === Advanced Search Filtering of Process Instances
 
 Administrators and process administrators can search for process instances using the *Search* tab on the *Process Instances* perspective.
@@ -237,7 +237,7 @@ For more information about advanced search filtering, see <<chap-process-admin-q
 
 endif::BPMS[]
 
-[[_aborting_a_process_instance]]
+[id='_aborting_a_process_instance']
 === Aborting a Process instance
 
 
@@ -258,7 +258,7 @@ To abort a Process instance from the Business Central, do the following:
 . On the top menu of the Business Central, go to *Menu* -> *Manage* -> *Process Instances*.
 . In the list on the *Process Instances* tab, locate the required Process instance and click the *Abort* button in the instance row.
 
-[[_signaling_a_process_instance]]
+[id='_signaling_a_process_instance']
 === Signaling Process Instance
 
 You can signal a running process instance using either API or Business Central. For further information about signals, signaling external deployment, catching and processing signals, and more, see <<_sect_collaboration_mechanisms>>.
@@ -302,7 +302,7 @@ NOTE: When using the Business Central user interface, you may signal only Signal
 
 
 
-[[_sect_user_tasks]]
+[id='_sect_user_tasks']
 == Task Management
 
 
@@ -349,7 +349,7 @@ The Task Details section comprises the following tabs:
 
 
 
-[[_creating_custom_tasks_filters]]
+[id='_creating_custom_tasks_filters']
 === Creating Custom Tasks Filters
 
 
@@ -386,7 +386,7 @@ image::in_name-column.png[]
 
 ifdef::BPMS[]
 
-[[sect-task-filtering]]
+[id='sect-task-filtering']
 === Advanced Search Filtering of Tasks
 
 Task filtering includes the same filter attributes whether you are searching the *Task List* for users, or the *Task Administration List* for process administrators and administrators.

--- a/docs/product-user-guide/src/main/asciidoc/chap-examples.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/chap-examples.adoc
@@ -1,4 +1,4 @@
-[[_chap_examples]]
+[id='_chap_examples']
 = Examples
 
 

--- a/docs/product-user-guide/src/main/asciidoc/chap-graphic-resources.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/chap-graphic-resources.adoc
@@ -1,4 +1,4 @@
-[[_chap_graphic_resources]]
+[id='_chap_graphic_resources']
 = Graphic Resources
 
 Red Hat JBoss Dashboard Builder
@@ -24,7 +24,7 @@ Every component definition contains the following:
 When creating custom graphic resources, it is recommended to download one of the existing components and modify it as necessary.
 This will prevent unnecessary mistakes in your definition.
 
-[[_adding_graphic_resources]]
+[id='_adding_graphic_resources']
 == Working With Graphic Resources
 
 

--- a/docs/product-user-guide/src/main/asciidoc/chap-introduction-brms.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/chap-introduction-brms.adoc
@@ -1,7 +1,7 @@
-[[_chap_introduction]]
+[id='_chap_introduction']
 = Introduction
 
-[[_jboss_brms]]
+[id='_jboss_brms']
 
 include::about-product-con.adoc[leveloffset=+1]
 

--- a/docs/product-user-guide/src/main/asciidoc/chap-introduction.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/chap-introduction.adoc
@@ -1,4 +1,4 @@
-[[_chap_introduction]]
+[id='_chap_introduction']
 = Introduction
 
 include::about-product-con.adoc[leveloffset=+1]

--- a/docs/product-user-guide/src/main/asciidoc/chap-logging.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/chap-logging.adoc
@@ -1,4 +1,4 @@
-[[_chap_logging]]
+[id='_chap_logging']
 = Logging
 
 

--- a/docs/product-user-guide/src/main/asciidoc/chap-management-console.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/chap-management-console.adoc
@@ -1,4 +1,4 @@
-[[_chap_management_console]]
+[id='_chap_management_console']
 = Management Console
 
 Click *General Configuration* at the upper right hand corner of the standalone Dashbuilder application to access the management console.

--- a/docs/product-user-guide/src/main/asciidoc/chap-plug-in.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/chap-plug-in.adoc
@@ -19,7 +19,7 @@ To create a BPM project:
 * `Java and jBPM Runtime classes`: select the runtime to be used by the project or click *Manage Runtime Definitions...* and define a new runtime (for details on runtime resources, see the _{DEVELOPMENT_GUIDE}_).
 * `Maven`: specify maven properties of your project.
 
-[[_creating_process]]
+[id='_creating_process']
 = Creating Process
 
 In JBoss Developer Studio with the Red Hat JBoss BPM Suite plug-in, create a process the same way as other resources:
@@ -30,7 +30,7 @@ In JBoss Developer Studio with the Red Hat JBoss BPM Suite plug-in, create a pro
 
 Once created, the process opens for editing in the graphical Process Designer.
 
-[[_checking_session_logs]]
+[id='_checking_session_logs']
 = Checking Session Logs
 
 The audit log allows you to check the log of all events logged during the session. Audit log is an XML-based log file that contains a log of all the events that occurred while executing a specific KIE session.

--- a/docs/product-user-guide/src/main/asciidoc/chap-process-admin-quick-filtering.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/chap-process-admin-quick-filtering.adoc
@@ -1,4 +1,4 @@
-[[chap-process-admin-quick-filtering]]
+[id='chap-process-admin-quick-filtering']
 = Process Administration Advanced Search Filtering
 
 Business Central allows you to search for process instances, tasks, jobs, and errors by applying filters to narrow down the list of results displayed in the *Search* tab of the relevant perspective. 
@@ -7,7 +7,7 @@ All *Search* tabs use a single filter by default to show working results. The re
 
 Filters applied while using the *Search* tab are cleared whenever you navigate to a different screen in Business Central, and cannot be saved for reuse. To create save a custom filter for reuse, use the image:plus_icon.png[] button at the end of the tabs list to create a new filtered list. For more information about creating custom filters, see <<_chap_deploying_projects>>.
 
-[[sect-filtering-using-input-field]]
+[id='sect-filtering-using-input-field']
 == Searching Using the Input Field
 
 The default *Search* tab includes an input field that allows you to search for certain filter attributes manually. These filter attributes vary depending on which results you are filtering.
@@ -26,7 +26,7 @@ To create a filter using the input field, do the following:
 
 The results are filtered according to all results that match your the input for the attribute. 
 
-[[sect-advanced-search-filter-perspectives]]
+[id='sect-advanced-search-filter-perspectives']
 == Using the Advanced Search Filter Perspectives
 
 To search for specific process instances, jobs, tasks, or errors, use the *Search* tab to filter the results in the perspective.

--- a/docs/product-user-guide/src/main/asciidoc/chap-process-designer.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/chap-process-designer.adoc
@@ -1,4 +1,4 @@
-[[_chap_process_designer]]
+[id='_chap_process_designer']
 = Process Designer
 
 
@@ -29,8 +29,8 @@ Details on execution semantics and properties of individual BPMN2 shapes are ava
 . The Properties panel displays the properties of the selected element. If no element is selected, the panel contains process properties.
 +
 . The editor toolbar enables you, for example, to select an operation to be applied to the Elements on the canvas. It also contains tools for validation, simulation, saving, and others.
- 
-[[_configuring_automatic_saving]]
+
+[id='_configuring_automatic_saving']
 == Configuring Automatic Saving
 
 
@@ -41,7 +41,7 @@ To set an automatic saving, click the image:save-button.png[] button in Process 
 image::5216.png[Enable autosave feature in Process Designer.]
 
 
-[[_defining_process_properties]]
+[id='_defining_process_properties']
 == Defining Process Properties
 
 To define process properties, do the following:
@@ -63,8 +63,13 @@ image::3415.jpg[Variable definition input field with the arrow for calling the e
 . Define the process properties on the tab by clicking individual entries. For entries that require other input than just string input, the respective editors can be used by clicking the arrow icon. Note that editors for complex fields mostly provide validation and auto-completion features.
 . To save your changes, click *Save* in the top right corner.
 
+<<<<<<< HEAD
 [[_sect_designing_a_process]]
 == Designing a Process
+=======
+[id='_sect_designing_a_process']
+== Designing Process
+>>>>>>> 385fed4... BXMSDOC-1517-master-B Update anchor format to [id='anchor-name'] in User Guide.
 
 
 To model a process, do the following:
@@ -110,7 +115,7 @@ To copy a business process into the same package:
 . The *Copy this item* dialogue window appears. Name your copy.
 . Click *Create copy*.
 
-[[_aligning_elements]]
+[id='_aligning_elements']
 === Aligning Elements
 
 
@@ -129,7 +134,7 @@ image::5924.png[]
 
 Note that dockers of Connection elements are not influenced by aligning and you might need to remove them.
 
-[[_solving_overlapping_of_elements]]
+[id='_solving_overlapping_of_elements']
 === Changing Element Layering
 
 
@@ -145,7 +150,7 @@ Choose one of the following options:
 
 Note that the connection elements are not influenced by the layering and remain always visible.
 
-[[_bending_connection_elements]]
+[id='_bending_connection_elements']
 === Bending Connection Elements
 
 
@@ -153,7 +158,7 @@ You can bend the connection elements and create angles in your business process.
 
 image:0011.png[]
 
-[[_resizing_elements]]
+[id='_resizing_elements']
 === Resizing Elements
 
 
@@ -163,7 +168,7 @@ To make the size of multiple elements identical, select the Elements and then cl
 
 Note that only Activity Elements can be resized.
 
-[[_grouping_elements]]
+[id='_grouping_elements']
 === Grouping Elements
 
 To create and manage an element group:
@@ -173,7 +178,7 @@ To create and manage an element group:
 . Click *Deletes the group of all selected shapes* (image:5221.png[]) to ungroup the elements.
 
 
-[[_locking_elements]]
+[id='_locking_elements']
 === Locking Elements
 
 
@@ -183,7 +188,7 @@ When you lock process model elements, the elements cannot be edited or moved.
 * To unlock the elements, select the elements and click *Unlock Elements* (image:5223.png[]).
 
 
-[[_changing_the_color_scheme]]
+[id='_changing_the_color_scheme']
 === Changing Color Scheme
 
 
@@ -207,7 +212,7 @@ In order to be able to use the new color schemes, you have to reload the browser
 
 To apply a new color scheme or any other defined scheme, click the image:5224.png[] button in the Process Designer toolbar and select one of the available color schemes from the drop-down menu.
 
-[[_recording_local_history]]
+[id='_recording_local_history']
 === Recording local history
 
 
@@ -216,13 +221,13 @@ Local history keeps track of any changes you apply to your process model to allo
 To turn on local history recording, click the *Local History* image:5225.png[] button and select *Enable Local History* entry.
 From this menu, you can also display the local history records and apply the respective status to the process as well as disable the feature or clear the current local history log.
 
-[[_enlarging_and_shriking_canvas]]
+[id='_enlarging_and_shriking_canvas']
 === Enlarging and shrinking canvas
 
 
 To change the size of the canvas, click the respective yellow arrow on the canvas edge.
 
-[[_validating_a_process]]
+[id='_validating_a_process']
 === Validating a Process
 
 
@@ -268,7 +273,7 @@ Alternatively, you can edit the XML to correct the business process and click *S
 You can now open the valid process and view it as a diagram on the canvas.
 
 
-[[_exporting_a_process1]]
+[id='_exporting_a_process1']
 == Exporting Process
 
 
@@ -296,10 +301,10 @@ Note that Internet Explorer 11 does not support PDF objects in HTML.
 image::5925.png[]
 
 
-[[_sect_process_elements]]
+[id='_sect_process_elements']
 == Process Elements
 
-[[_process_elements]]
+[id='_process_elements']
 === Generic Properties of Visualized Process Elements
 
 
@@ -320,7 +325,7 @@ The size of the font in the element name
 Name::
 The element name displayed on the BPMN diagram
 
-[[_defining_process_elements_properties]]
+[id='_defining_process_elements_properties']
 === Defining Process Element Properties
 
 
@@ -347,7 +352,7 @@ To define element properties, do the following:
 . Click *Save* in the upper right corner and fill out the *Save this item* dialogue to save your changes.
 
 
-[[_sect_save_point]]
+[id='_sect_save_point']
 == Business Process Save Points
 
 
@@ -367,7 +372,7 @@ Asynchronous continuation allows process designers to decide what activities sho
 
 The `Is Async` feature is available for all task types (Service, Send, Receive, Business Rule, Script, and User Tasks), subprocesses (embedded and reusable), and multi-instance task and subprocesses. When marked `Is Async`, the node execution is started in a separate thread.
 
-When the engine encounters one of the save point nodes, the transaction is commited into the database before continuing with the execution. This ensures that the state of the process is saved.   
+When the engine encounters one of the save point nodes, the transaction is commited into the database before continuing with the execution. This ensures that the state of the process is saved.
 
 [NOTE]
 ====
@@ -376,13 +381,13 @@ Asynchronous processing relies on Executor Service component, which must be conf
 For fully asynchronous workflow execution, use the {KIE_SERVER} configured with JMS Queues.
 ====
 
-[[_sect_forms]]
+[id='_sect_forms']
 == Forms
 
 
 A _form_ is a layout definition for a page (defined as HTML) that is displayed as a dialog window to the user on:
 
-* Process instantiation 
+* Process instantiation
 * Task instantiation
 
 
@@ -393,7 +398,7 @@ The form is then respectively called a _process form_ or a _task form_. Forms ac
 
 For example:
 
-* With a process form, a user can provide the input parameters needed for process instantiation. 
+* With a process form, a user can provide the input parameters needed for process instantiation.
 * With a task form, you can use a Human Task to provide input for further process execution.
 
 The input is then mapped to the task using the data input assignment, which you can then use inside of a task. When the task is completed, the data is mapped as a data output assignment to provide the data to the parent process instance. For further information, see <<_sect_assignment>>.
@@ -412,7 +417,7 @@ To create a process form, do the following:
 
 Note that the Form is created in the root of your current Project and is available from any other process definitions in the Projects.
 
-[[_defining_task_form]]
+[id='_defining_task_form']
 === Defining Task form
 
 
@@ -426,7 +431,7 @@ To create a task form, do the following:
 . In the displayed Form Editor, define the task form.
 
 
-[[_defining_forms]]
+[id='_defining_forms']
 === Defining form fields
 
 
@@ -438,7 +443,7 @@ You can add either the pre-defined field types to your form, or define your own 
 Automatic form generation is not recursive, which means that when custom data objects are used, only the top-level form is generated (no subforms). The user is responsible for creating forms that represent the custom data objects and link them to the parent form.
 ====
 
-[[_sect_form_modeler]]
+[id='_sect_form_modeler']
 == Form Modeler
 
 Red{nbsp}Hat JBoss{nbsp}BPM{nbsp}Suite provides a custom editor for defining forms called Form Modeler.
@@ -500,7 +505,7 @@ The following figure shows a new form created in Form Modeler.
 image::5424.png[]
 
 
-[[_opening_an_existing_form_in_form_modeler]]
+[id='_opening_an_existing_form_in_form_modeler']
 === Opening an Existing Form in Form Modeler
 
 
@@ -513,7 +518,7 @@ To open an existing form in a project that already has a form defined, go to *Fo
 image::5427.png[]
 
 
-[[_setting_properties_of_a_form_field_in_form_modeler]]
+[id='_setting_properties_of_a_form_field_in_form_modeler']
 === Setting Properties of a Form Field in Form Modeler
 
 
@@ -524,7 +529,7 @@ To set the properties of a form field, do the following:
 . In the *Properties* dialog window that opens on the right, set the form field properties and click *Apply* at the bottom of the dialog window for HTML Labels. For other form field properties, the properties change once you have removed focus from the property that you are modifying.
 
 
-[[_configuring_a_process_in_form_modeler]]
+[id='_configuring_a_process_in_form_modeler']
 === Configuring a Process in Form Modeler
 
 
@@ -545,7 +550,7 @@ image::5803.png[]
 
 ====
 
-[[_generating_forms_from_task_definitions]]
+[id='_generating_forms_from_task_definitions']
 === Generating Forms from Task Definitions
 
 
@@ -561,7 +566,7 @@ image::5830.png[]
 
 Forms follow a naming convention that relates them to tasks. If you define a form named `_TASK_NAME_-taskform` in the same package as the process, the human task engine will use the form to display and capture information entered by the user. If you create a form named ``_PROCESS_ID_-task``, the application will use it as the initial form when starting the process.
 
-[[_editing_forms]]
+[id='_editing_forms']
 === Editing Forms
 
 
@@ -577,7 +582,7 @@ When you display the fields in the editor, the color of the data origin is displ
 
 To customize a form, you can for example move fields, add new fields, configure fields, or set values for object properties.
 
-[[_moving_a_field_in_form_modeler]]
+[id='_moving_a_field_in_form_modeler']
 === Moving a Field in Form Modeler
 
 
@@ -595,7 +600,7 @@ After you click the *Move field* option, a set of rectangular contextual icons a
 image::5833.png[]
 
 
-[[_adding_new_fields_to_a_form]]
+[id='_adding_new_fields_to_a_form']
 === Adding New Fields to a Form
 
 
@@ -898,7 +903,7 @@ To use these field types, it is necessary to create extra forms in order to disp
 
 |===
 
-[[_configuring_fields_of_a_form]]
+[id='_configuring_fields_of_a_form']
 === Configuring Fields of a Form
 
 
@@ -921,7 +926,7 @@ Generic field properties:
 * `Output Binding Expression` defines the link between the field and the process task output variable. In runtime, it is used to set the task output variable.
 
 
-[[_creating_subforms_with_simple_and_complex_field_types]]
+[id='_creating_subforms_with_simple_and_complex_field_types']
 === Creating Subforms with Simple and Complex Field Types
 
 
@@ -985,7 +990,7 @@ image::7225.png[Parent Form]
 This inserts your subform containing an array of Java objects inside the parent form.
 
 
-[[_attaching_documents_to_a_form]]
+[id='_attaching_documents_to_a_form']
 === Attaching Documents to a Form
 
 
@@ -1062,7 +1067,7 @@ If you want to view or modify the attachments inside of the task forms, create a
 --
 * Name: `taskdoc_out`
 * Data Type: `Object`
-* Target: `document` 
+* Target: `document`
 --
 ---
 +
@@ -1103,7 +1108,7 @@ For example, if you create a custom strategy that stores your uploaded documents
 There is a default marshalling strategy that simply saves the uploaded documents in the file system under a folder called `docs`.
 This default implementation is defined by the [class]``DocumentStorageService`` class and is implemented through the [class]``DocumentStorageServiceImpl`` class.
 
-[[_sect_rendering_forms_for_external_use]]
+[id='_sect_rendering_forms_for_external_use']
 === Rendering Forms for External Use
 
 
@@ -1191,7 +1196,7 @@ The JavaScript library is pretty comprehensive and provides several methods to r
 * ``divId``: The identifier of the div that contains the form.
 
 
-[[_sect_variables]]
+[id='_sect_variables']
 == Variables
 
 
@@ -1217,7 +1222,7 @@ Values of local variables can be mapped to global or process variables using the
 Such isolation may help prevent technical exceptions.
 
 
-[[_sect_globals]]
+[id='_sect_globals']
 === Global Variables
 
 
@@ -1234,7 +1239,7 @@ The rules are evaluated at the moment the fact is inserted.
 Therefore, if you are using a global variable to constrain a fact pattern and the global is not set, the system returns a ``NullPointerException``.
 ====
 
-[[_creating_global_variables]]
+[id='_creating_global_variables']
 ==== Creating Global Variables
 
 
@@ -1260,7 +1265,7 @@ image::5226.png[]
 image::5227.png[]
 . Click *Ok* to add the global variable.
 
-[[_process_variables]]
+[id='_process_variables']
 ==== Process variables
 
 
@@ -1275,12 +1280,12 @@ Their value can be changed by the process Activities using the Assignment, when 
 . In Business Central, go to *Menu -> Design -> Projects* and click on the project name. For example, *Evaluation*.
 . Click on an empty space in the canvas and click image:3140.png[].
 . Click on the text field next to *Variable Definitions* and click image:6563.png[].
-. Define your variables in the *Editor for Variable Definitions* window. 
+. Define your variables in the *Editor for Variable Definitions* window.
 . Click *Ok* and *Save* to save your process.
 
 Note that process variables should be mapped to local variables. See <<_sect_local_variables>> for more information.
 
-[[_sect_local_variables]]
+[id='_sect_local_variables']
 === Local Variables
 
 
@@ -1299,7 +1304,7 @@ Local variables are initialized when the process element instance is created.
 Their value can be changed by their parent Activity by a direct call to the variable.
 ====
 
-[[_accessing_local_variables]]
+[id='_accessing_local_variables']
 ==== Accessing Local Variables
 
 
@@ -1387,7 +1392,7 @@ When a process instance is inserted into ksession as a fact, it can only be used
 ====
 
 
-[[_action_scripts]]
+[id='_action_scripts']
 == Action Scripts
 
 
@@ -1411,7 +1416,7 @@ System.out.println( person.name );
 ----
 ====
 
-[[_interceptor_actions]]
+[id='_interceptor_actions']
 == Interceptor Actions
 
 
@@ -1426,7 +1431,7 @@ You can define both types of actions in the *Properties*
 You can define them either in Java, Javascript, Drools, or MVEL, and set the language in the *Script Language*
  property.
 
-[[_sect_assignment]]
+[id='_sect_assignment']
 == Assignment
 
 
@@ -1499,7 +1504,7 @@ This is demonstrated by the `maxamount` Data Input, that has the constant ``1000
 
 The `myvar` Data Input and Data Output demonstrates a custom *Data Type*``com.test.MyType``, which is entered in the dialog window by the user.
 
-[[_constraints2]]
+[id='_constraints2']
 == Constraints
 
 
@@ -1569,7 +1574,7 @@ When a Java script cannot be represented by the editor, the following alert appe
 
 image::6087.png[]
 
-[[_sect_domain_specific_tasks]]
+[id='_sect_domain_specific_tasks']
 == Domain-Specific Tasks
 
 
@@ -1591,7 +1596,7 @@ For the Execution Engine to execute your custom work item, you need to:
 Work Item Definition::
 A work item definition defines how the custom task is presented (its name, icon, parameters, and similar attributes).
 
-[[_sect_work_item_definition]]
+[id='_sect_work_item_definition']
 === Work Item Definition
 
 
@@ -1658,7 +1663,7 @@ If the dependencies are located in a Maven repository, you can define them in th
 --
 
 
-[[_creating_a_work_item]]
+[id='_creating_a_work_item']
 === Creating Custom Work Item Definition
 
 [float]
@@ -1716,7 +1721,7 @@ Additionally, The icon defined in the WID must be set and exist in your project.
 
 
 [float]
-[[pre_defined_list_enum]]
+[id='pre_defined_list_enum']
 ==== Assign Pre-Defined ListDataType or Enumeration to Work Item Definitions
 The process designer allows you to add service task list of predefined values for assignments:
 
@@ -1773,7 +1778,7 @@ To upload a custom icon for your work item definition, follow these steps:
 
 You can now refer to your icon in your WID. Your WID is in the Process Designer, in the *Service Tasks* section by default.
 
-[[_work_item_handler]]
+[id='_work_item_handler']
 === Work Item Handler
 
 
@@ -1858,7 +1863,7 @@ If you use the work item in a maven project, you need to declare the following d
 To abort the work item, use the `WorkItemHandler.abortWorkItem()` before it is completed.
 For more information about asynchronous execution, see _{DEVELOPMENT_GUIDE}_.
 
-[[_registering_a_work_item_handler]]
+[id='_registering_a_work_item_handler']
 === Registering Work Item handler in Business Central
 
 
@@ -1941,7 +1946,7 @@ RuntimeEnvironment environment = RuntimeEnvironmentBuilder.Factory.get().newDefa
   .userGroupCallback(userGroupCallback)
   .addAsset(ResourceFactory.newClassPathResource("BPMN2-ScriptTask.bpmn2"), ResourceType.BPMN2)
   .registerableItemsFactory(new DefaultRegisterableItemsFactory() {
- 
+
     @Override
     public Map<String, WorkItemHandler> getWorkItemHandlers(RuntimeEngine runtime) {
       Map<String, WorkItemHandler> handlers = super.getWorkItemHandlers(runtime);
@@ -1950,7 +1955,7 @@ RuntimeEnvironment environment = RuntimeEnvironmentBuilder.Factory.get().newDefa
     }
   })
   .get();
- 
+
 manager = RuntimeManagerFactory.Factory.get().newSingletonRuntimeManager(environment);
 
 ----
@@ -1978,7 +1983,7 @@ For a list of Maven dependencies, see example _Embedded jBPM Engine Dependencies
 The recommended practice is to use the https://github.com/droolsjbpm/jbpm/tree/7.0.x/jbpm-services/jbpm-services-api/src/main/java/org/jbpm/services/api[Service API] and register your work item handlers in KJAR in `kie-deployment-descriptor.xml`.
 ====
 
-[[_sect_service_repository]]
+[id='_sect_service_repository']
 == Service Repository
 
 The service repository feature enables you to import an already existing service from a repository directly into your project. It allows multiple users to reuse generic services, such as work items allowing integration with Twitter, performing file system operations, and similar. Imported work items are automatically added to your palette and ready to use.
@@ -1998,7 +2003,7 @@ A public service repository with various predefined work items is available at h
 
 NOTE: Although you can import any work items, only the following work items are available by default (and supported) in {PRODUCT}: Log, Email, Rest, and WS. You can still import the other work items, but they are _not_ supported by Red Hat.
 
-[[_connecting_to_a_service_repository1]]
+[id='_connecting_to_a_service_repository1']
 === Installing Services from Service Repository
 
 There are two ways of installing services from a service repository: using Process Designer in Business Central or during the Business Central startup process.
@@ -2024,7 +2029,7 @@ After the service is successfully installed, a notification will appear on the s
 The automatic installation enables you to specify the repository URL and a list of services to be installed during the Business Central startup process. The services are then ready for use after you create or open a process in Process Designer.
 
 NOTE: Make sure you have the correct service names specified in the service's `.wid` file ready.
- 
+
 To install a service (for example Twitter) from the repository located at http://docs.jboss.org/jbpm/v6.4/repository/, start the server using the following command:
 
 [source]
@@ -2045,7 +2050,7 @@ You can specify more services at once by separating them with a comma. Install-a
 Every work item must be registered in the `_DEPLOY_DIRECTORY_/business-central.war/WEB-INF/classes/META-INF/CustomWorkItemHandler.conf` file. If a work item is not registered in the file, it will not be available for use.
 ====
 
-[[_setting_up_a_service_repository]]
+[id='_setting_up_a_service_repository']
 === Setting up Service Repository
 
 A service repository can be any repository, local or remote, with the `index.conf` file in its root directory.
@@ -2137,7 +2142,7 @@ When creating a work item configuration file, it is also possible to use JSON in
 ----
 ====
 
-[[_interacting_with_service_repository]]
+[id='_interacting_with_service_repository']
 === Retrieving Service Repository Information
 
 Classes provided in the `org.jbpm.process.workitem` package allow you to connect to the service and retrieve service information. For example, to list all the services contained in a repository and declared in `index.conf`, use:
@@ -2172,7 +2177,7 @@ if(workitemsFromRepo.containsKey("Twitter") && workitemsFromRepo.get("Twitter").
 IMPORTANT: All operations are read-only. It is not possible to update the service repository automatically.
 
 
-[[_sect_actor_assignment_calls]]
+[id='_sect_actor_assignment_calls']
 == Actor assignment calls
 
 
@@ -2190,7 +2195,7 @@ The Administrator can manipulate the life cycle of all Tasks, even if not being 
 ====
 
 
-[[_sect_ldap_connection]]
+[id='_sect_ldap_connection']
 == LDAP connection
 
 
@@ -2217,7 +2222,7 @@ The LDAP UserGroupCallback implementation takes the following properties:
 * [property]``java.naming.provider.url``: LDAP url (by default ``ldap://localhost:389``; if the protocol is set to `ssl` then ``ldap://localhost:636``)
 
 
-[[_connecting_to_ldap]]
+[id='_connecting_to_ldap']
 === Connecting to LDAP
 
 
@@ -2265,7 +2270,7 @@ ldap.user.roles.filter=(member\={0})
 ----
 
 
-[[_exception_management]]
+[id='_exception_management']
 == Exception Management
 
 
@@ -2294,4 +2299,3 @@ Compensation is equivalent to the Error mechanism; however, it can be used only 
 
 
 Technical components used in a process fail in a way that cannot be described using BPMN (for further information, see _{DEVELOPMENT_GUIDE}_). For other technical issues, such as failure to connect to an external system, should be escalated to the system administrator.
-

--- a/docs/product-user-guide/src/main/asciidoc/chap-process-designer.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/chap-process-designer.adoc
@@ -63,14 +63,8 @@ image::3415.jpg[Variable definition input field with the arrow for calling the e
 . Define the process properties on the tab by clicking individual entries. For entries that require other input than just string input, the respective editors can be used by clicking the arrow icon. Note that editors for complex fields mostly provide validation and auto-completion features.
 . To save your changes, click *Save* in the top right corner.
 
-<<<<<<< HEAD
-[[_sect_designing_a_process]]
-== Designing a Process
-=======
 [id='_sect_designing_a_process']
 == Designing Process
->>>>>>> 385fed4... BXMSDOC-1517-master-B Update anchor format to [id='anchor-name'] in User Guide.
-
 
 To model a process, do the following:
 

--- a/docs/product-user-guide/src/main/asciidoc/chap-process-simulation.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/chap-process-simulation.adoc
@@ -1,4 +1,4 @@
-[[_chap_process_simulation]]
+[id='_chap_process_simulation']
 = Process Simulation
 
 Process simulation allows users to simulate a business process based on the simulation parameters and get a statistical analysis of the process models over time in the form of graphs. This helps to optimize pre and post execution of a process, minimizing the risk of change in business processes, performance forecast, and promote improvements in performance, quality and resource utilization of a process.
@@ -22,10 +22,10 @@ A dialog with data on individual path appears: to visualize any of the identifie
 .Process Paths
 image::4563.png[]
 
-[[_sect_simulating_a_process]]
+[id='_sect_simulating_a_process']
 == Simulating Processes
 
-[[_defining_simulation_data_on_elements]]
+[id='_defining_simulation_data_on_elements']
 === Defining Simulation Data on Elements
 
 To run a process simulation, the input simulation data must be specified for the process and each of its elements. To specify the simulation data:
@@ -40,7 +40,7 @@ image::4632.png[]
 
 For more information about the simulation data for individual process elements, see <<_appe_simulation_data>>.
 
-[[_running_a_simulation]]
+[id='_running_a_simulation']
 === Running Process Simulations
 
 . Open the corresponding process in the Process Editor.
@@ -62,7 +62,7 @@ If the simulation fails, a notification message is displayed. To prevent the sim
 * Processes that contain a complex series of XOR and AND gateways.
 * Processes that contain a loop where one instance of the loop is not finished before a new instance starts.
 
-[[_examining_simulation_results]]
+[id='_examining_simulation_results']
 === Examining Simulation Results
 
 In the *Simulation Graphs* panel that opens after you run a simulation, the results are divided into the following categories:
@@ -86,7 +86,7 @@ In the *Simulation Graphs* panel that opens after you run a simulation, the resu
 |Simulation results of the paths used during the simulation.
 |===
 
-[[_graph_types]]
+[id='_graph_types']
 ==== Switching Between Graph Types
 
 To change the type of the displayed graphs, click the corresponding icon at the upper right hand corner of the Process Editor. The available graph types are:
@@ -106,7 +106,7 @@ In line charts, point to a particular place on a line to view the value of the i
 .Line Chart
 image::4631.png[]
 
-[[_filters]]
+[id='_filters']
 ==== Filtering in Graphs
 
 To filter the displayed data in a chart, click the corresponding coloured radio button in the chart legend.
@@ -114,7 +114,7 @@ To filter the displayed data in a chart, click the corresponding coloured radio 
 .Filtering the Maximum Value
 image::4628.png[]
 
-[[_timeline]]
+[id='_timeline']
 ==== Viewing Graph Timeline
 
 The timeline feature enables you to view the graph in a particular stage during simulation execution. Every event is included in the timeline as a new status.

--- a/docs/product-user-guide/src/main/asciidoc/chap-project.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/chap-project.adoc
@@ -58,7 +58,7 @@ include::project-duplicate-GAV-manage-proc.adoc[leveloffset=+3]
 
 
 ifdef::BPMS[]
-[[_sect_process_definition]]
+[id='_sect_process_definition']
 == Process Definition
 
 
@@ -95,7 +95,7 @@ We refer to a Process definition as a business process.
 ----
 ====
 
-[[_creating_a_process]]
+[id='_creating_a_process']
 === Creating a Process Definition
 
 
@@ -109,7 +109,7 @@ Create a Process Definition:
 . Click *Create New Asset* -> *Business Process*.
 . In the *Create new Business Process* window, enter the *Business Process* name, select the package, and click *OK*.
 
-[[_importing_a_process_definition]]
+[id='_importing_a_process_definition']
 === Importing a Process Definition
 
 To import an existing BPMN2 or JSON definition, do the following:

--- a/docs/product-user-guide/src/main/asciidoc/chap-red-hat-jboss-dashboard-builder.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/chap-red-hat-jboss-dashboard-builder.adoc
@@ -1,4 +1,4 @@
-[[_chap_red_hat_jboss_dashboard_builder]]
+[id='_chap_red_hat_jboss_dashboard_builder']
 = Red Hat JBoss Dashboard Builder
 
 Red Hat JBoss Dashboard Builder
@@ -15,7 +15,7 @@ Business Activity Monitoring (BAM) software helps to monitor business activities
 The software monitors particular metrics, such as the status of running processes, the number of invoices to be processed, processing times and other.
 It provides tools for visualization of the collected data (for example in graphs or tables).
 
-[[_structure]]
+[id='_structure']
 == Basic Concepts
 
 
@@ -32,7 +32,7 @@ Pages are contained within a workspace and can define permission access rights.
 The number of pages within a workspace is arbitrary.
 A set of pages that presents related information on similar KPIs is referred to as a dashboard.
 
-[[_accessing_dashboard_builder]]
+[id='_accessing_dashboard_builder']
 == Accessing Dashboard Builder
 
 
@@ -59,7 +59,7 @@ At the top of the page, you can change the workspace, the page, as well as find 
 
 Dashboard area with variable content, a lateral menu on the left and the main dashboard area on the right, is located below the common interface area.
 
-[[_process_and_task_dashboard]]
+[id='_process_and_task_dashboard']
 == Process & Task Dashboard
 
 
@@ -109,7 +109,7 @@ image::processinstancedetails.png[]
 
 
 [float]
-[[_tasks_dashboard]]
+[id='_tasks_dashboard']
 === Tasks Dashboard
 
 
@@ -118,7 +118,7 @@ To view the *Tasks*
  tab at the top of the screen.
 This dashboard provides the same features as introduced above, but related to the tasks only.
 
-[[_sect_data_sources]]
+[id='_sect_data_sources']
 == Data Sources
 
 Red Hat JBoss Dashboard Builder can be connected to an external database, either using the container's JNDI data source or connecting directly using the JDBC driver to access the database.
@@ -147,7 +147,7 @@ ifdef::BPMS[]
 If you wish the jBPM Dashboard to use the new data source, modify also the respective data providers (jBPM Count Processes, jBPM Process Summary, jBPM Task Summary). Note that the data source needs to have access to jBPM history.
 endif::BPMS[]
 
-[[_security_considerations]]
+[id='_security_considerations']
 === Security Considerations
 
 [IMPORTANT]
@@ -156,7 +156,7 @@ When creating an external datasource using JBoss Dashboard Builder, it needs to 
 Otherwise, with a connection that uses <host>:<port>, every user would have the same virtual database (VDB) permissions.
 ====
 
-[[_building_a_dashboard_for_large_volumes_of_data]]
+[id='_building_a_dashboard_for_large_volumes_of_data']
 === Building a Dashboard for Large Volumes of Data
 
 
@@ -276,7 +276,7 @@ Here,
 When a filter occurs in the UI, the Dashboard Builder parses and injects all the SQL data providers referenced by the KPIs into these SQL statements.
 Every time a filter occurs in the UI, the Dashboard Builder gets all the SQL data providers referenced by the KPIs and injects the current filter selections made by the user into these SQLs.
 
-[[_sect_data_providers]]
+[id='_sect_data_providers']
 === Data Providers
 
 
@@ -285,7 +285,7 @@ You can think about them as database queries.
 
 The collected data can be then visualized in indicators on pages, exported as XLS or CSV, etc.
 
-[[_creating_data_provider]]
+[id='_creating_data_provider']
 ==== Creating Data Providers
 
 
@@ -319,7 +319,7 @@ Data provider over a database (SQL query)::
 
 The data provider can now be visualized in an indicator on a page of your choice.
 
-[[_sect_workspace]]
+[id='_sect_workspace']
 === Workspace
 
 
@@ -335,7 +335,7 @@ You can also edit the current workspace properties, delete the current workspace
 
 Every workspace uses a particular skin and envelope, which define the workspace's graphical properties.
 
-[[_creating_a_workspace]]
+[id='_creating_a_workspace']
 ==== Creating Workspace
 
 
@@ -358,7 +358,7 @@ If set to `Role assigned page`, the home page as in the page permissions is appl
 If set to `Current page`, all users will use the current home page as their home page.
 
 
-[[_sect_pages]]
+[id='_sect_pages']
 ==== Pages
 
 
@@ -391,7 +391,7 @@ To create a new page, do the following:
 * Spacing between regions and panels
 
 
-[[_page_permissions1]]
+[id='_page_permissions1']
 ===== Defining Page Permissions
 
 
@@ -409,7 +409,7 @@ To define permissions on a page or all workspace pages for a role, do the follow
 . Click *Save*.
 
 
-[[_sect_panels]]
+[id='_sect_panels']
 ==== Panels
 
 
@@ -445,7 +445,7 @@ are panels that provide access to system setting and administration facilities a
 * Export dashboards: a panel export of dashboards
 * Export/Import workspaces: a panel for exporting and importing of workspaces
 
-[[_adding_panels]]
+[id='_adding_panels']
 ===== Adding Panels
 
 
@@ -462,7 +462,7 @@ If adding an instance of an already existing indicator, you might not be able to
 . If applicable, edit the content of the newly added panel.
 
 
-[[_import_and_export]]
+[id='_import_and_export']
 == Import and Export
 
 
@@ -510,7 +510,7 @@ If the workspace already exists (there is a workspace with the same logic identi
 
 The workspaces are imported once during the application deployment.
 
-[[_importing_and_exporting_kpis]]
+[id='_importing_and_exporting_kpis']
 === Importing and Exporting KPIs
 
 
@@ -548,7 +548,7 @@ Note that these two files do not have to have the same name in order to be repla
 
 The KPIs are imported once during the application deployment.
 
-[[_importing_data_sources]]
+[id='_importing_data_sources']
 === Importing Data Sources
 
 [NOTE]
@@ -632,7 +632,7 @@ Note that these two files do not have to have the same name in order to be repla
 
 The data sources are imported once during the application deployment.
 
-[[_dashbuilder_data_model]]
+[id='_dashbuilder_data_model']
 == Dashboard Builder Data Model
 
 The following image illustrates the Dashboard Builder data model:

--- a/docs/product-user-guide/src/main/asciidoc/chap-setting-up-a-new-project.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/chap-setting-up-a-new-project.adoc
@@ -1,4 +1,4 @@
-[[_chap_setting_up_a_new_project]]
+[id='_chap_setting_up_a_new_project']
 = Setting up a New Project
 
 
@@ -85,7 +85,7 @@ curl -X POST 'localhost:8080/business-central/rest/organizationalunits/' -u USER
 
 For further information, see the _{DEVELOPMENT_GUIDE}_, chapter _Knowledge Store REST API_, section _Organizational Unit Calls_.
 
-[[_creating_a_repository2]]
+[id='_creating_a_repository2']
 == Creating a Repository
 
 
@@ -176,7 +176,7 @@ curl -X POST 'localhost:8080/business-central/rest/repositories/' -u USERNAME:PA
 
 For further information, see the _{DEVELOPMENT_GUIDE}_, chapter _Knowledge Store REST API_, section _Repository Calls_.
 
-[[_cloning_a_repository]]
+[id='_cloning_a_repository']
 == Cloning a Repository
 
 
@@ -272,7 +272,7 @@ curl -X POST 'localhost:8080/business-central/rest/repositories/' -u USERNAME:PA
 
 For further information, see the _{DEVELOPMENT_GUIDE}_, chapter _Knowledge Store REST API_, section _Repository Calls_.
 
-[[_creating_a_project]]
+[id='_creating_a_project']
 == Creating a Project
 
 
@@ -352,7 +352,7 @@ curl -X POST 'localhost:8080/business-central/rest/repositories/REPOSITORY_NAME/
 
 For further information, see the _{DEVELOPMENT_GUIDE}_, chapter _Knowledge Store REST API_, section _Repository Calls_.
 
-[[_creating_a_new_package]]
+[id='_creating_a_new_package']
 == Creating a New Package
 
 
@@ -372,7 +372,7 @@ image::create-new-package.png[]
 A new package is now created under the selected project.
 
 
-[[_adding_dependencies1]]
+[id='_adding_dependencies1']
 == Adding Dependencies
 
 
@@ -397,7 +397,7 @@ When you add a repository, you can click the gear icon and select *Add all* or *
 If working with modified artifacts, do not re-upload modified non-snapshot artifacts as Maven will not know these artifacts have been updated, and it will not work if it is deployed in this manner.
 ====
 
-[[_defining_kie_bases_and_sessions]]
+[id='_defining_kie_bases_and_sessions']
 == Defining KIE Bases and Sessions
 
 
@@ -454,7 +454,7 @@ image::5191.png[]
 You can switch between the Project Editor view and the Repository view to look at the changes you make in each view.
 To do so, close and reopen the view each time a change is made.
 
-[[_creating_a_resource]]
+[id='_creating_a_resource']
 == Creating a Resource
 
 

--- a/docs/product-user-guide/src/main/asciidoc/chap-social-events.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/chap-social-events.adoc
@@ -1,6 +1,0 @@
-
-include::social-events-con.adoc[]
-
-include::social-events-follow-user-proc.adoc[leveloffset=+1]
-
-include::social-events-activity-proc.adoc[leveloffset=+1]

--- a/docs/product-user-guide/src/main/asciidoc/components-product-con.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/components-product-con.adoc
@@ -1,4 +1,4 @@
-[[_components_product_con]]
+[id='_components_product_con']
 = Components
 ifdef::BPMS[]
 {PRODUCT} has the following components:

--- a/docs/product-user-guide/src/main/asciidoc/con-business-central-settings-artifact-repo.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/con-business-central-settings-artifact-repo.adoc
@@ -1,4 +1,4 @@
-[[con-business-central-settings-artifact-repo]]
+[id='con-business-central-settings-artifact-repo']
 = Artifact Repository
  
 Use the Artifact Repository perspective to specify Maven Artifact repository preferences.

--- a/docs/product-user-guide/src/main/asciidoc/con-business-central-settings-data-sets.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/con-business-central-settings-data-sets.adoc
@@ -1,4 +1,4 @@
-[[business_central_settings_data_sets]]
+[id='business_central_settings_data_sets']
 = Data Sets
 
 Use this perspective to specify what data will be used in the dashboards. 

--- a/docs/product-user-guide/src/main/asciidoc/con-business-central-settings-lanuage.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/con-business-central-settings-lanuage.adoc
@@ -1,4 +1,4 @@
-[[con-business-central-settings-language]]
+[id='con-business-central-settings-language']
 = Languages
 
 Click Languages to choose the language for the {PRODUCT} user interface.

--- a/docs/product-user-guide/src/main/asciidoc/con-business-central-settings-library.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/con-business-central-settings-library.adoc
@@ -1,4 +1,4 @@
-[[con-business-central-settings-library]]
+[id='con-business-central-settings-library']
 = Library
  
 The settings in the Library section determine the behavior of the Projects perspective, which is available from the *Main* menu.

--- a/docs/product-user-guide/src/main/asciidoc/con-business-central-settings-project.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/con-business-central-settings-project.adoc
@@ -1,4 +1,4 @@
-[[con-business-central-settings-project]]
+[id='con-business-central-settings-project']
 = Projects
 
 Use the Project perspective to enable or disable the `GroupId`, `ArtifactId`, and `Version` (GAV) conflict check and allow or forbid child GAV editions. 

--- a/docs/product-user-guide/src/main/asciidoc/data-modeler-annotations-add-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/data-modeler-annotations-add-proc.adoc
@@ -1,4 +1,4 @@
-[#data_modeler_annotations_add_proc]
+[id='data_modeler_annotations_add_proc']
 = Adding Annotations in the Data Modeler
 
 You can switch to the *Source* tab of the Data Modeler and modify the source code and annotations directly. However, as a more secure and guided method for adding standard annotations, you can also use the *Advanced* option at the right side of the Data Modeler.

--- a/docs/product-user-guide/src/main/asciidoc/data-modeler-annotations-con.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/data-modeler-annotations-con.adoc
@@ -1,4 +1,4 @@
-[#data_modeler_annotations_con]
+[id='data_modeler_annotations_con']
 = Annotations in the Data Modeler
 
 {PRODUCT} supports all Drools annotations by default, and can be customized using the *Drools & jBPM* domain screen. For further information about available domain screens, see <<data_object_domain_screens_con>>.

--- a/docs/product-user-guide/src/main/asciidoc/data-modeler-con.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/data-modeler-con.adoc
@@ -1,4 +1,4 @@
-[#data_modeler_con]
+[id='data_modeler_con']
 = Data Modeler
 
 ifdef::BPMS[]

--- a/docs/product-user-guide/src/main/asciidoc/data-modeler-field-types-ref.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/data-modeler-field-types-ref.adoc
@@ -1,4 +1,4 @@
-[#available_field_types_ref]
+[id='available_field_types_ref']
 = Available Field Types
 
 In the *Data Objects* editor of your Project Explorer, you can assign the following types of fields to the data objects that you add to your project:

--- a/docs/product-user-guide/src/main/asciidoc/data-object-deployment-descriptor-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/data-object-deployment-descriptor-proc.adoc
@@ -1,4 +1,4 @@
-[#data_objects_deployment_descriptor_proc]
+[id='data_objects_deployment_descriptor_proc']
 = Modifying the Deployment Descriptor
 
 For advanced persistence configuration, you can modify the `kie-deployment-descriptor.xml` file. This file defines deployment in the jBPM runtime, persistence unit information, and other advanced deployment settings. Automatic configuration of the JPA Marshalling Strategies is only available in JBoss BPM Suite.

--- a/docs/product-user-guide/src/main/asciidoc/data-object-domain-screens-con.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/data-object-domain-screens-con.adoc
@@ -1,4 +1,4 @@
-[#data_object_domain_screens_con]
+[id='data_object_domain_screens_con']
 = Data Object Domain Screens
 
 You can use these domain screen options to add various types of annotations and data object configurations. The domain screen tabs can be selected from the right side of the data object editor screen.

--- a/docs/product-user-guide/src/main/asciidoc/data-objects-create-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/data-objects-create-proc.adoc
@@ -1,4 +1,4 @@
-[#data_objects_create_proc]
+[id='data_objects_create_proc']
 = Creating a Data Object
 
 The data objects that you define can be implemented in various types of assets in your project, and are essential building blocks for your project.

--- a/docs/product-user-guide/src/main/asciidoc/data-objects-persistable-con.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/data-objects-persistable-con.adoc
@@ -1,4 +1,4 @@
-[#data_objects_persistable_con]
+[id='data_objects_persistable_con']
 = Persistable Data Objects
 
 The Data Modeler supports the generation of persistable data objects. Persistable data objects are based on the JPA you specify (Hibernate is the default JPA). When you check the *Persistable* check box for a new or existing data object, the platform will use default persistence settings. You can change these settings by <<data_objects_persistable_modify_proc,modifying the persistence descriptor>>. 

--- a/docs/product-user-guide/src/main/asciidoc/data-objects-persistable-define-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/data-objects-persistable-define-proc.adoc
@@ -1,4 +1,4 @@
-[#data_objects_persistable_define_proc]
+[id='data_objects_persistable_define_proc']
 = Defining Persistable Data Objects
 
 You can select the *Persistable* check box in the process of <<data_objects_create_proc, creating a new data object>>, or you can define an existing data object to be persistable going forward.

--- a/docs/product-user-guide/src/main/asciidoc/data-objects-persistable-modify-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/data-objects-persistable-modify-proc.adoc
@@ -1,4 +1,4 @@
-[#data_objects_persistable_modify_proc]
+[id='data_objects_persistable_modify_proc']
 = Modifying the Persistence Descriptor
 
 Business central contains a `persistence.xml` file with default persistence settings. You can modify these persistence settings for all persistable data objects.

--- a/docs/product-user-guide/src/main/asciidoc/data-objects-relationships-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/data-objects-relationships-proc.adoc
@@ -1,4 +1,4 @@
-[#data_objects_relationships_proc]
+[id='data_objects_relationships_proc']
 = Configuring Relationships between Data Object Attributes
 
 When an attribute type is defined as another persistable data object, the relationship is identified and defined by the image:Info_icon.png[]

--- a/docs/product-user-guide/src/main/asciidoc/data-sets-add-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/data-sets-add-proc.adoc
@@ -1,4 +1,4 @@
-[#data_sets_add_proc]
+[id='data_sets_add_proc']
 = Adding Data Sets
 
 You can define and add a new data set to fetch your data from an external storage system and begin using data sets in your Dashboard displayer.

--- a/docs/product-user-guide/src/main/asciidoc/data-sets-caching-con.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/data-sets-caching-con.adoc
@@ -1,4 +1,4 @@
-[#data_sets_caching_con]
+[id='data_sets_caching_con']
 = Caching
 
 {PRODUCT} data set functionality provides two cache levels:

--- a/docs/product-user-guide/src/main/asciidoc/data-sets-con.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/data-sets-con.adoc
@@ -1,4 +1,4 @@
-[#data_sets_con]
+[id='data_sets_con']
 = Data Sets
 
 The data set functionality in Business Central defines how to access and parse data.

--- a/docs/product-user-guide/src/main/asciidoc/data-sets-edit-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/data-sets-edit-proc.adoc
@@ -1,4 +1,4 @@
-[#data_sets_edit_proc]
+[id='data_sets_edit_proc']
 = Editing Data Sets
 
 You can edit existing data sets as needed to ensure that fetched data in your Dashboard displayer is updated.

--- a/docs/product-user-guide/src/main/asciidoc/data-sets-refresh-con.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/data-sets-refresh-con.adoc
@@ -1,4 +1,4 @@
-[#data_sets_refresh_con]
+[id='data_sets_refresh_con']
 = Data Refresh
 
 The refresh features enables you to invalidate cached data set data after a specified interval of time.

--- a/docs/product-user-guide/src/main/asciidoc/decision-tables-con.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/decision-tables-con.adoc
@@ -1,4 +1,4 @@
-[#decision_tables_con]
+[id='decision_tables_con']
 = Decision Tables
 
 Rules can be stored in spreadsheet decision tables. Each row in the spreadsheet is a rule, and each column is either a condition, an action, or an option. Details on how to use decision tables are provided in the [ref]_{DEVELOPMENT_GUIDE}_.

--- a/docs/product-user-guide/src/main/asciidoc/decision-tables-examples-con.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/decision-tables-examples-con.adoc
@@ -1,4 +1,4 @@
-[#decision_tables_examples_con]
+[id='decision_tables_examples_con']
 = Decision Table Example
 
 An online shopping site lists the shipping charges for ordered items. The site provides free shipping under the following conditions:

--- a/docs/product-user-guide/src/main/asciidoc/decision-tables-upload-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/decision-tables-upload-proc.adoc
@@ -1,4 +1,4 @@
-[#decision_tables_upload_proc]
+[id='decision_tables_upload_proc']
 = Uploading Decision Tables
 
 After you define your rules in an external XLS or XLSX file, you can upload the file as a decision table in your project.

--- a/docs/product-user-guide/src/main/asciidoc/dependencies-add-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/dependencies-add-proc.adoc
@@ -1,4 +1,4 @@
-[[dependencies_add_proc]]
+[id='dependencies_add_proc']
 
 = Adding Dependencies
 

--- a/docs/product-user-guide/src/main/asciidoc/enumerations-add-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/enumerations-add-proc.adoc
@@ -1,4 +1,4 @@
-[#enumerations_add_proc]
+[id='enumerations_add_proc']
 = Adding Enumerations
 
 You can add data enumerations to your package that can be used in other assets in your project. This expands the options that are presented in drop-down menus or fields configured in guided rules, guided decision tables, and other assets.

--- a/docs/product-user-guide/src/main/asciidoc/enumerations-con.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/enumerations-con.adoc
@@ -1,4 +1,4 @@
-[#enumerations_con]
+[id='enumerations_con']
 = Enumerations
 
 Enumerations are an optional type of asset that you can configure to include additional values in other assets in your project package. For example, configured enumerations can be selected from drop-down lists in a guided decision table in the same package. Double-click a cell to view the enumeration drop-down list if the cell condition is based on the same fact and field as the enumeration.

--- a/docs/product-user-guide/src/main/asciidoc/enumerations-external-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/enumerations-external-proc.adoc
@@ -1,4 +1,4 @@
-[#enumerations_external_proc]
+[id='enumerations_external_proc']
 = Using External Data in Enumerations
 
 You can use a list of strings from an external source in an enumeration for your project. This enables you to configure project assets with value options beyond what you have created in your project package.

--- a/docs/product-user-guide/src/main/asciidoc/guided-decision-table-graphs-add-tables-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/guided-decision-table-graphs-add-tables-proc.adoc
@@ -1,4 +1,4 @@
-[#guided_decision_table_graphs_add_tables_proc]
+[id='guided_decision_table_graphs_add_tables_proc']
 = Adding Decision Tables to a Guided Decision Table Graph
 
 You can add new or existing decision tables within the guided decision table graph editor to create a consolidated view of your decision tables.

--- a/docs/product-user-guide/src/main/asciidoc/guided-decision-table-graphs-con.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/guided-decision-table-graphs-con.adoc
@@ -1,4 +1,4 @@
-[#guided_decision_table_graphs_con]
+[id='guided_decision_table_graphs_con']
 = Guided Decision Table Graphs
 
 A Guided Decision Table Graph is a collection of related guided decision tables that are displayed within a single editor. You can use this editor to better visualize and work with various related decision tables in one location. Additionally, when a condition or an action in one table uses the same data type as a condition or an action in another table, the tables will be physically linked with a line in the table graph editor.

--- a/docs/product-user-guide/src/main/asciidoc/guided-decision-table-graphs-create-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/guided-decision-table-graphs-create-proc.adoc
@@ -1,4 +1,4 @@
-[#guided_decision_table_graphs_create_proc]
+[id='guided_decision_table_graphs_create_proc']
 = Creating Guided Decision Table Graphs
 
 You can use guided decision table graphs to consolidate related guided decision tables in a single table editor.

--- a/docs/product-user-guide/src/main/asciidoc/guided-decision-table-graphs-remove-tables-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/guided-decision-table-graphs-remove-tables-proc.adoc
@@ -1,4 +1,4 @@
-[#guided_decision_table_graphs_remove_tables_proc]
+[id='guided_decision_table_graphs_remove_tables_proc']
 = Removing Decision Tables from a Guided Decision Table Graph
 
 You can remove decision tables from the guided decision table graph editor without deleting the decision table file.

--- a/docs/product-user-guide/src/main/asciidoc/guided-decision-tables-columns-action-BRL-con.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/guided-decision-tables-columns-action-BRL-con.adoc
@@ -1,4 +1,4 @@
-[[_guided_decision_tables_columns_action_BRL_con]]
+[id='_guided_decision_tables_columns_action_BRL_con']
 = "Add an Action BRL fragment"
 
 A Business Rule Language (BRL) fragment is a section of a rule created using the Guided Rule Editor. The <<_guided_decision_tables_columns_condition_BRL_con, Condition BRL fragment>> is the "WHEN" portion of the rule, and the Action BRL fragment is the "THEN" portion of the rule. With this column option you can define an Action BRL fragment to be used in the right ("THEN") side of a rule. When using the embedded Guided Rule Editor, field values defined as "Template Keys" form columns in the decision table.

--- a/docs/product-user-guide/src/main/asciidoc/guided-decision-tables-columns-attribute-con.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/guided-decision-tables-columns-attribute-con.adoc
@@ -1,4 +1,4 @@
-[[_guided_decision_tables_columns_attribute_con]]
+[id='_guided_decision_tables_columns_attribute_con']
 = "Add a new Attribute column"
 
 With this column option, you can add one or more attribute columns representing any of the DRL rule attributes, such as Saliance, Enabled, Date-Effective, and others.

--- a/docs/product-user-guide/src/main/asciidoc/guided-decision-tables-columns-condition-BRL-con.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/guided-decision-tables-columns-condition-BRL-con.adoc
@@ -1,4 +1,4 @@
-[[_guided_decision_tables_columns_condition_BRL_con]]
+[id='_guided_decision_tables_columns_condition_BRL_con']
 = "Add a Condition BRL fragment"
 
 A Business Rule Language (BRL) fragment is a section of a rule created using the Guided Rule Editor. The condition BRL fragment is the "WHEN" portion of the rule, and the <<_guided_decision_tables_columns_action_BRL_con, Action BRL fragment>> is the "THEN" portion of the rule. With this column option, you can define a Condition BRL fragment to be used in the left ("WHEN") side of a rule. In the embedded Guided Rule Editor, field values defined as "Template Keys" form columns in the decision table.

--- a/docs/product-user-guide/src/main/asciidoc/guided-decision-tables-columns-condition-con.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/guided-decision-tables-columns-condition-con.adoc
@@ -1,4 +1,4 @@
-[[_guided_decision_tables_columns_condition_con]]
+[id='_guided_decision_tables_columns_condition_con']
 = "Add a simple Condition"
 
 Conditions represent fact patterns defined in the left ("WHEN") portion of a rule. With this column option, you can define one or more condition columns that check for the presence or absence of data objects with certain field values, and that affect the action ("THEN") portion of the rule. You can define a binding for the fact in the condition table, or select one that has previously been defined. You can also choose to negate the pattern.

--- a/docs/product-user-guide/src/main/asciidoc/guided-decision-tables-columns-create-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/guided-decision-tables-columns-create-proc.adoc
@@ -1,4 +1,4 @@
-[[_guided_decision_tables_columns_create_proc]]
+[id='_guided_decision_tables_columns_create_proc']
 = Adding Columns to Guided Decision Tables
 
 After you have created the guided decision table, you can define and add various types of columns within the decision table editor.

--- a/docs/product-user-guide/src/main/asciidoc/guided-decision-tables-columns-delete-fact-con.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/guided-decision-tables-columns-delete-fact-con.adoc
@@ -1,4 +1,4 @@
-[[_guided_decision_tables_columns_delete_fact_con]]
+[id='_guided_decision_tables_columns_delete_fact_con']
 = "Delete an existing fact"
 
 With this column option, you can implement an action to delete a fact that was added previously as a fact pattern in the table. When this column is created, the fact types are provided in the table cells for that column as a drop-down list, from which users can select only one option.

--- a/docs/product-user-guide/src/main/asciidoc/guided-decision-tables-columns-edit-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/guided-decision-tables-columns-edit-proc.adoc
@@ -1,4 +1,4 @@
-[[_guided_decision_tables_columns_edit_proc]]
+[id='_guided_decision_tables_columns_edit_proc']
 = Editing or Deleting Columns in Guided Decision Tables
 
 You can edit or delete the columns you have created at any time in the guided decision table editor.

--- a/docs/product-user-guide/src/main/asciidoc/guided-decision-tables-columns-field-con.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/guided-decision-tables-columns-field-con.adoc
@@ -1,4 +1,4 @@
-[[_guided_decision_tables_columns_field_con]]
+[id='_guided_decision_tables_columns_field_con']
 = "Set the value of a field"
 
 With this column option, you can implement an action to set the value of a field on a previously bound fact for the "THEN" portion of the rule.

--- a/docs/product-user-guide/src/main/asciidoc/guided-decision-tables-columns-field-work-item-con.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/guided-decision-tables-columns-field-work-item-con.adoc
@@ -1,4 +1,4 @@
-[[_guided_decision_tables_columns_field_work_item_con]]
+[id='_guided_decision_tables_columns_field_work_item_con']
 = "Set the value of a field with a Work Item parameter"
 
 With this column option, you can implement an action to set the value of a previously defined fact field to the value of a result parameter of a work item handler for the "THEN" portion of the rule. The work item must define a result parameter of the same data type as a field on a bound fact in order for you to set the field to the return parameter. (Work items are created in *Menu* -> *Design* -> *Projects* -> *_[select project]_* -> *Create new asset* -> *Work Item Definition*.)

--- a/docs/product-user-guide/src/main/asciidoc/guided-decision-tables-columns-metadata-con.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/guided-decision-tables-columns-metadata-con.adoc
@@ -1,4 +1,4 @@
-[[_guided_decision_tables_columns_metadata_con]]
+[id='_guided_decision_tables_columns_metadata_con']
 = "Add a new Metadata column"
 
 With this column option, you can define a metadata element as a column in your decision table. Each column represents the normal metadata annotation in DRL rules. By default, the metadata column is hidden. To display the column, click *Edit Columns* in the decision table editor and clear the *Hide column* check box.

--- a/docs/product-user-guide/src/main/asciidoc/guided-decision-tables-columns-types-con.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/guided-decision-tables-columns-types-con.adoc
@@ -1,4 +1,4 @@
-[[_guided_decision_tables_columns_types_con]]
+[id='_guided_decision_tables_columns_types_con']
 = Types of Columns in Guided Decision Tables
 
 The *Add a new column* wizard for guided decision tables provides the following column options. (Select *Include advanced options* to view all options.)
@@ -15,7 +15,7 @@ The *Add a new column* wizard for guided decision tables provides the following 
 
 These column types and the parameters required for each in the *Add a new column* wizard are described in the sections that follow.
 
-[[_required_data_objects]]
+[id='_required_data_objects']
 .IMPORTANT: Required data objects for column parameters
 [IMPORTANT]
 ====

--- a/docs/product-user-guide/src/main/asciidoc/guided-decision-tables-columns-work-item-con.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/guided-decision-tables-columns-work-item-con.adoc
@@ -1,4 +1,4 @@
-[[_guided_decision_tables_columns_work_item_con]]
+[id='_guided_decision_tables_columns_work_item_con']
 = "Execute a Work Item"
 
 With this column option, you can execute a work item handler, based on your predefined work item definitions in Business Central. (Work items are created in *Menu* -> *Design* -> *Projects* -> *_[select project]_* -> *Create new asset* -> *Work Item Definition*.)

--- a/docs/product-user-guide/src/main/asciidoc/guided-decision-tables-con.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/guided-decision-tables-con.adoc
@@ -1,4 +1,4 @@
-[[_guided_decision_tables_con]]
+[id='_guided_decision_tables_con']
 = Guided Decision Tables
 
 The Guided Decision Table feature works similarly to the Guided Editor by outlining available facts and fields to guide the creation of a decision table.

--- a/docs/product-user-guide/src/main/asciidoc/guided-decision-tables-create-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/guided-decision-tables-create-proc.adoc
@@ -1,4 +1,4 @@
-[[_guided_decision_tables_create_proc]]
+[id='_guided_decision_tables_create_proc']
 = Creating Guided Decision Tables
 
 You can use guided decision tables to define rule attributes, meta-data, conditions, and actions in a tabular format that can be added to your business rules project.

--- a/docs/product-user-guide/src/main/asciidoc/guided-decision-tables-errors-ref.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/guided-decision-tables-errors-ref.adoc
@@ -1,4 +1,4 @@
-[#guided_decision_tables_errors_ref]
+[id='guided_decision_tables_errors_ref']
 = Types of Problems in Guided Decision Tables
 
 The validation and verification feature detects the following types of problems:

--- a/docs/product-user-guide/src/main/asciidoc/guided-decision-tables-hit-policies-con.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/guided-decision-tables-hit-policies-con.adoc
@@ -1,4 +1,4 @@
-[[_hit_policies_con]]
+[id='_hit_policies_con']
 = Hit Policies for Guided Decision Tables
 
 Hit policies determine the order in which rules (rows) in a guided decision table are applied, whether top to bottom, per specified priority, or other options.

--- a/docs/product-user-guide/src/main/asciidoc/guided-decision-tables-hit-policies-examples-ref.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/guided-decision-tables-hit-policies-examples-ref.adoc
@@ -1,4 +1,4 @@
-[[_hit_policies_examples_ref]]
+[id='_hit_policies_examples_ref']
 = Hit Policy Examples: Decision Table for Discounts on Movie Tickets
 
 The following is part of a decision table for discounts on movie tickets based on customer age, student status, or military status, or all three.

--- a/docs/product-user-guide/src/main/asciidoc/guided-decision-tables-messages-ref.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/guided-decision-tables-messages-ref.adoc
@@ -1,4 +1,4 @@
-[#guided_decision_tables_messages_ref]
+[id='guided_decision_tables_messages_ref']
 = Types of Notifications
 
 The verification and validation feature uses three types of notifications:

--- a/docs/product-user-guide/src/main/asciidoc/guided-decision-tables-otherwise-add-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/guided-decision-tables-otherwise-add-proc.adoc
@@ -1,4 +1,4 @@
-[[_guided_decision_tables_otherwise_add_proc]]
+[id='_guided_decision_tables_otherwise_add_proc']
 = Adding an `Otherwise` Operation to Condition Column Cells
 
 For simple condition columns in guided decision tables, you can apply an `otherwise` value to table cells within the column if the following parameters are set:

--- a/docs/product-user-guide/src/main/asciidoc/guided-decision-tables-rows-create-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/guided-decision-tables-rows-create-proc.adoc
@@ -1,4 +1,4 @@
-[[_guided_decision_tables_rows_create_proc]]
+[id='_guided_decision_tables_rows_create_proc']
 = Adding Rows and Defining Rules in Guided Decision Tables
 
 After you have created your columns in the guided decision table, you can add rows and define rules within the decision table editor.

--- a/docs/product-user-guide/src/main/asciidoc/guided-decision-tables-types-con.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/guided-decision-tables-types-con.adoc
@@ -1,4 +1,4 @@
-[[_guided_decision_tables_types_con]]
+[id='_guided_decision_tables_types_con']
 = Types of Guided Decision Tables
 
 Two types of decision tables are supported in {PRODUCT}: Extended entry and Limited entry tables.

--- a/docs/product-user-guide/src/main/asciidoc/guided-decision-tables-validation-con.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/guided-decision-tables-validation-con.adoc
@@ -1,4 +1,4 @@
-[#guided_decision_tables_validation_con]
+[id='guided_decision_tables_validation_con']
 = Real-Time Verification and Validation of Guided Decision Tables
 
 Business Central provides a real-time verification and validation feature for guided decision tables to ensure that your tables are complete and error free. Guided decision tables are validated after each cell change. If a problem in logic is detected, an error notification appears and describes the problem.

--- a/docs/product-user-guide/src/main/asciidoc/guided-decision-tables-validation-disable-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/guided-decision-tables-validation-disable-proc.adoc
@@ -1,4 +1,4 @@
-[#guided_decision_tables_validation_disable_proc]
+[id='guided_decision_tables_validation_disable_proc']
 = Disabling Verification and Validation of Guided Decision Tables
 
 The decision table verification and validation feature of Business Central is enabled by default. You can disable it by setting the `org.kie.verification.disable-dtable-realtime-verification` system property value to `true` in your {EAP} directory.

--- a/docs/product-user-guide/src/main/asciidoc/guided-rule-templates-con.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/guided-rule-templates-con.adoc
@@ -1,4 +1,4 @@
-[#guided_rule_templates_con]
+[id='guided_rule_templates_con']
 = Guided Rule Templates
 
 Guided Rule Templates enable you to define a rule structure and provide a place-holder for values and data to generate many rules. From the user's perspective, Guided Rule Templates are parameterized guided rules that contain a data table that provides parameter values. The templates enable more flexible decision tables and can enhance the flexibility of rules in existing databases.

--- a/docs/product-user-guide/src/main/asciidoc/guided-rule-templates-create-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/guided-rule-templates-create-proc.adoc
@@ -1,4 +1,4 @@
-[#guided_rule_templates_create_proc]
+[id='guided_rule_templates_create_proc']
 = Creating Guided Rule Templates
 
 You can create guided rule templates to define rule structure and data that can be used for other rules, instead of defining many different rule structures individually.

--- a/docs/product-user-guide/src/main/asciidoc/guided-rule-templates-tables-cells-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/guided-rule-templates-tables-cells-proc.adoc
@@ -1,4 +1,4 @@
-[#guided_rule_templates_tables_cells_proc]
+[id='guided_rule_templates_tables_cells_proc']
 = Merging Cells and Grouping Rows in Data Tables
 
 You can merge cells in a column of the data table that have the same value, and then group merged cells in a single row to consolidate the table. This functionality helps you simplify your data tables for optimal readability.

--- a/docs/product-user-guide/src/main/asciidoc/guided-rule-templates-tables-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/guided-rule-templates-tables-proc.adoc
@@ -1,4 +1,4 @@
-[#guided_rule_templates_tables_proc]
+[id='guided_rule_templates_tables_proc']
 = Defining Data Tables in Guided Rule Templates
 
 Data tables provide variables for guided rule templates that you define. This generates a number of rules, based on your settings. You can define data tables in the *Data* tab of the Guided Rule Template Editor.

--- a/docs/product-user-guide/src/main/asciidoc/guided-rules-THEN-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/guided-rules-THEN-proc.adoc
@@ -1,4 +1,4 @@
-[#guided_rules_THEN_proc]
+[id='guided_rules_THEN_proc']
 = Adding THEN Actions in Guided Rules
 
 The *THEN* part of the rule is the action to be performed when the *WHEN* condition of the rule has been met. For example, when a loan applicant is under 21 years old, the *THEN* action might set `approved` to `false`, declining the loan because the applicant is under age. You can set simple or complex actions to determine how and when your rules are applied.

--- a/docs/product-user-guide/src/main/asciidoc/guided-rules-WHEN-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/guided-rules-WHEN-proc.adoc
@@ -1,4 +1,4 @@
-[#guided_rules_WHEN_proc]
+[id='guided_rules_WHEN_proc']
 = Adding WHEN Conditions in Guided Rules
 
 The *WHEN* part of the rule is the condition that must be met to execute an action. For example, if a bank requires loan applicants to have over 21 years of age, then the *WHEN* condition would be `Age | greater than | 21`. You can set simple or complex conditions to determine how and when your rules are applied.

--- a/docs/product-user-guide/src/main/asciidoc/guided-rules-con.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/guided-rules-con.adoc
@@ -1,4 +1,4 @@
-[#guided_rules_con]
+[id='guided_rules_con']
 = Guided Rules
 
 Guided Rules are business rules that you can create in a UI-based Guided Rules editor that leads you through the rule creation process. The rule editor provides fields and options for acceptable input based on the object model of the rule being edited. All data objects related to the rule must be in the same project package as the rule. Assets in the same package are imported by default. You can use the *Data Objects* tab of the rule editor to verify that all required data objects are listed or to import any other needed data objects.

--- a/docs/product-user-guide/src/main/asciidoc/guided-rules-create-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/guided-rules-create-proc.adoc
@@ -1,4 +1,4 @@
-[#guided_rules_create_proc]
+[id='guided_rules_create_proc']
 = Creating Guided Rules
 
 Guided rules enable you to define business rules in a structured format, based on the data objects associated with the rules. You can create and define guided rules individually for your project.

--- a/docs/product-user-guide/src/main/asciidoc/hit-policies-con.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/hit-policies-con.adoc
@@ -1,4 +1,4 @@
-[[_hit_policies_con]]
+[id='_hit_policies_con']
 = Hit Policies for Decision Tables
 
 Hit policies determine the order in which rules (rows) in a guided decision table are applied, whether top to bottom, per specified priority, or other options.

--- a/docs/product-user-guide/src/main/asciidoc/hit-policies-examples-ref.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/hit-policies-examples-ref.adoc
@@ -1,4 +1,4 @@
-[[_hit_policies_examples_ref]]
+[id='_hit_policies_examples_ref']
 = Hit Policy Examples: Decision Table for Discounts on Movie Tickets
 
 The following is part of a decision table for discounts on movie tickets based on customer age, student status, or military status, or all three.

--- a/docs/product-user-guide/src/main/asciidoc/kie-bases-create-con.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/kie-bases-create-con.adoc
@@ -1,4 +1,4 @@
-[[kie_bases_create_con]]
+[id='kie_bases_create_con']
 
 = Defining KIE Bases and Sessions
 

--- a/docs/product-user-guide/src/main/asciidoc/kie-bases-project-view-create-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/kie-bases-project-view-create-proc.adoc
@@ -1,4 +1,4 @@
-[[kie_bases_project_view_create_proc]]
+[id='kie_bases_project_view_create_proc']
 
 = Defining KIE Bases and Sessions
 

--- a/docs/product-user-guide/src/main/asciidoc/kie-bases-repo-view-create-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/kie-bases-repo-view-create-proc.adoc
@@ -1,4 +1,4 @@
-[[kie_bases_repo_view_create_proc]]
+[id='kie_bases_repo_view_create_proc']
 
 = Defining KIE Bases and Sessions in Repository View
 

--- a/docs/product-user-guide/src/main/asciidoc/main.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/main.adoc
@@ -46,7 +46,7 @@ include::chap-process-simulation.adoc[leveloffset=+1]
 include::chap-testing-brms.adoc[leveloffset=+1]
 
 // Part
-[[_chap_plug_in]]
+[id='_chap_plug_in']
 = Plug-in
 
 include::chap-plug-in.adoc[leveloffset=+1]

--- a/docs/product-user-guide/src/main/asciidoc/main.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/main.adoc
@@ -36,8 +36,6 @@ include::chap-data-models.adoc[leveloffset=+1]
 
 include::chap-advanced-process-modeling.adoc[leveloffset=+1]
 
-include::chap-social-events.adoc[leveloffset=+1]
-
 // Part
 = Simulation and Testing
 
@@ -66,8 +64,8 @@ include::chap-examples.adoc[leveloffset=+1]
 
 include::chap-case-management.adoc[leveloffset=+1]
 
-// Part 
-= Planner Workbench 
+// Part
+= Planner Workbench
 
 include::Quickstart-chapter.adoc[leveloffset=+1]
 
@@ -90,7 +88,7 @@ include::appe-process-elements.adoc[]
 include::appe-service-tasks.adoc[]
 
 include::appe-simulation-data.adoc[]
-endif::BPMS[]
+endif::[]
 
 ifdef::BRMS[]
 include::chap-introduction-brms.adoc[leveloffset=+1]
@@ -103,8 +101,6 @@ include::chap-project.adoc[leveloffset=+1]
 
 include::chap-data-sets.adoc[leveloffset=+1]
 
-include::chap-social-events.adoc[leveloffset=+1]
-
 include::chap-data-models.adoc[leveloffset=+1]
 
 include::chap-writing-rules.adoc[leveloffset=+1]
@@ -112,7 +108,6 @@ include::chap-writing-rules.adoc[leveloffset=+1]
 include::chap-building-and-deploying-assets.adoc[leveloffset=+1]
 
 include::chap-testing-brms.adoc[leveloffset=+1]
-
-endif::BRMS[]
+endif::[]
 
 include::product-shared-docs/versioning-information.adoc[]

--- a/docs/product-user-guide/src/main/asciidoc/organizational-unit-REST-create-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/organizational-unit-REST-create-proc.adoc
@@ -1,4 +1,4 @@
-[[_organizational_unit_REST_create_proc]]
+[id='_organizational_unit_REST_create_proc']
 
 = ⁠⁠Creating a Team using the Knowledge Store REST API
 

--- a/docs/product-user-guide/src/main/asciidoc/organizational-unit-business-central-create-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/organizational-unit-business-central-create-proc.adoc
@@ -1,4 +1,4 @@
-[[_organizational_unit_business_central_create_proc]]
+[id='_organizational_unit_business_central_create_proc']
 
 = ⁠Creating a Team
 

--- a/docs/product-user-guide/src/main/asciidoc/organizational-unit-con.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/organizational-unit-con.adoc
@@ -1,4 +1,4 @@
-[[_organizational_unit_con]]
+[id='_organizational_unit_con']
 
 = Creating a Team
 

--- a/docs/product-user-guide/src/main/asciidoc/organizational-unit-kie-create-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/organizational-unit-kie-create-proc.adoc
@@ -1,4 +1,4 @@
-[[_organizational_unit_kie_create_proc]]
+[id='_organizational_unit_kie_create_proc']
 
 = ⁠Creating a Team using the `kie-config-cli` Tool
 

--- a/docs/product-user-guide/src/main/asciidoc/packages-create-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/packages-create-proc.adoc
@@ -1,4 +1,4 @@
-[[packages_create_proc]]
+[id='packages_create_proc']
 
 = Creating a Package
 

--- a/docs/product-user-guide/src/main/asciidoc/proc-business-central-settings-artifacts.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/proc-business-central-settings-artifacts.adoc
@@ -1,4 +1,4 @@
-[[business_central_settings_artifacts]]
+[id='business_central_settings_artifacts']
 = Artifacts
 
 In the Artifacts perspective, you can manage the content of the Maven repository. The artifacts that you build from your projects are listed here, along with their `GroupId`, `ArtifactId`, and `Version` (GAV). You can view the contents an artifact, as well as upload and download artifacts.

--- a/docs/product-user-guide/src/main/asciidoc/proc-business-central-settings-data-sources.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/proc-business-central-settings-data-sources.adoc
@@ -1,4 +1,4 @@
-[[business_central_settings_data_sources]]
+[id='business_central_settings_data_sources']
 = Data Sources
 
 This perspective enables you to configure connections to external databases. To connect to an external database, the required JDBC driver must be available. You can add JDBC drivers in this perspective. The data sources created in this perspective can be used to create SQL data sets. For more information, see Data Sets.

--- a/docs/product-user-guide/src/main/asciidoc/project-REST-create-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/project-REST-create-proc.adoc
@@ -1,4 +1,4 @@
-[[_project_REST_create_proc]]
+[id='_project_REST_create_proc']
 
 = ⁠⁠Creating a Project Using the Knowledge Store REST API
 

--- a/docs/product-user-guide/src/main/asciidoc/project-business-central-create-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/project-business-central-create-proc.adoc
@@ -1,4 +1,4 @@
-[[project_business_central_create_proc]]
+[id='project_business_central_create_proc']
 
 = Creating a Project
 

--- a/docs/product-user-guide/src/main/asciidoc/project-create-con.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/project-create-con.adoc
@@ -1,4 +1,4 @@
-[[_project_create_con]]
+[id='_project_create_con']
 
 = Creating a Project
 

--- a/docs/product-user-guide/src/main/asciidoc/project-deploy-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/project-deploy-proc.adoc
@@ -1,4 +1,4 @@
-[#project_deploy_proc_{context}]
+[id='project_deploy_proc_{context}']
 = Building and Deploying a Project
 
 When your project contains all necessary assets and is ready for deployment, you can build the project and download a deployable file from Business Central.

--- a/docs/product-user-guide/src/main/asciidoc/project-duplicate-GAV-con.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/project-duplicate-GAV-con.adoc
@@ -1,4 +1,4 @@
-[#project_duplicate_GAV_con_{context}]
+[id='project_duplicate_GAV_con_{context}']
 = Duplicate GAV Detection
 
 All Maven repositories are checked for any duplicated `GroupId`, `ArtifactId`, and `Version` (GAVs). This check examine the GAV attributes. If a GAV duplicate exists, the performed operation is canceled.

--- a/docs/product-user-guide/src/main/asciidoc/project-duplicate-GAV-manage-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/project-duplicate-GAV-manage-proc.adoc
@@ -1,4 +1,4 @@
-[#project_duplicate_GAV_manage_proc_{context}]
+[id='project_duplicate_GAV_manage_proc_{context}']
 = Managing Duplicate GAV Detection Settings
 
 Users with the `admin` role can modify the list of repositories that are checked for duplicate GAVs.

--- a/docs/product-user-guide/src/main/asciidoc/repository-REST-clone-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/repository-REST-clone-proc.adoc
@@ -1,4 +1,4 @@
-[[_repository_REST_clone_proc]]
+[id='_repository_REST_clone_proc']
 
 = Cloning a Repository Using the Knowledge Store REST API
 

--- a/docs/product-user-guide/src/main/asciidoc/repository-REST-create-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/repository-REST-create-proc.adoc
@@ -1,4 +1,4 @@
-[[_repository_REST_create_proc]]
+[id='_repository_REST_create_proc']
 
 = ⁠⁠Creating a Repository Using the Knowledge Store REST API
 

--- a/docs/product-user-guide/src/main/asciidoc/repository-business-central-clone-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/repository-business-central-clone-proc.adoc
@@ -1,4 +1,4 @@
-[[repository_business_central_clone_proc]]
+[id='repository_business_central_clone_proc']
 
 = Cloning a Repository in Business Central
 

--- a/docs/product-user-guide/src/main/asciidoc/repository-business-central-create-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/repository-business-central-create-proc.adoc
@@ -1,4 +1,4 @@
-[[repository_business_central_create_proc]]
+[id='repository_business_central_create_proc']
 
 = ⁠Creating a Repository in Business Central
 

--- a/docs/product-user-guide/src/main/asciidoc/repository-clone-con.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/repository-clone-con.adoc
@@ -1,4 +1,4 @@
-[[repository_clone_proc]]
+[id='repository_clone_proc']
 
 = Cloning a Repository
 

--- a/docs/product-user-guide/src/main/asciidoc/repository-con.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/repository-con.adoc
@@ -1,4 +1,4 @@
-[[repository_con]]
+[id='repository_con']
 = Creating a Repository
 
 All business assets are stored in repositories associated with teams. By default, the main Business Central *Artifact repository* does not contain any team. Therefore, to be able to create your own business assets, you need to create a repository within a team that you have defined.

--- a/docs/product-user-guide/src/main/asciidoc/repository-kie-create-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/repository-kie-create-proc.adoc
@@ -1,4 +1,4 @@
-[[_repository_kie_create_proc]]
+[id='_repository_kie_create_proc']
 = ⁠Creating a Repository Using the `kie-config-cli` Tool
 
 The `kie-config-cli` tool is a command line configuration tool that enables you to manage the system repository from the command line in either an online or an offline mode. You can use the `kie-config-cli` tool to create a repository in {PRODUCT}.

--- a/docs/product-user-guide/src/main/asciidoc/rules-con.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/rules-con.adoc
@@ -1,4 +1,4 @@
-[#rules_con]
+[id='rules_con']
 = Business Rules
 
 {PRODUCT} provides several tools to help you write and manage business rules:

--- a/docs/product-user-guide/src/main/asciidoc/rules-drl-con.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/rules-drl-con.adoc
@@ -1,4 +1,4 @@
-[#rules_drl_con]
+[id='rules_drl_con']
 = Drools Rule Language (DRL)
 
 Drools Rule Language (DRL) rules are stored as text and can be managed in the {PRODUCT} user interface. A DRL file can contain one or more rules. The condition and the action of the rule are the WHEN and THEN parts of the rule.

--- a/docs/product-user-guide/src/main/asciidoc/rules-dsl-con.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/rules-dsl-con.adoc
@@ -1,4 +1,4 @@
-[#rules_dsl_con]
+[id='rules_dsl_con']
 = Domain Specific Language (DSL)
 
 A Domain Specific Language (DSL) is a rule language defined specifically for your problem domain. You or a business analyst user can then create rules using only the predefined language. This simplifies the process of rule creation for users without deep knowledge of rules and the rule language.

--- a/docs/product-user-guide/src/main/asciidoc/rules-facts-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/rules-facts-proc.adoc
@@ -1,4 +1,4 @@
-[#rules_facts_proc]
+[id='rules_facts_proc']
 = Narrowing Facts Using Package White List
 
 You can narrow down the facts available during rule creation and modification by adding the facts to the `package-names-white-list` file in your project. This file is a text file that accepts single package names on each line. By adding a group of facts to this file, you can speed up the loading process as you create rules.

--- a/docs/product-user-guide/src/main/asciidoc/test-scenarios-add-sections-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/test-scenarios-add-sections-proc.adoc
@@ -1,4 +1,4 @@
-[#test_scenarios_add_sections_proc]
+[id='test_scenarios_add_sections_proc']
 = Adding More Sections
 
 You can include additional sets of *GIVEN*, *EXPECT*, and *CALL METHOD* sections to your test scenario editor for more complex scenarios.

--- a/docs/product-user-guide/src/main/asciidoc/test-scenarios-advanced-con.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/test-scenarios-advanced-con.adoc
@@ -1,4 +1,4 @@
-[#test_scenarios_advanced_con]
+[id='test_scenarios_advanced_con']
 = Advanced Settings in Test Scenarios
 
 In addition to the basic data required to <<test_scenarios_create_proc,create and run a test scenario>>, you can also perform any of the following more advanced configurations with your test scenarios:

--- a/docs/product-user-guide/src/main/asciidoc/test-scenarios-advanced-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/test-scenarios-advanced-proc.adoc
@@ -1,4 +1,4 @@
-[#test_scenarios_advanced_proc]
+[id='test_scenarios_advanced_proc']
 = Defining Advanced Field Data
 
 After you have defined a *GIVEN* input fact, you can further define it by adding a literal value, bound variable, or a new fact.

--- a/docs/product-user-guide/src/main/asciidoc/test-scenarios-call-method-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/test-scenarios-call-method-proc.adoc
@@ -1,4 +1,4 @@
-[#test_scenario_call_method_proc]
+[id='test_scenario_call_method_proc']
 = Adding a Call Method
 
 A `CALL METHOD` enables you to call a method on an existing fact in the beginning of the rule execution.

--- a/docs/product-user-guide/src/main/asciidoc/test-scenarios-con.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/test-scenarios-con.adoc
@@ -1,4 +1,4 @@
-[#test_scenarios_con]
+[id='test_scenarios_con']
 = Test Scenarios
 
 Test Scenarios in {PRODUCT} enable you to validate the functionality of rules, models, and events before deploying them into production. A test scenario uses data for conditions that resemble an instance of your fact or project model. This data is matched against a given set of rules and if the expected results match the actual results, the test is successful. If the expected results do not match the actual results, then the test fails.

--- a/docs/product-user-guide/src/main/asciidoc/test-scenarios-create-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/test-scenarios-create-proc.adoc
@@ -1,4 +1,4 @@
-[#test_scenarios_create_proc]
+[id='test_scenarios_create_proc']
 = Creating and Running a Test Scenario
 
 A basic test scenario requires, at minimum, the following data:

--- a/docs/product-user-guide/src/main/asciidoc/test-scenarios-date-time-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/test-scenarios-date-time-proc.adoc
@@ -1,4 +1,4 @@
-[#test_scenarios_date_time_proc]
+[id='test_scenarios_date_time_proc']
 = Defining Date and Time
 
 Next to the *EXPECT* section, you can configure the test scenario to use a real date and time when running the scenario, or a simulated date and time, such as if the date and time are part of what is being tested in the scenario (example: a test scenario designed for after-hours deployment).

--- a/docs/product-user-guide/src/main/asciidoc/test-scenarios-globals-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/test-scenarios-globals-proc.adoc
@@ -1,4 +1,4 @@
-[#test_scenarios_globals_proc]
+[id='test_scenarios_globals_proc']
 = Using Globals
 Globals are named objects that are visible to the rule engine but are different from the objects for facts. Accordingly, the changes in the object of a global do not trigger the re-evaluation of rules. You can use and validate global fields in a test scenario.
 

--- a/docs/product-user-guide/src/main/asciidoc/test-scenarios-rule-config-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/test-scenarios-rule-config-proc.adoc
@@ -1,4 +1,4 @@
-[#test_scenarios_rule_config_proc]
+[id='test_scenarios_rule_config_proc']
 = Defining Advanced Rule Configurations
 The *(configuration)* label enables you to set additional constraints on the firing of rules.
 

--- a/docs/product-user-guide/src/main/asciidoc/use-case-product-con.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/use-case-product-con.adoc
@@ -1,4 +1,4 @@
-[[_use_case_product_con]]
+[id='_use_case_product_con']
 
 ifdef::BPMS[]
 = Use Case: Process­-based solutions in the loan industry

--- a/docs/shared-kie-docs/src/main/asciidoc/Product/versioning-information.adoc
+++ b/docs/shared-kie-docs/src/main/asciidoc/Product/versioning-information.adoc
@@ -1,9 +1,8 @@
 :sectnums!:
 
 [appendix]
-[[_revision_history]]
-[[_versioning_information]]
+[id='_revision_history']
+[id='_versioning_information']
 = Versioning information
 
 Documentation last updated on: {REBUILT}.
-


### PR DESCRIPTION
Ready to merge with upstream 7.4.x.

Implemented the following new anchor format in all guides:
**[id='anchor_name']**

Also resolved a few minor build errors left over from the LA release skirmish.

See [JIRA](https://issues.jboss.org/browse/BXMSDOC-1517) for details.