### PR TITLE
BXMSDOC-2038 (for upstream master): Added :CENTRAL: attribute to BA and DM attribute docs

### DIFF
--- a/docs/shared-kie-docs/src/main/asciidoc/Product/document-attributes-ba.adoc
+++ b/docs/shared-kie-docs/src/main/asciidoc/Product/document-attributes-ba.adoc
@@ -4,3 +4,5 @@
 
 :KIE_SERVER: Process Server
 :A_KIE_SERVER: a Process Server
+
+:CENTRAL: Business Central

--- a/docs/shared-kie-docs/src/main/asciidoc/Product/document-attributes-dm.adoc
+++ b/docs/shared-kie-docs/src/main/asciidoc/Product/document-attributes-dm.adoc
@@ -4,3 +4,5 @@
 
 :KIE_SERVER: Decision Server
 :A_KIE_SERVER: a Decision Server
+
+:CENTRAL: Decision Central


### PR DESCRIPTION
Ready to merge with upstream master.

Minor. This change defines :CENTRAL: as Business Central when used in BA docs and Decision Central when used in DM docs. I wanted this in so others could begin using it throughout their deliverables.

[JIRA](https://issues.jboss.org/browse/BXMSDOC-2038)