### PR TITLE
BXMSDOC-1348-B (for upstream master): Update section on Storing Query Definitions in a kJAR in Dev Guide

### DIFF
--- a/docs/product-development-guide/src/main/asciidoc/chap-kie-api.adoc
+++ b/docs/product-development-guide/src/main/asciidoc/chap-kie-api.adoc
@@ -4386,7 +4386,7 @@ With this mechanism, you can define what data are retrieved and how they should 
 
 ==== Storing Query Definitions in a kJAR
 
-You can store query definitions in a kJAR so that the definitions are registered when the kJAR is deployed. In some cases, defining queries this way can be more efficient than manually defining them with the <<_sect_the_rest_query_api,REST Query API>>.
+You can store query definitions in a kJAR so that the definitions are registered when the kJAR is deployed. In some cases, defining queries this way can be more efficient than manually defining them with the <<_advanced_queries2,{KIE_SERVER} REST API>>.
 
 .Procedure
 . Create a JSON file named `query-definitions.json` and place it in the kJAR.


### PR DESCRIPTION
Ready to merge with upstream master.

The branch BXMSDOC-1348 was merged prematurely by gatekeeper before SME and peer reviews. This new branch, with suffix B, implements SME and peer feedback to the same change.

[JIRA](https://issues.jboss.org/browse/BXMSDOC-1348)
[Doc preview](http://file.rdu.redhat.com/~sterobin/BXMSDOC-1348/#sect_query_service) - Scroll to "21.3.6.5 Storing Query Definitions in a kJAR" 