### PR TITLE
BXMSDOC-1348 (for upstream 7.4.x): Update section on Storing Query Definitions in a kJAR in Dev Guide

### DIFF
--- a/docs/product-development-guide/src/main/asciidoc/chap-kie-api.adoc
+++ b/docs/product-development-guide/src/main/asciidoc/chap-kie-api.adoc
@@ -15,7 +15,7 @@ To create a session:
 . First, create a knowledge base and load all the necessary process definitions. Process definitions can be loaded from various sources, such as the class path, file system, or a process repository.
 . Instantiate a session.
 
-Once a session is set, you can use the session to execute processes. Every time a process is started, a new process instance of that particular process defition is created. The process instance maintains its state throughout the process life cycle. 
+Once a session is set, you can use the session to execute processes. Every time a process is started, a new process instance of that particular process defition is created. The process instance maintains its state throughout the process life cycle.
 
 For example, to write an application that processes sales orders, define one or more process definitions that specify how the orders must be processed. When starting the application, create a knowledge base that contains the specified process definitions. Based on the knowledge base, instantiate a session such that each time a new sales order comes in, a new process instance is started for that sales order. The process instance then contains the state of the process for that specific sales request.
 
@@ -82,10 +82,10 @@ The name which retrieves `KieBase` from `KieContainer`. _This attribute is manda
 +
 [cols="1,1", options="header"]
 |===
-|Default Value 
+|Default Value
 |Admitted Values
 
-|None 
+|None
 |Any
 |===
 
@@ -94,10 +94,10 @@ A comma-separated list of other ``KieBase`` objects contained in this `kmodule`.
 +
 [cols="1,1", options="header"]
 |===
-|Default Value 
+|Default Value
 |Admitted Values
 
-|None 
+|None
 |A comma-separated list
 |===
 
@@ -107,10 +107,10 @@ packages::
 +
 [cols="1,1", options="header"]
 |===
-|Default Value 
+|Default Value
 |Admitted Values
 
-|All 
+|All
 |A comma-separated list
 |===
 
@@ -120,10 +120,10 @@ default::
 +
 [cols="1,1", options="header"]
 |===
-|Default Value 
+|Default Value
 |Admitted Values
 
-|`false` 
+|`false`
 |`true` or `false`
 |===
 
@@ -135,14 +135,14 @@ The scope can be specified in two ways;
 +
 --
 * As `javax.enterprise.context._INTERFACE_`, for example.
-* As _INTERFACE_. 
+* As _INTERFACE_.
 --
 +
 The `javax.enterprise.context` package is added automatically if no package is specified.
 +
 [cols="1,1", options="header"]
 |===
-|Default Value 
+|Default Value
 |Admitted Values
 
 |`javax.enterprise.context.ApplicationScoped`
@@ -150,15 +150,15 @@ The `javax.enterprise.context` package is added automatically if no package is s
 |===
 
 equalsBehavior::
-Defines the behavior of Red Hat JBoss BRMS when a new fact is inserted into the working memory. 
+Defines the behavior of Red Hat JBoss BRMS when a new fact is inserted into the working memory.
 +
-If set to `identity`, a new `FactHandle` is always created unless the same object is already present in the working memory. 
+If set to `identity`, a new `FactHandle` is always created unless the same object is already present in the working memory.
 +
 If set to `equality`, a new `FactHandle` is created only if the newly inserted object is not equal, according to its `equals()` method, to an existing fact.
 +
 [cols="1,1", options="header"]
 |===
-|Default Value 
+|Default Value
 |Admitted Values
 
 |`identity`
@@ -167,15 +167,15 @@ If set to `equality`, a new `FactHandle` is created only if the newly inserted o
 
 
 eventProcessingMode::
-If set to `cloud`, `KieBase` treats events as normal facts. 
+If set to `cloud`, `KieBase` treats events as normal facts.
 +
-If set to `stream`, temporal reasoning on events is allowed. 
+If set to `stream`, temporal reasoning on events is allowed.
 +
 See <<_sect_temporal_operations>> for more information.
 +
 [cols="1,1", options="header"]
 |===
-|Default Value 
+|Default Value
 |Admitted Values
 
 |`cloud`
@@ -237,7 +237,7 @@ A unique name of the `KieSession` used to fetch `KieSession` from `KieContainer`
 +
 [cols="1,1", options="header"]
 |===
-|Default Value 
+|Default Value
 |Admitted Values
 
 |None
@@ -253,7 +253,7 @@ A stateless session stores a knowledge state. Therefore, a state is changed ever
 +
 [cols="1,1", options="header"]
 |===
-|Default Value 
+|Default Value
 |Admitted Values
 
 |`stateful`
@@ -265,7 +265,7 @@ Defines whether the `KieSession` is the default one for a module, and therefore 
 +
 [cols="1,1", options="header"]
 |===
-|Default Value 
+|Default Value
 |Admitted Values
 
 |`false`
