### PR TITLE
BXMSDOC-1182 (for upstream 7.5.x): Added note on process instance migration on KIE server in Dev Guide

### DIFF
--- a/docs/product-development-guide/src/main/asciidoc/chap-human-tasks-management.adoc
+++ b/docs/product-development-guide/src/main/asciidoc/chap-human-tasks-management.adoc
@@ -1835,6 +1835,26 @@ public interface ProcessInstanceMigrationService {
 }
 ----
 
+.Process Instance Migration on the KIE Server
+[IMPORTANT]
+====
+To migrate process instances on the KIE Server, use the following implementations. These correspond with the implementations described in the previous code sample.
+
+[source,java]
+----
+public interface ProcessAdminServicesClient {
+
+    MigrationReportInstance migrateProcessInstance(String containerId, Long processInstanceId, String targetContainerId, String targetProcessId);
+
+    MigrationReportInstance migrateProcessInstance(String containerId, Long processInstanceId, String targetContainerId, String targetProcessId, Map<String, String> nodeMapping);
+
+    List<MigrationReportInstance> migrateProcessInstances(String containerId, List<Long> processInstancesId, String targetContainerId, String targetProcessId);
+
+    List<MigrationReportInstance> migrateProcessInstances(String containerId, List<Long> processInstancesId, String targetContainerId, String targetProcessId, Map<String, String> nodeMapping);
+}
+----
+====
+
 You can migrate a single process instance, or multiple process instances at once. If you migrate multiple process instances, each instance will be migrated in a separate transaction to ensure that the migrations do not affect each other. Once migration is done, the `migrate` method returns `MigrationReport`.
 
 [float]


### PR DESCRIPTION
Ready for upstream 7.5.x.

This was a 6.4 update request that applies to 7.0 as well.

Links:
- [JIRA](https://issues.jboss.org/browse/BXMSDOC-1182)
- [Doc preview](http://file.rdu.redhat.com/~sterobin/BXMSDOC-1182/#process_instance_migration) (see note on "Process instance migration on the KIE Server")