### PR TITLE
BXMSDOC-1816 (for upstream 7.4.x): Updated Development Guide with new kie-server REST PUT call for updating taskInstance object

### DIFF
--- a/docs/product-development-guide/src/main/asciidoc/chap-intelligent-process-server.adoc
+++ b/docs/product-development-guide/src/main/asciidoc/chap-intelligent-process-server.adoc
@@ -3,9 +3,9 @@
 For {PRODUCT_BPMS}, the server is called _{KIE_SERVER_BPMS}_. For {PRODUCT_BRMS}, the server is called _{KIE_SERVER_BRMS}_. In the following text, only {KIE_SERVER_BPMS} is used.
 ====
 
-The {KIE_SERVER} is a standalone component that can be used to instantiate and execute rules and processes. The {KIE_SERVER_BPMS} and the {KIE_SERVER_BRMS} are created as a WAR file that can be deployed on any web container. 
+The {KIE_SERVER} is a standalone component that can be used to instantiate and execute rules and processes. The {KIE_SERVER_BPMS} and the {KIE_SERVER_BRMS} are created as a WAR file that can be deployed on any web container.
 
-This server has a low footprint with minimal memory consumption; therefore, it can be deployed easily on a cloud instance. 
+This server has a low footprint with minimal memory consumption; therefore, it can be deployed easily on a cloud instance.
 Each instance of this server can open and instantiate multiple KIE containers, which allows you to execute multiple rules and processes in parallel.
 
 [NOTE]
@@ -31,9 +31,9 @@ The default {KIE_SERVER_BRMS} includes the following components.
 * {PRODUCT_BRMS}
 * {PLANNER}
 
-For further information about the planner capabilities of the {KIE_SERVER_BPMS} and {KIE_SERVER_BRMS}, see the {URL_PLANNER_GUIDE}[{PLANNER}] guide. 
+For further information about the planner capabilities of the {KIE_SERVER_BPMS} and {KIE_SERVER_BRMS}, see the {URL_PLANNER_GUIDE}[{PLANNER}] guide.
 
-Each of the product components consists of one or more execution server extensions that provide greater control over your execution environment. You can disable or enable certain extensions. For more information about setting extensions, see the {URL_ADMIN_GUIDE}#bootstrap_switches[Bootstrap Switches] chapter of the _{ADMIN_GUIDE}_. 
+Each of the product components consists of one or more execution server extensions that provide greater control over your execution environment. You can disable or enable certain extensions. For more information about setting extensions, see the {URL_ADMIN_GUIDE}#bootstrap_switches[Bootstrap Switches] chapter of the _{ADMIN_GUIDE}_.
 
 Below is the list of extensions:
 
@@ -66,7 +66,7 @@ Provides the capability to perform complex search and filtering queries for task
 BRM::
 Provides the rule execution capability.
 
-DMN:: 
+DMN::
 Provides the Decision Model and Notation support.
 --
 
@@ -74,7 +74,7 @@ Provides the Decision Model and Notation support.
 +
 --
 BRP::
-Provides the {PLANNER} capability. 
+Provides the {PLANNER} capability.
 --
 
 == Extending {KIE_SERVER} Extensions
@@ -88,7 +88,7 @@ Provides the {PLANNER} capability.
 * `jBPMSearch` - equivalent to the `BPMQueries` capability.
 * `Case-Mgmt` - equivalent to the `CaseMgmt` capability.
 * `OptaPlanner` - equivalent to the `BRP` capability.
-* `DMN` - equivalent to the `DMN` capability. 
+* `DMN` - equivalent to the `DMN` capability.
 
 To extend {A_KIE_SERVER} extension, implement the following steps:
 
@@ -97,7 +97,7 @@ To extend {A_KIE_SERVER} extension, implement the following steps:
 . Make your custom extension discoverable.
 
 [float]
-== Hello World {KIE_SERVER} Extension 
+== Hello World {KIE_SERVER} Extension
 
 See the following steps to implement a hello world example custom {KIE_SERVER} extension:
 
@@ -114,7 +114,7 @@ See the following steps to implement a hello world example custom {KIE_SERVER} e
     <artifactId>kie-server-rest-common</artifactId>
     <version>${version.org.kie}</version>
   </dependency>