@@ -277,7 +277,7 @@ Defines whether event time stamps are determined by the system clock or by a pse
 +
 [cols="1,1", options="header"]
 |===
-|Default Value 
+|Default Value
 |Admitted Values
 
 |`realtime`
@@ -292,7 +292,7 @@ A belief system tries to deduce the truth from knowledge (facts). For example, i
 +
 [cols="1,1", options="header"]
 |===
-|Default Value 
+|Default Value
 |Admitted Values
 
 |`simple`
@@ -323,7 +323,7 @@ ksession.startProcess(“org.jbpm.hello”);
 
 manager.disposeRuntimeEngine(engine);
 manager.close();
----- 
+----
 
 For Maven dependencies, see <<_embedded_jbpm_engine_dependencies>>. For further information about the Runtime Manager, see <<_sect_runtime_manager>>.
 
@@ -696,7 +696,7 @@ The Red Hat JBoss BPM Suite engine executes actions serially. For example, if a 
 As a result, you may not even notice this behaivor. Similarly, when the engine encounters a script task in a process, it synchronously executes that script and waits for it to complete before continuing execution.
 
 For example, calling a `Thread.sleep(...)` method as a part of a script does not make the engine continue execution elsewhere, but blocks the engine thread during that period.
-The same principle applies to service tasks. 
+The same principle applies to service tasks.
 
 When a service task is reached in a process, the engine invokes the handler of the service synchronously. The engine waits for the `completeWorkItem(...)` method to return before continuing execution. It is important that your service handler executes your service asynchronously if its execution is not instantaneous. For example, a service task that invokes an external service. Since the delay in invoking the service remotely and waiting for the results can take too long, invoking this service asynchronously is advised. Asynchronous call invokes the service and notifies the engine later when the results are available. After invoking the service, the process engine continues execution of the process.
 
@@ -1062,7 +1062,7 @@ KieContainer kieContainer = kieServices.newKieContainer( releaseId );
 ----
 ====
 
-Use the `KieServices` interface to access KIE building and runtime facilities. 
+Use the `KieServices` interface to access KIE building and runtime facilities.
 
 The example shows how to compile all the Java sources and the KIE resources and deploy them into your KIE container, which makes its content available for use at runtime.
 
@@ -2614,10 +2614,10 @@ For example:
 ----
 KieServices services = KieServices.Factory.get();
 KieContainer container = services.newKieContainer(releaseId);
- 
+
 KieBaseConfiguration conf = KieServices.Factory.get().newKieBaseConfiguration();
 conf.setOption(SequentialOption.YES);
- 
+
 KieBase kieBase = kc.newKieBase(conf);
 ----
 
@@ -2632,10 +2632,10 @@ For example:
 ----
 KieServices services = KieServices.Factory.get();
 KieContainer container = services.newKieContainer(releaseId);
- 
+
 KieBaseConfiguration conf = KieServices.Factory.get().newKieBaseConfiguration();
 conf.setOption(SequentialAgendaOption.DYNAMIC);
- 
+
 KieBase kieBase = kc.newKieBase(conf);
 ----
 --
@@ -3128,12 +3128,12 @@ public interface RuntimeEngine {
    * @return
    */
   KieSession getKieSession();
-     
+
   /**
    * Returns TaskService configured for this RuntimeEngine.
    * @return
    */
-  TaskService getTaskService();   
+  TaskService getTaskService();
 }
 ----
 
@@ -3951,7 +3951,7 @@ The methods `read()` and `write()` are for backwards compatibility. Use the meth
 [id='runtime-manager-spring_proc']
 === Runtime Manager with Spring
 
-The following procedure demonstrates how to configure Spring for a single `RuntimeManager` within the Spring application context. 
+The following procedure demonstrates how to configure Spring for a single `RuntimeManager` within the Spring application context.
 
 .Procedure
 
