### PR TITLE
BXMSDOC-2041 (for upstream master): Corrected :context: variable in User Guide

### DIFF
--- a/docs/product-user-guide/src/main/asciidoc/assets-types-ref.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/assets-types-ref.adoc
@@ -1,5 +1,6 @@
 [id='_assets_types_ref']
 = Types of Assets
+:context: assets-types-ref
 
 Anything that can be stored as a version in the Business Central artifact repository is an asset. This includes rules, packages, business processes, decision tables, fact models, and domain specific languages (DSLs).
 
@@ -11,7 +12,6 @@ include::assets-business-rules-gloss.adoc[leveloffset=+1]
 
 include::assets-business-processes-gloss.adoc[leveloffset=+1]
 
-:context: assets-types-ref
 include::assets-projects-gloss.adoc[leveloffset=+1]
 
 include::assets-packages-gloss.adoc[leveloffset=+1]
@@ -20,5 +20,4 @@ include::assets-DSLs-gloss.adoc[leveloffset=+1]
 
 include::assets-decision-tables-gloss.adoc[leveloffset=+1]
 
-:context: assets-types-ref
 include::assets-data-models-gloss.adoc[leveloffset=+1]

--- a/docs/product-user-guide/src/main/asciidoc/business-central-con.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/business-central-con.adoc
@@ -13,8 +13,6 @@ Business Central integrates the following tools:
 * _Dashboard Builder_, the business activity monitoring (BAM) component, for monitoring and reporting (see <<_chap_red_hat_jboss_dashboard_builder>>)
 * _Business Asset Manager_ for accessing the Knowledge Repository resources, building, and deploying business assets (see xref:_assets_projects_gloss_chap-project[].)
 
-See also xref:_assets_projects_gloss_assets-types-ref[]
-
 endif::BA[]
 
 ifdef::DM[]

--- a/docs/product-user-guide/src/main/asciidoc/business-central-con.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/business-central-con.adoc
@@ -12,6 +12,9 @@ Business Central integrates the following tools:
 * _Process Manager_ for managing process instances (see <<_sect_process_instances>>)
 * _Dashboard Builder_, the business activity monitoring (BAM) component, for monitoring and reporting (see <<_chap_red_hat_jboss_dashboard_builder>>)
 * _Business Asset Manager_ for accessing the Knowledge Repository resources, building, and deploying business assets (see xref:_assets_projects_gloss_chap-project[].)
+
+See also xref:_assets_projects_gloss_assets-types-ref[]
+
 endif::BA[]
 
 ifdef::DM[]

--- a/docs/product-user-guide/src/main/asciidoc/chap-assets.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/chap-assets.adoc
@@ -1,10 +1,10 @@
 [id='_chap_assets']
+:context: chap-assets
 
 include::assets-con.adoc[]
 
 include::assets-types-ref.adoc[leveloffset=+1]
 
-:context: chap-assets
 include::assets-creating-proc.adoc[leveloffset=+1]
 
 include::assets-renaming-proc.adoc[leveloffset=+1]

--- a/docs/product-user-guide/src/main/asciidoc/chap-data-models.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/chap-data-models.adoc
@@ -1,5 +1,6 @@
 
 :context: chap-data-models
+
 include::assets-data-models-gloss.adoc[]
 
 include::data-modeler-con.adoc[leveloffset=+1]

--- a/docs/product-user-guide/src/main/asciidoc/chap-deploying-projects.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/chap-deploying-projects.adoc
@@ -1,16 +1,14 @@
 [id='_chap_deploying_projects']
 = Deploying and Managing Projects
+:context: chap-deploying-and-managing
 
 After you have created a project with your process definition and relevant resources, you must build it and deploy it to the process engine.
 After it is deployed, you can create process instances based on the deployed resources.
 
-:context: chap-deploying-and-managing
 include::project-deploy-proc.adoc[leveloffset=+1]
 
-:context: chap-deploying-and-managing
 include::project-duplicate-GAV-con.adoc[leveloffset=+2]
 
-:context: chap-deploying-and-managing
 include::project-duplicate-GAV-manage-proc.adoc[leveloffset=+3]
 
 

--- a/docs/product-user-guide/src/main/asciidoc/chap-project.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/chap-project.adoc
@@ -1,5 +1,6 @@
 
 :context: chap-project
+
 include::assets-projects-gloss.adoc[]
 ////
 // Commented out for LA, per BXMSDOC-1759
@@ -35,7 +36,6 @@ include::project-REST-create-proc.adoc[leveloffset=+2]
 ////
 include::packages-create-proc.adoc[leveloffset=+1]
 
-:context: chap-project
 include::assets-creating-proc.adoc[leveloffset=+1]
 
 include::dependencies-add-proc.adoc[leveloffset=+1]
@@ -47,13 +47,10 @@ include::kie-bases-project-view-create-proc.adoc[leveloffset=+2]
 
 include::kie-bases-repo-view-create-proc.adoc[leveloffset=+2]
 ////
-:context: chap-project
 include::project-deploy-proc.adoc[leveloffset=+1]
 
-:context: chap-project
 include::project-duplicate-GAV-con.adoc[leveloffset=+2]
 
-:context: chap-project
 include::project-duplicate-GAV-manage-proc.adoc[leveloffset=+3]
 
 


### PR DESCRIPTION
Ready to merge with upstream master.

This is a minor, under-the-hood clean-up effort to rectify the misuse of the :context: variable to date (by me) before others perpetuate it or get confused. Now that I've got the method down, tested, and documented in the contrib guide. See [JIRA](https://issues.jboss.org/browse/BXMSDOC-2041) for details.