### PR TITLE
BXMSDOC-1101 (for upstream 7.5.x): Added new Scheduler Service chapter to Admin and Config Guide

### DIFF
--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-scheduler-service.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-scheduler-service.adoc
@@ -1,0 +1,19 @@
+[id='_chap_scheduler_service']
+
+= Scheduler Service
+
+The {PRODUCT} engine employs scheduler service to execute jobs at a scheduled time and date. {PRODUCT} has 3 types of scheduler service:
+
+ThreadPoolSchedulerService::
+
+Default scheduler service that manages its own thread pool to allocate available worker threads for the scheduled task. This service is best for a single node use case.
+
+EjbSchedulerService::
+
+Scheduler service implementation backed by EJB Timer Service. You can enable this if you have `jbpm-services-ejb-timer-XXX.jar` in your application. This service is only available under Java EE container, and uses the container's thread pool. This service is best for a single node use case.
+
+QuartzSchedulerService::
+
+Scheduler service implementation backed by Quartz job scheduler. You can enable this when Quartz is configured. For details, see {URL_INSTALLATION_GUIDE}#setting_up_quartz[Setting Quartz] in the _{INSTALLATION_GUIDE}_.
+
+NOTE: For WebSphere, use clustered EjbSchedulerService instead of QuartzSchedulerService, even in a cluster use case. For details, see https://access.redhat.com/solutions/2175471[How to set up BPM Suite Timers to work in Websphere Application Server clustering] on our Red Hat website.

--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-scheduler-service.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-scheduler-service.adoc
@@ -2,7 +2,7 @@
 
 = Scheduler Service
 
-The {PRODUCT} engine employs scheduler service to execute jobs at a scheduled time and date. {PRODUCT} has 3 types of scheduler service:
+The {PRODUCT} engine employs scheduler service to execute jobs at a scheduled time and date. {PRODUCT} has three types of scheduler service:
 
 ThreadPoolSchedulerService::
 
@@ -10,10 +10,10 @@ Default scheduler service that manages its own thread pool to allocate available
 
 EjbSchedulerService::
 
-Scheduler service implementation backed by EJB Timer Service. You can enable this if you have `jbpm-services-ejb-timer-XXX.jar` in your application. This service is only available under Java EE container, and uses the container's thread pool. This service is best for a single node use case.
+Scheduler service implementation backed by EJB Timer Service. You can enable this if you have a `jbpm-services-ejb-timer-XXX.jar` file in your application. This service is only available under Java EE container and uses the container's thread pool. This service is best for a single node use case.
 
 QuartzSchedulerService::
 
-Scheduler service implementation backed by Quartz job scheduler. You can enable this when Quartz is configured. For details, see {URL_INSTALLATION_GUIDE}#setting_up_quartz[Setting Quartz] in the _{INSTALLATION_GUIDE}_.
+Scheduler service implementation backed by Quartz job scheduler. You can enable this when Quartz is configured. For more information, see {URL_INSTALLATION_GUIDE}#setting_up_quartz[Setting Quartz] in the _{INSTALLATION_GUIDE}_.
 
-NOTE: For WebSphere, use clustered EjbSchedulerService instead of QuartzSchedulerService, even in a cluster use case. For details, see https://access.redhat.com/solutions/2175471[How to set up BPM Suite Timers to work in Websphere Application Server clustering] on our Red Hat website.
+NOTE: For WebSphere, use clustered EjbSchedulerService instead of QuartzSchedulerService, even in a cluster use case. For more information, see https://access.redhat.com/solutions/2175471[How to set up BPM Suite Timers to work in Websphere Application Server clustering] on our Red Hat website.

--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/main.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/main.adoc
@@ -44,6 +44,8 @@ include::chap-asset-repository.adoc[leveloffset=+1]
 
 include::chap-process-export-and-import.adoc[leveloffset=+1]
 
+include::chap-scheduler-service.adoc[leveloffset=+1]
+
 // Part
 = Integration
 ////


### PR DESCRIPTION
For upstream 7.5.x.

This was part of a 6.4 JIRA that impacted 7.0. I know we've moved past 6.4 things for now, but the JIRA is half complete and was waiting SME approval, who said to apply this change to 7.0 as is. So need to do so to close the JIRA. Very small and isolated piece that's easy and worth it to carry forward.

Links:
- [JIRA](https://issues.jboss.org/browse/BXMSDOC-1101)
- [Doc preview](http://file.rdu.redhat.com/~sterobin/BXMSDOC-1101/#chap_scheduler_service)