@@ -4007,9 +4007,9 @@ Alternatively, you can bind `TransactionManager` to `java:comp/TransactionManage
 </bean>
 ----
 +
-This configures the `sample.bpmn` on the classpath as a process that is available for execution. 
+This configures the `sample.bpmn` on the classpath as a process that is available for execution.
 
-. Configure `RuntimeEnvironment` as follows: 
+. Configure `RuntimeEnvironment` as follows:
 +
 [source,xml,options="nowrap"]
 ----
@@ -4031,12 +4031,12 @@ This provides a default `RuntimeEnvironment` that can be used to create an insta
   <property name="runtimeEnvironment" ref="runtimeEnvironment"/>
 </bean>
 ----
- 
+
 With this configuration, you can execute processes with Spring and {PRODUCT} using `EntityManagerFactory` and JTA transaction manager.
 
 {PRODUCT} also supports the following configurations:
 
-* JTA and `SharedEntityManager` 
+* JTA and `SharedEntityManager`
 * Local Persistence Unit and `EntityManagerFactory`
 * Local Persistence Unit and `SharedEntityManager`
 
@@ -4236,7 +4236,7 @@ While using the `QueryDefinition` and `QueryParam` classes is straightforward, t
 
 The Query Result Mapper maps data taken out from database (from data set) into object representation (like ORM providers such as Hibernate map tables to entities).
 As there can be many object types that you can use for representing data set results, it is almost impossible to provide them out of the box.
-Mappers are powerful and thus are pluggable. You can implement your own mapper to transform the result into any type. 
+Mappers are powerful and thus are pluggable. You can implement your own mapper to transform the result into any type.
 {PRODUCT} comes with the following mappers out of the box:
 
 org.jbpm.kie.services.impl.query.mapper.ProcessInstanceQueryMapper::
@@ -4383,6 +4383,34 @@ Collection<ProcessInstanceDesc> instances = queryService.query("getAllProcessIns
 ----
 
 With this mechanism, you can define what data are retrieved and how they should be fetched, without being limited by JPA provider. This also promotes the use of tailored queries for a given environment, as in most of the cases, there may be a single database used. Thus, specific features of that database can be utilized to increase performance.
+
+==== Storing Query Definitions in a kJAR
+
+You can store query definitions in a kJAR so that the definitions are registered when the kJAR is deployed. In some cases, defining queries this way can be more efficient than manually defining them with the <<_advanced_queries2,{KIE_SERVER} REST API>>.
+
+.Procedure
+. Create a JSON file named `query-definitions.json` and place it in the kJAR.
+. Define the query definition or definitions in the JSON file.
++
+Example:
++
+[source,json]
+----
+[
+{
+  "query-name" : "taskSampleQuery",
+  "query-source" : "${org.kie.server.persistence.ds}",
+  "query-expression" : "select * from AuditTaskImpl t ",
+  "query-target" : "CUSTOM"
+}, {
+  "query-name" : "errorSampleQuery",
+  "query-source" : "${org.kie.server.persistence.ds}",
+  "query-expression" : "select * from ExecutionErrorInfo errInfo ",
+  "query-target" : "CUSTOM"
+}
+]
+----
+. Ensure that all queries are named uniquely. If a defined query already exists in the database, then it will be replaced with the one from the JSON file in the kJAR.
 
 === Process Instance Migration Service
 
@@ -4771,7 +4799,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 public class SpringSecurityIdentityProvider implements IdentityProvider {
 
 	public String getName() {
-		
+
 		Authentication auth = SecurityContextHolder.getContext().getAuthentication();
 		if (auth != null && auth.isAuthenticated()) {
 			return auth.getName();
@@ -4783,14 +4811,14 @@ public class SpringSecurityIdentityProvider implements IdentityProvider {
 		Authentication auth = SecurityContextHolder.getContext().getAuthentication();
 		if (auth != null && auth.isAuthenticated()) {
 			List<String> roles = new ArrayList<String>();
-			
+
 			for (GrantedAuthority ga : auth.getAuthorities()) {
 				roles.add(ga.getAuthority());
 			}
-			
+
 			return roles;
 		}
-		
+
 		return Collections.emptyList();
 	}
 
@@ -4810,7 +4838,7 @@ Configure the execution server with KIE services and Spring using the following 
 ----
 <context:annotation-config />
 <tx:annotation-driven />
-<tx:jta-transaction-manager />                
+<tx:jta-transaction-manager />
 
 <bean id="transactionManager" class="org.springframework.transaction.jta.JtaTransactionManager" />
 ----
@@ -4829,7 +4857,7 @@ Configure the execution server with KIE services and Spring using the following 
 [source,xml,options="nowrap"]
 ----
 <util:properties id="roleProperties" location="classpath:/roles.properties" />
- 
+
 <bean id="userGroupCallback" class="org.jbpm.services.task.identity.JBossUserGroupCallbackImpl">
   <constructor-arg name="userGroups" ref="roleProperties"></constructor-arg>
 </bean>
@@ -4838,7 +4866,7 @@ Configure the execution server with KIE services and Spring using the following 
 
 ----
 
-. Configure the the Spring context-aware runtime manager factory that can interact with the Spring container with supporting services, such as transactional command service and task service: 
+. Configure the the Spring context-aware runtime manager factory that can interact with the Spring container with supporting services, such as transactional command service and task service:
 +
 [source,xml,options="nowrap"]
 ----
@@ -4911,5 +4939,3 @@ Configure the execution server with KIE services and Spring using the following 
   </property>
 </bean>
 ----
-
-


### PR DESCRIPTION
Ready to merge with upstream 7.4.x.

Cherry-picked changes from BXMSDOC-1348-B, which contained the changes from BXMSDOC-1348.

[JIRA](https://issues.jboss.org/browse/BXMSDOC-1348)
[Doc preview](http://file.rdu.redhat.com/~sterobin/BXMSDOC-1348/#sect_query_service) - Scroll to "21.3.6.5 Storing Query Definitions in a kJAR" 