### PR TITLE
BXMSDOC-1968 (for upstream master): Added Mikhail Ramendik to author-group.adoc.

### DIFF
--- a/docs/shared-kie-docs/src/main/asciidoc/Product/author-group.adoc
+++ b/docs/shared-kie-docs/src/main/asciidoc/Product/author-group.adoc
@@ -1,1 +1,1 @@
-Red_Hat Customer_Content_Services <brms-docs@redhat.com>; Emily Murphy; Gemma Sheldon; Michele Haglund; Stetson Robinson; Vidya Iyengar
+Red_Hat Customer_Content_Services <brms-docs@redhat.com>; Emily Murphy; Gemma Sheldon; Michele Haglund; Mikhail Ramendik; Stetson Robinson; Vidya Iyengar


### PR DESCRIPTION
Ready for upstream master.

[Sample doc (User Guide)](http://file.rdu.redhat.com/~sterobin/BXMSDOC-1968/)