-  
+
   <!-- Replace with logger of your choice -->
   <dependency>
     <groupId>org.slf4j</groupId>
@@ -147,13 +147,13 @@ public class CustomKieServerApplicationComponentsService implements KieServerApp
     private static final String OWNER_EXTENSION = "Drools";
     private static final Logger logger = LoggerFactory.getLogger(CustomKieServerApplicationComponentsService.class);
 
-    
+
     public Collection<Object> getAppComponents(String extension, SupportedTransports type, Object... services) {
         // Skip calls from extensions other than the one you want to extend
         if ( !OWNER_EXTENSION.equals(extension) ) {
             return Collections.emptyList();
         }
-        
+
         List<Object> components = new ArrayList<Object>(1);
         if( SupportedTransports.REST.equals(type) ) {
             components.add(new CustomResource());
@@ -185,8 +185,8 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Variant;
 
 @Path("server/helloworld")
-public class CustomResource {    
-    
+public class CustomResource {
+
     @GET()
     @Produces(MediaType.APPLICATION_XML)
     public Response testMe(@Context HttpHeaders headers) {
@@ -206,7 +206,7 @@ brq.redhat.documentation.CustomKieServerApplicationComponentsService
 
 . Package the class into the `JAR` format, and copy the resulting `JAR` file into the `kie-server.war/WEB-INF/lib` directory. For example, on {EAP}, the path is `_EAP_HOME_/standalone/deployments/kie-server.war/WEB-INF/lib`.
 
-When you start the {KIE_SERVER}, the `server/helloworld` endpoint becomes available, for example `http://localhost:8080/kie-server/services/rest/server/helloworld`. 
+When you start the {KIE_SERVER}, the `server/helloworld` endpoint becomes available, for example `http://localhost:8080/kie-server/services/rest/server/helloworld`.
 
 [id='_realtime_decision_server']
 = The REST API for {KIE_SERVER} Execution
@@ -369,17 +369,17 @@ Request Type::
 The variable marshalled value.
 
 Description::
-Sets the value of the `_VARIABLE_NAME_` variable for the `_PROCESS_INSTANCE_ID_` process instance. If successful, the return value is HTTP code 201. 
+Sets the value of the `_VARIABLE_NAME_` variable for the `_PROCESS_INSTANCE_ID_` process instance. If successful, the return value is HTTP code 201.
 --
 
 [GET] /instances/_PROCESS_INSTANCE_ID_/variable/_VARIABLE_NAME_::
 +
 --
 Response Type::
-The variable value. 
+The variable value.
 
 Description::
-Returns the marshalled value of the `_VARIABLE_NAME_` variable for the `_PROCESS_INSTANCE_ID_` process instance. 
+Returns the marshalled value of the `_VARIABLE_NAME_` variable for the `_PROCESS_INSTANCE_ID_` process instance.
 --
 
 [POST] /instances/_PROCESS_INSTANCE_ID_/variables::
@@ -389,7 +389,7 @@ Request Type::
 A map with variable names and values.
 
 Description::
-Sets multiple variables that belong to a `_PROCESS_INSTANCE_ID_` process instance. The request is a map, in which the key is the name of the variable and the value is the new value of the variable. 
+Sets multiple variables that belong to a `_PROCESS_INSTANCE_ID_` process instance. The request is a map, in which the key is the name of the variable and the value is the new value of the variable.
 --
 
 [GET] /instances/_PROCESS_INSTANCE_ID_/variables::
@@ -415,7 +415,7 @@ Additional parameters you can use: `status`, `sort`, `sortOrder`.
 +
 --
 Response Type::
-A list of https://github.com/kiegroup/droolsjbpm-integration/blob/6.5.x/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/instance/WorkItemInstance.java[WorkItemInstance] objects. 
+A list of https://github.com/kiegroup/droolsjbpm-integration/blob/6.5.x/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/instance/WorkItemInstance.java[WorkItemInstance] objects.
 
 Description::
 Gets all the work items of the given `_PROCESS_INSTANCE_ID_` process instance.
@@ -425,7 +425,7 @@ Gets all the work items of the given `_PROCESS_INSTANCE_ID_` process instance.
 +
 --
 Response Type::
-A https://github.com/kiegroup/droolsjbpm-integration/blob/6.5.x/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/instance/WorkItemInstance.java[WorkItemInstance] object. 
+A https://github.com/kiegroup/droolsjbpm-integration/blob/6.5.x/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/instance/WorkItemInstance.java[WorkItemInstance] object.
 
 Description::
 Gets the `_WORK_ITEM_ID_` work item of the given `_PROCESS_INSTANCE_ID_` process instance.
@@ -435,14 +435,14 @@ Gets the `_WORK_ITEM_ID_` work item of the given `_PROCESS_INSTANCE_ID_` process
 +
 --
 Description::
-Aborts the `_WORK_ITEM_ID_` work item of the given `_PROCESS_INSTANCE_ID_` process instance. If successful, the return value is HTTP code 201. 
+Aborts the `_WORK_ITEM_ID_` work item of the given `_PROCESS_INSTANCE_ID_` process instance. If successful, the return value is HTTP code 201.
 --
 
 [PUT]  /instances/_PROCESS_INSTANCE_ID_/workitems/_WORK_ITEM_ID_/completed::
 +
 --
 Description::
-Completes the `_WORK_ITEM_ID_` work item of the given `_PROCESS_INSTANCE_ID_` process instance. If successful, the return value is HTTP code 201. 
+Completes the `_WORK_ITEM_ID_` work item of the given `_PROCESS_INSTANCE_ID_` process instance. If successful, the return value is HTTP code 201.
 --
 
 [POST] /_PROCESS_ID_/instances::
@@ -452,10 +452,10 @@ Request Type::
 A map with variables used to start the process.
 
 Response Type::
-Plain text with the process instance id. 
+Plain text with the process instance id.
 
 Description::
-Creates a `_PROCESS_ID_` business process instance. Accepted input is a map with the process variables and its values. 
+Creates a `_PROCESS_ID_` business process instance. Accepted input is a map with the process variables and its values.
 --
 
 [POST] /instances/signal/_SIGNAL_NAME_::
@@ -465,14 +465,14 @@ Request Type::
 A marshalled object.
 
 Description::
-Signals multiple process instances of a query parameter `instanceId` with the `_SIGNAL_NAME_` signal. You can provide the signal payload marshalled in the request body. 
+Signals multiple process instances of a query parameter `instanceId` with the `_SIGNAL_NAME_` signal. You can provide the signal payload marshalled in the request body.
 --
 
-[DELETE] /instances/_PROCESS_INSTANCE_ID_:: 
+[DELETE] /instances/_PROCESS_INSTANCE_ID_::
 +
 --
 Description::
-Aborts the `_PROCESS_INSTANCE_ID_` process instance. If successful, the return value is HTTP code 204. 
+Aborts the `_PROCESS_INSTANCE_ID_` process instance. If successful, the return value is HTTP code 204.
 --
 
 [GET] /instances/_PROCESS_INSTANCE_ID_::
@@ -482,7 +482,7 @@ Response Type::
 A https://github.com/kiegroup/droolsjbpm-integration/blob/6.5.x/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/instance/ProcessInstance.java[process instance] object.
 
 Description::
-Returns the details of the `_PROCESS_INSTANCE_ID_` process instance. To request variable information, set the `withVars` query parameter to `true`. 
+Returns the details of the `_PROCESS_INSTANCE_ID_` process instance. To request variable information, set the `withVars` query parameter to `true`.
 --
 
 [GET] /instances::
@@ -512,7 +512,7 @@ Response Type::
 A https://github.com/kiegroup/droolsjbpm-integration/blob/6.5.x/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/instance/VariableInstanceList.java[variable instance list] object.
 
 Description::
-Returns the current variable values of the specified process instance. 
+Returns the current variable values of the specified process instance.
 --
 
 [GET] /instances/_PROCESS_INSTANCE_ID_/variables/instances/_VARIABLE_ID_::
@@ -522,7 +522,7 @@ Response Type::
 A https://github.com/kiegroup/droolsjbpm-integration/blob/6.5.x/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/instance/VariableInstance.java[variable instance list] object.
 
 Description::
-Returns the value of the variable in the specified process instance. 
+Returns the value of the variable in the specified process instance.
 --
 
 [POST] /instances/_PROCESS_INSTANCE_ID_/signal/_SIGNAL_NAME_::
@@ -532,20 +532,20 @@ Request Type::
 A marshalled object.
 
 Description::
-Signals the `_PROCESS_INSTANCE_ID_` process instance with `_SIGNAL_NAME_` signal. You can provide the signal payload marshalled in the request body. 
+Signals the `_PROCESS_INSTANCE_ID_` process instance with `_SIGNAL_NAME_` signal. You can provide the signal payload marshalled in the request body.
 --
 
 [POST] /_PROCESS_ID_/instances/correlation/_CORRELATION_KEY_::
 +
 --
 Request Type::
-A map with variables used to start the process. 
+A map with variables used to start the process.
 
 Response Type::
  Plain text with the process instance id.
 
 Description::
-Creates the `_PROCESS_ID_` business process instance with the `_CORRELATION_KEY_` correlation key. Accepted input is a map with the process variables and its values. 
+Creates the `_PROCESS_ID_` business process instance with the `_CORRELATION_KEY_` correlation key. Accepted input is a map with the process variables and its values.
 --
 
 
@@ -602,7 +602,7 @@ endif::BPMS[]
 [id='_process_queries']
 == Managing Process Definitions
 
-Use this base URI: `http://_SERVER:PORT_/kie-execution-server/services/rest/server/containers/_CONTAINER_ID_/processes/definitions`. To use pagination, use the `page` and `pageSize` query parameters. See the list of endpoints: 
+Use this base URI: `http://_SERVER:PORT_/kie-execution-server/services/rest/server/containers/_CONTAINER_ID_/processes/definitions`. To use pagination, use the `page` and `pageSize` query parameters. See the list of endpoints:
 
 [GET] /_PROCESS_ID_/variables::
 +
@@ -914,7 +914,7 @@ If you disabled the security settings and still experience authentication issues
 ----
 <property name="org.jbpm.ht.callback" value="props"/>
 <!-- If necessary, override the userinfo configuration as well. -->
-<property name="org.jbpm.ht.userinfo" value="props"/> 
+<property name="org.jbpm.ht.userinfo" value="props"/>
 ----
 +
 See the https://github.com/droolsjbpm/jbpm/blob/6.5.x/jbpm-runtime-manager/src/main/java/org/jbpm/runtime/manager/impl/identity/UserDataServiceProvider.java#L42-L47[source code] for other possible values.
@@ -924,7 +924,7 @@ See the https://github.com/droolsjbpm/jbpm/blob/6.5.x/jbpm-runtime-manager/src/m
 ----
 <property name="jbpm.user.group.mapping" value="file:///EAP_HOME/standalone/configuration/application-roles.properties"/>
 <!-- If no other file is specified, the business-central.war/WEB-INF/classes/userinfo.properties file is used.
-You can specify a file with the following property: 
+You can specify a file with the following property:
 <property name="jbpm.user.info.properties" value="file:///path" /> -->
 ----
 
@@ -960,7 +960,7 @@ You can also use a different callback object. The Human Task callback is instant
 
 === Managing Task Instance Data
 
-Use this base URI: `http://_SERVER:PORT_/kie-execution-server/services/rest/server/containers/_CONTAINER_ID_/tasks/_TASK_ID_`. See the list of endpoints: 
+Use this base URI: `http://_SERVER:PORT_/kie-execution-server/services/rest/server/containers/_CONTAINER_ID_/tasks/_TASK_ID_`. See the list of endpoints:
 
 
 [GET] /::
@@ -971,6 +971,17 @@ A https://github.com/kiegroup/droolsjbpm-integration/blob/6.5.x/kie-server-paren
 
 Description::
 Gets the `_TASK_ID_` task instance details.
+--
+
+
+[PUT] /::
++
+--
+Request Type::
+A map of a  https://github.com/kiegroup/droolsjbpm-integration/blob/6.5.x/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/instance/TaskInstance.java[TaskInstance] object in `xml-jaxb`, `xml-xstream`, or `json` format that defines TaskInstance properties and input and output parameters.
+
+Description::
+Updates the TaskInstance object and returns HTTP 201 if successful. Provide the TaskInstance properties and input and output parameters to be updated.
 --
 
 
@@ -1597,7 +1608,7 @@ Returns the value of the given variable in the specified process instance.
 
 
 Use the following entry point: `http://_SERVER:PORT_/kie-execution-server/services/rest/server/queries/`.
-To use pagination, use the `page` and `pageSize` parameters. See the list of endpoints: 
+To use pagination, use the `page` and `pageSize` parameters. See the list of endpoints:
 
 [GET] tasks/instances/pot-owners::
 Returns a list of tasks where the actual user is defined as a potential owner.
@@ -1828,7 +1839,7 @@ For endpoints that include _MAPPER_ID_, you can use following default mappers:
 * `org.jbpm.kie.services.impl.query.mapper.RawListQueryMapper`
 ** registered with name - `RawList`
 
-See the list of endpoints: 
+See the list of endpoints:
 
 .Advanced Queries Endpoints
 [GET] /::
@@ -1998,7 +2009,7 @@ Use the following base URI: __http://_SERVER_ADDRESS:PORT_/kie-execution-server/
 [GET] /::
 Response type: list of `RequestInfoInstance` objects
 +
-Description: Use this endpoint to query jobs in the server. You can specify the parameters ``page``, ``pageSize``, and ``status``; possible values for status are `QUEUED`, `DONE`, `CANCELLED`, `ERROR`, `RETRYING`, and `RUNNING`. 
+Description: Use this endpoint to query jobs in the server. You can specify the parameters ``page``, ``pageSize``, and ``status``; possible values for status are `QUEUED`, `DONE`, `CANCELLED`, `ERROR`, `RETRYING`, and `RUNNING`.
 Note that these values must be capitalized.
 
 [POST] /::
@@ -2032,7 +2043,7 @@ Description: Updates the data field for existing command. For example, the https
 [GET] /commands/_JOB_COMMAND_NAME_::
 Response type: list of `RequestInfoInstance` objects
 +
-Description: Returns a list of jobs configured to run with the `_JOB_COMMAND_NAME_` command class. You can specify the parameters ``page``, ``pageSize``, and ``status``. Use the `status` query parameter to filter queries based on their status; possible values for status are `QUEUED`, `DONE`, `CANCELLED`, `ERROR`, `RETRYING`, and `RUNNING`. 
+Description: Returns a list of jobs configured to run with the `_JOB_COMMAND_NAME_` command class. You can specify the parameters ``page``, ``pageSize``, and ``status``. Use the `status` query parameter to filter queries based on their status; possible values for status are `QUEUED`, `DONE`, `CANCELLED`, `ERROR`, `RETRYING`, and `RUNNING`.
 
 [GET] /_JOB_ID_::
 Response type: `RequestInfoInstance` object
@@ -2052,19 +2063,19 @@ Description: Requests unfinished or failed job request with the given `_JOB_ID_`
 [GET] /keys/_BUSINESS_KEY_::
 Response type: list of `RequestInfoInstance` objects.
 +
-Description: Returns a list of jobs that match the given ``_BUSINESS_KEY_``. You can specify the parameters ``page``, ``pageSize``, and ``status``. Use the `status` query parameter to filter queries based on their status; possible values for status are `QUEUED`, `DONE`, `CANCELLED`, `ERROR`, `RETRYING`, and `RUNNING`. 
+Description: Returns a list of jobs that match the given ``_BUSINESS_KEY_``. You can specify the parameters ``page``, ``pageSize``, and ``status``. Use the `status` query parameter to filter queries based on their status; possible values for status are `QUEUED`, `DONE`, `CANCELLED`, `ERROR`, `RETRYING`, and `RUNNING`.
 
 [GET] /containers/_CONTAINER_ID_::
 +
 Response type: list of `RequestInfoInstance` objects.
 +
-Description: Returns a list of jobs that match given container. You can specify the parameters ``page``, ``pageSize``, and ``status``. Use the `status` query parameter to filter queries based on their status; possible values for status are `QUEUED`, `DONE`, `CANCELLED`, `ERROR`, `RETRYING`, and `RUNNING`. 
+Description: Returns a list of jobs that match given container. You can specify the parameters ``page``, ``pageSize``, and ``status``. Use the `status` query parameter to filter queries based on their status; possible values for status are `QUEUED`, `DONE`, `CANCELLED`, `ERROR`, `RETRYING`, and `RUNNING`.
 
 [GET] /processes/instances/_PROCESS_INSTANCE_ID_::
 +
 Response type: list of `RequestInfoInstance` objects.
 +
-Description: Returns a list of jobs associated with given _PROCESS_INSTANCE_ID_. You can specify the parameters ``page``, ``pageSize``, and ``status``. Use the `status` query parameter to filter queries based on their status; possible values for status are `QUEUED`, `DONE`, `CANCELLED`, `ERROR`, `RETRYING`, and `RUNNING`. 
+Description: Returns a list of jobs associated with given _PROCESS_INSTANCE_ID_. You can specify the parameters ``page``, ``pageSize``, and ``status``. Use the `status` query parameter to filter queries based on their status; possible values for status are `QUEUED`, `DONE`, `CANCELLED`, `ERROR`, `RETRYING`, and `RUNNING`.
 
 
 .[POST] New Job
@@ -2161,15 +2172,15 @@ Process Instance Id:: Filter by process instance ID.
 +
 Input: `Numeric`
 
-Business Key:: Filter by business key. The business key is defined when a job is created, usually relating in some way to the business process. 
+Business Key:: Filter by business key. The business key is defined when a job is created, usually relating in some way to the business process.
 +
 Input: `String`
 
 Type:: Filter by class name. The type is the class to be executed as part of the job request.
 +
-Input: 'String' 
+Input: 'String'
 
-Process Description:: Filter by process description. 
+Process Description:: Filter by process description.
 +
 Input: `String`
 
@@ -2209,7 +2220,7 @@ For more information about advanced search filtering, see {URL_USER_GUIDE}#chap-
 
 == Managing Documents
 
-The {KIE_SERVER} enables you to upload and interact with documents. Use the following base URI: `http://_SERVER:PORT_/kie-execution-server/services/rest/server/documents`. See the list of endpoints: 
+The {KIE_SERVER} enables you to upload and interact with documents. Use the following base URI: `http://_SERVER:PORT_/kie-execution-server/services/rest/server/documents`. See the list of endpoints:
 
 [GET] /::
 +
@@ -2310,7 +2321,7 @@ A https://github.com/kiegroup/droolsjbpm-integration/blob/7.0.x/kie-server-paren
 +
 --
 Description::
-Deletes the specified document. 
+Deletes the specified document.
 --
 
 
@@ -2706,7 +2717,7 @@ The `<capabilities>` tags provide information about your execution server. See <
 
 
 [POST] /config::
-Use this endpoint to execute commands on the execution server, for example `create-container`, `list-containers`, `dispose-container`, and `call-container`. 
+Use this endpoint to execute commands on the execution server, for example `create-container`, `list-containers`, `dispose-container`, and `call-container`.
 +
 An example call for the JAXB marshaller:
 +
@@ -3294,14 +3305,14 @@ import org.kie.server.api.marshalling.MarshallingFormat;
 
 ...
 
-Marshaller marshaller = MarshallerFactory.getMarshaller(MarshallingFormat.JSON,myclass.class.getClassLoader()); 
+Marshaller marshaller = MarshallerFactory.getMarshaller(MarshallingFormat.JSON,myclass.class.getClassLoader());
 //Marshalling format is changed based on the method of marshalling for the CallContainerCommand. Also note myclass.class classloader is called. If replicating this code, change the name to the name of your class.
 
 Command<?> fire = KieServices.Factory.get().getCommands().newFireAllRules();
 BatchExecutionCommand batch = KieServices.Factory.get().getCommands().newBatchExecution(Arrays.<Command<?>>asList(fire), "defaultKieSession");
 String payload = marshaller.marshall(batch);
 ----
-+ 
++
 XML body request using the JAXB marshaller:
 +
 [source,xml]
@@ -3725,7 +3736,7 @@ To stop the scanner, replace the status with `DISPOSED` and remove the `poll-int
 
 == {KIE_SERVER} Standalone Controller
 
-The {KIE_SERVER} standalone controller is used for handling {KIE_SERVER} instead of Business Central. The standalone controller provides a REST interface that allows {KIE_SERVER} to register with the controller, and allows the controller to then deploy and undeploy (start and stop) containers to {KIE_SERVER} instances running a given server template. The standalone controller can be deployed to all supported containers. 
+The {KIE_SERVER} standalone controller is used for handling {KIE_SERVER} instead of Business Central. The standalone controller provides a REST interface that allows {KIE_SERVER} to register with the controller, and allows the controller to then deploy and undeploy (start and stop) containers to {KIE_SERVER} instances running a given server template. The standalone controller can be deployed to all supported containers.
 
 The following configuration settings can be used to expose the {KIE_SERVER} to the controller:
 
@@ -3812,7 +3823,7 @@ The base URI for process administration is `http://_SERVER:PORT_/kie-execution-s
 +
 --
 Description::
-Returns a list of execution errors for the given container. 
+Returns a list of execution errors for the given container.
 +
 Possible query parameters with the type associated value: `includeAck` (Boolean), `page` (number), `pageSize` (number), `sort` (String), `sortOrder` (Boolean).
 --
@@ -3821,7 +3832,7 @@ Possible query parameters with the type associated value: `includeAck` (Boolean)
 +
 --
 Description::
-Returns information about the given execution error for the given container. 
+Returns information about the given execution error for the given container.
 --
 
 [PUT] /errors/_ERROR_ID_::
@@ -3848,9 +3859,9 @@ Payload is not required.
 +
 --
 Description::
-Returns information about execution errors for the given process instance. 
+Returns information about execution errors for the given process instance.
 +
-Possible query parameters with the type associated value: `includeAck` (Boolean), `page` (number), `pageSize` (number), `sort` (String), `sortOrder` (Boolean). Use the `node` (String) parameter to display errors only for the specified node ID. 
+Possible query parameters with the type associated value: `includeAck` (Boolean), `page` (number), `pageSize` (number), `sort` (String), `sortOrder` (Boolean). Use the `node` (String) parameter to display errors only for the specified node ID.
 --
 
 [PUT] /instances/_PROCESS_INSTANCE_ID_::
@@ -4065,7 +4076,7 @@ Removes the specified business administrator user group from the specified task.
 +
 --
 Description::
-Enters the input into a task instance variable. 
+Enters the input into a task instance variable.
 
 Payload::
 A `Map<String,Object>` object where the key is the ID of the task input variable and the value is the value of the input. The following example sets the task input `performance` to the value `good`:
@@ -4189,7 +4200,7 @@ Deletes the notification.
 +
 --
 Description::
-Returns a list of execution task errors for the given container. 
+Returns a list of execution task errors for the given container.
 +
 Possible query parameters with the type associated value: `includeAck` (Boolean), `page` (number), `pageSize` (number), `sort` (String), `sortOrder` (Boolean), `process` (String), `name` (String).
 --
@@ -4208,7 +4219,7 @@ Payload is not required.
 +
 --
 Description::
-Returns information about the given execution task error for the given container. 
+Returns information about the given execution task error for the given container.
 --
 
 [PUT] /errors/_ERROR_ID_::
@@ -4443,12 +4454,12 @@ public class DecisionServerTest {
   @Before
   public void initialize() {
     conf = KieServicesFactory.newRestConfiguration(URL, USER, PASSWORD);
-    
+
     //If you use custom classes, such as Obj.class, add them to the configuration
     Set<Class<?>> extraClassList = new HashSet<Class<?>>();
     extraClassList.add(Obj.class);
     conf.addExtraClasses(extraClassList);
-    
+
     conf.setMarshallingFormat(FORMAT);
     kieServicesClient = KieServicesFactory.newKieServicesClient(conf);
   }
@@ -4499,12 +4510,12 @@ public class DecisionServerTest {
     ConnectionFactory connectionFactory = (ConnectionFactory) context.lookup(CONNECTION_FACTORY);
 
     conf = KieServicesFactory.newJMSConfiguration(connectionFactory, requestQueue, responseQueue, USER, PASSWORD);
-    
+
     //If you use custom classes, such as Obj.class, add them to the configuration
     Set<Class<?>> extraClassList = new HashSet<Class<?>>();
     extraClassList.add(Obj.class);
     conf.addExtraClasses(extraClassList);
-    
+
     kieServicesClient = KieServicesFactory.newKieServicesClient(conf);
   }
 }
@@ -4617,18 +4628,18 @@ import java.util.Arrays;
 ...
 
 public void executeCommands() {
-  
+
   String containerId = "hello";
   System.out.println("== Sending commands to the server ==");
   RuleServicesClient rulesClient = kieServicesClient.getServicesClient(RuleServicesClient.class);
   KieCommands commandsFactory = KieServices.Factory.get().getCommands();
-  
+
   Command<?> insert = commandsFactory.newInsert("Some String OBJ");
   Command<?> fireAllRules = commandsFactory.newFireAllRules();
   Command<?> batchCommand = commandsFactory.newBatchExecution(Arrays.asList(insert, fireAllRules));
-  
+
   ServiceResponse<String> executeResponse = rulesClient.executeCommands(containerId, batchCommand);
-  
+
   if(executeResponse.getType() == ResponseType.SUCCESS) {
     System.out.println("Commands executed with success! Response: ");
     System.out.println(executeResponse.getResult());
@@ -4666,10 +4677,10 @@ IMPORTANT: Regardless of which response handler is globally specified, `KieServi
 [source,java]
 ----
 public void listCapabilities() {
-    
+
   KieServerInfo serverInfo = kieServicesClient.getServerInfo().getResult();
   System.out.print("Server capabilities:");
-  
+
   for (String capability : serverInfo.getCapabilities()) {
     System.out.print(" " + capability);
   }
@@ -4785,7 +4796,7 @@ Following services are available in the `org.kie.server.client` package:
 * https://github.com/droolsjbpm/droolsjbpm-integration/blob/6.5.x/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/RuleServicesClient.java[RuleServicesClient] is used to send commands to the server to perform rule-related operations (for example insert objects into the working memory, fire rules, ...).
 * https://github.com/droolsjbpm/droolsjbpm-integration/blob/6.5.x/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/UserTaskServicesClient.java[UserTaskServicesClient] is used to perform all user-task operations (start, claim, cancel a task) and query tasks by specified field (process instances id, user, ...)
 * https://github.com/droolsjbpm/droolsjbpm-integration/blob/6.5.x/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/UIServicesClient.java[UIServicesClient] is used to get String representation of forms (XML or JSON) and of the process image (SVG).
-* https://github.com/droolsjbpm/droolsjbpm-integration/blob/6.5.x/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/SolverServicesClient.java[SolverServicesClient] is used to perform all {PLANNER} operations, such as getting the solver state and the best solution, or disposing of a solver. 
+* https://github.com/droolsjbpm/droolsjbpm-integration/blob/6.5.x/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/SolverServicesClient.java[SolverServicesClient] is used to perform all {PLANNER} operations, such as getting the solver state and the best solution, or disposing of a solver.
 
 * https://github.com/kiegroup/droolsjbpm-integration/blob/7.3.x/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/admin/ProcessAdminServicesClient.java[ProcessAdminServicesClient] and https://github.com/kiegroup/droolsjbpm-integration/blob/7.3.x/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/admin/UserTaskAdminServicesClient.java[UserTaskAdminServicesClient]. For more information about the `ProcessAdminServicesClient` and `UserTaskAdminServicesClient` clients, see <<_administration_service_interface>>.
 
@@ -4844,25 +4855,25 @@ import org.kie.server.client.ProcessServicesClient;
 public static void startProcess() {
   //Client configuration setup
   KieServicesConfiguration config = KieServicesFactory.newRestConfiguration(SERVER_URL, LOGIN, PASSWORD);
-  
+
   //Add custom classes, such as Obj.class, to the configuration
   Set<Class<?>> extraClassList = new HashSet<Class<?>>();
   extraClassList.add(Obj.class);
   config.addExtraClasses(extraClassList);
   config.setMarshallingFormat(MarshallingFormat.JSON);
-  
+
   // ProcessServicesClient setup
   KieServicesClient client = KieServicesFactory.newKieServicesClient(config);
   ProcessServicesClient processServicesClient = client.getServicesClient(ProcessServicesClient.class);
-  
+
   // Create an instance of the custom class
   Obj obj = new Obj();
   obj.setOk("ok");
-  
+
   Map<String, Object> variables = new HashMap<String, Object>();
   variables.put("test", obj);
 
-  
+
   // Start the process with custom class
   processServicesClient.startProcess(CONTAINER, processId, variables);
 }


### PR DESCRIPTION
Ready to merge with upstream 7.4.x.

Cherry-picked from BXMSDOC-1816-master.

[JIRA](https://issues.jboss.org/browse/BXMSDOC-1816)
[Doc preview](http://file.rdu.redhat.com/~sterobin/BXMSDOC-1816/#managing_task_instance_data)