### PR TITLE
Avoid duplicate GAVs across repositories

### DIFF
--- a/docs/product-business-resource-planner-guide/pom.xml
+++ b/docs/product-business-resource-planner-guide/pom.xml
@@ -5,12 +5,12 @@
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.optaplanner</groupId>
-    <artifactId>optaplanner</artifactId>
-    <version>8.0.0-SNAPSHOT</version>
+    <groupId>org.kie</groupId>
+    <artifactId>kie-docs-guides</artifactId>
+    <version>7.6.0-SNAPSHOT</version>
   </parent>
 
-  <artifactId>optaplanner-docs</artifactId>
+  <artifactId>product-business-resource-planner-guide</artifactId>
   <packaging>jar</packaging>
 
   <name>OptaPlanner documentation</name>


### PR DESCRIPTION
`org.optaplanner:optaplanner-docs` already exists in the `optaplanner` repository. The module doesn't seem to be built so it doesn't matter much but the change removes an apparent circular dependency between `optaplanner` and `kie-docs` repositories which will make the `repo-dep-tree.pl` script work correctly.