### PR TITLE
UserGuideFix: Corrected main.adoc file where a space had been inserte…

### DIFF
--- a/docs/product-user-guide/src/main/asciidoc/main.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/main.adoc
@@ -1,4 +1,4 @@
- include::product-shared-docs/document-attributes.adoc[]
+include::product-shared-docs/document-attributes.adoc[]
 
 = User Guide
 :doctype: book


### PR DESCRIPTION
where a space had been inserted before the attribute file insertion, preventing the book from building.