### PR TITLE
BXMSDOC-2169 (for upstream master): Added doc attributes for new DM deliverable name and URL components.

### DIFF
--- a/docs/product-assembly_decision-tables/src/main/asciidoc/main.adoc
+++ b/docs/product-assembly_decision-tables/src/main/asciidoc/main.adoc
@@ -12,8 +12,7 @@ include::product-shared-docs/author-group.adoc[]
 As a business analyst or business rules developer, you can upload decision table spreadsheets to define business rules in a tabular format. These rules are compiled into Drools Rule Language (DRL) and form the core of the decision service for your project.
 
 .Prerequisite
-//@doc-link: Add link to Getting started ref below. Update doc name if needed.
-The team and project for the decision tables have been created in {CENTRAL}. Each asset is associated with a project assigned to a team. For details, see Getting started with decision services.
+The team and project for the decision tables have been created in {CENTRAL}. Each asset is associated with a project assigned to a team. For details, see {URL_GETTING_STARTED_DECISION_SERVICE}[_{GETTING_STARTED_DECISION_SERVICE}_].
 
 // Modules - concepts, procedures, refs, etc.
 include::product-user-guide/rules-authoring-assets-ref.adoc[leveloffset=+1]
@@ -37,9 +36,8 @@ include::product-user-guide/decision-tables-attributes-ref.adoc[leveloffset=+2]
 include::product-user-guide/decision-tables-upload-proc.adoc[leveloffset=+1]
 
 == Next steps
-//@doc-link: Add links to the following docs. Update doc name if needed.
-* Packaging and deploying your decision service
-* Testing decision services
+* {URL_PACKAGING_DEPLOYING_DECISION_SERVICE}[_{PACKAGING_DEPLOYING_DECISION_SERVICE}_]
+* {URL_TESTING_DECISION_SERVICE}[_{TESTING_DECISION_SERVICE}_]
 
 // Versioning info
 include::product-shared-docs/versioning-information.adoc[]

--- a/docs/product-assembly_drl-rules/src/main/asciidoc/main.adoc
+++ b/docs/product-assembly_drl-rules/src/main/asciidoc/main.adoc
@@ -12,8 +12,7 @@ include::product-shared-docs/author-group.adoc[]
 As a business rules developer, you can define business rules using the DRL (Drools Rule Language) designer in {CENTRAL}. DRL rules are defined directly in free-form `.drl` text files instead of in a guided or tabular format like other types of rule assets in {CENTRAL}. These DRL files form the core of the decision service for your project.
 
 .Prerequisite
-//@doc-link: Add link to Getting started ref below. Update doc name if needed.
-The team and project for the DRL rules have been created in {CENTRAL}. Each asset is associated with a project assigned to a team. For details, see Getting started with decision services.
+The team and project for the DRL rules have been created in {CENTRAL}. Each asset is associated with a project assigned to a team. For details, see {URL_GETTING_STARTED_DECISION_SERVICE}[_{GETTING_STARTED_DECISION_SERVICE}_].
 
 // Modules - concepts, procedures, refs, etc.
 include::product-user-guide/rules-authoring-assets-ref.adoc[leveloffset=+1]
@@ -41,9 +40,8 @@ include::product-user-guide/drl-rules-java-create-proc.adoc[leveloffset=+2]
 include::product-user-guide/drl-rules-maven-create-proc.adoc[leveloffset=+2]
 
 == Next steps
-//@doc-link: Add links to the following docs. Update doc name if needed.
-* Packaging and deploying your decision service
-* Testing decision services
+* {URL_PACKAGING_DEPLOYING_DECISION_SERVICE}[_{PACKAGING_DEPLOYING_DECISION_SERVICE}_]
+* {URL_TESTING_DECISION_SERVICE}[_{TESTING_DECISION_SERVICE}_]
 
 // Versioning info
 include::product-shared-docs/versioning-information.adoc[]

--- a/docs/product-assembly_guided-decision-tables/src/main/asciidoc/main.adoc
+++ b/docs/product-assembly_guided-decision-tables/src/main/asciidoc/main.adoc
@@ -12,8 +12,7 @@ include::product-shared-docs/author-group.adoc[]
 As a business analyst or business rules developer, you can use guided decision tables to define business rules in a wizard-led tabular format. These rules are compiled into Drools Rule Language (DRL) and form the core of the decision service for your project.
 
 .Prerequisite
-//@doc-link: Add link to Getting started ref below. Update doc name if needed.
-The team and project for the guided decision tables have been created in {CENTRAL}. Each asset is associated with a project assigned to a team. For details, see Getting started with decision services.
+The team and project for the guided decision tables have been created in {CENTRAL}. Each asset is associated with a project assigned to a team. For details, see {URL_GETTING_STARTED_DECISION_SERVICE}[_{GETTING_STARTED_DECISION_SERVICE}_].
 
 // Modules - concepts, procedures, refs, etc.
 include::product-user-guide/rules-authoring-assets-ref.adoc[leveloffset=+1]
@@ -49,9 +48,8 @@ include::product-user-guide/guided-decision-tables-messages-ref.adoc[leveloffset
 include::product-user-guide/guided-decision-tables-validation-disable-proc.adoc[leveloffset=+2]
 
 == Next steps
-//@doc-link: Add links to the following docs. Update doc name if needed.
-* Packaging and deploying your decision service
-* Testing decision services
+* {URL_PACKAGING_DEPLOYING_DECISION_SERVICE}[_{PACKAGING_DEPLOYING_DECISION_SERVICE}_]
+* {URL_TESTING_DECISION_SERVICE}[_{TESTING_DECISION_SERVICE}_]
 
 // Versioning info
 include::product-shared-docs/versioning-information.adoc[]

--- a/docs/product-assembly_guided-rule-templates/src/main/asciidoc/main.adoc
+++ b/docs/product-assembly_guided-rule-templates/src/main/asciidoc/main.adoc
@@ -12,8 +12,7 @@ include::product-shared-docs/author-group.adoc[]
 As a business analyst or business rules developer, you can define business rule templates using the guided rule templates designer in {CENTRAL}. These guided rule templates provide a reusable rule structure for multiple rules that are compiled into Drools Rule Language (DRL) and form the core of the decision service for your project.
 
 .Prerequisite
-//@doc-link: Add link to Getting started ref below. Update doc name if needed.
-The team and project for the guided rule templates have been created in {CENTRAL}. Each asset is associated with a project assigned to a team. For details, see Getting started with decision services.
+The team and project for the guided rule templates have been created in {CENTRAL}. Each asset is associated with a project assigned to a team. For details, see {URL_GETTING_STARTED_DECISION_SERVICE}[_{GETTING_STARTED_DECISION_SERVICE}_].
 
 // Modules - concepts, procedures, refs, etc.
 include::product-user-guide/rules-authoring-assets-ref.adoc[leveloffset=+1]
@@ -37,9 +36,8 @@ include::product-user-guide/rules-attributes-ref.adoc[leveloffset=+3]
 include::product-user-guide/guided-rule-templates-tables-proc.adoc[leveloffset=+1]
 
 == Next steps
-//@doc-link: Add links to the following docs. Update doc name if needed.
-* Packaging and deploying your decision service
-* Testing decision services
+* {URL_PACKAGING_DEPLOYING_DECISION_SERVICE}[_{PACKAGING_DEPLOYING_DECISION_SERVICE}_]
+* {URL_TESTING_DECISION_SERVICE}[_{TESTING_DECISION_SERVICE}_]
 
 // Versioning info
 include::product-shared-docs/versioning-information.adoc[]

--- a/docs/product-assembly_guided-rules/src/main/asciidoc/main.adoc
+++ b/docs/product-assembly_guided-rules/src/main/asciidoc/main.adoc
@@ -12,8 +12,7 @@ include::product-shared-docs/author-group.adoc[]
 As a business analyst or business rules developer, you can define business rules using the guided rules designer in {CENTRAL}. These guided rules are compiled into Drools Rule Language (DRL) and form the core of the decision service for your project.
 
 .Prerequisite
-//@doc-link: Add link to Getting started ref below. Update doc name if needed.
-The team and project for the guided rules have been created in {CENTRAL}. Each asset is associated with a project assigned to a team. For details, see Getting started with decision services.
+The team and project for the guided rules have been created in {CENTRAL}. Each asset is associated with a project assigned to a team. For details, see {URL_GETTING_STARTED_DECISION_SERVICE}[_{GETTING_STARTED_DECISION_SERVICE}_].
 
 // Modules - concepts, procedures, refs, etc.
 include::product-user-guide/rules-authoring-assets-ref.adoc[leveloffset=+1]
@@ -35,9 +34,8 @@ include::product-user-guide/guided-rules-options-proc.adoc[leveloffset=+2]
 include::product-user-guide/rules-attributes-ref.adoc[leveloffset=+3]
 
 == Next steps
-//@doc-link: Add links to the following docs. Update doc name if needed.
-* Packaging and deploying your decision service
-* Testing decision services
+* {URL_PACKAGING_DEPLOYING_DECISION_SERVICE}[_{PACKAGING_DEPLOYING_DECISION_SERVICE}_]
+* {URL_TESTING_DECISION_SERVICE}[_{TESTING_DECISION_SERVICE}_]
 
 // Versioning info
 include::product-shared-docs/versioning-information.adoc[]

--- a/docs/product-user-guide/src/main/asciidoc/decision-tables-upload-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/decision-tables-upload-proc.adoc
@@ -15,6 +15,5 @@ IMPORTANT: You should typically upload only one decision table spreadsheet, cont
 .Converting a decision table spreadsheet to a guided decision table
 [NOTE]
 ====
-To convert an uploaded decision table spreadsheet to a guided decision table, click *Convert* in the upper-right toolbar in the decision table designer. Converting the spreadsheet to a guided decision table enables you to edit the table data directly in {CENTRAL}. For more information about guided decision tables, see Designing a decision service using guided decision tables.
+To convert an uploaded decision table spreadsheet to a guided decision table, click *Convert* in the upper-right toolbar in the decision table designer. Converting the spreadsheet to a guided decision table enables you to edit the table data directly in {CENTRAL}. For more information about guided decision tables, see {URL_GUIDED_DECISION_TABLES}[_{GUIDED_DECISION_TABLES}_].
 ====
-//@doc-link: Add link to Designing a decision service using guided decision tables ref in note above.

--- a/docs/product-user-guide/src/main/asciidoc/drl-rules-maven-create-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/drl-rules-maven-create-proc.adoc
@@ -185,9 +185,8 @@ This example defines two KIE bases. Two KIE sessions are instantiated from the `
 </project>
 ----
 +
-For the Maven artifact version supported in {PRODUCT}, see Installing {PRODUCT} on premise.
-//@doc-link: Add link to Installing {PRODUCT} on premise ref above.
-
+For the Maven artifact version supported in {PRODUCT}, see {URL_INSTALLING_DM_ON_PREMISE}[_{INSTALLING_DM_ON_PREMISE}_].
++
 . Use the `testApp` method in `my-app/src/test/java/com/sample/app/AppTest.java` to test the rule. The `AppTest.java` file is created by Maven by default.
 +
 . In the `AppTest.java` file, add the required `import` statements to import KIE services, a KIE container, and a KIE session. Then load the knowledge base, insert facts, and execute the rule from the `testApp()` method that passes the fact model to the rule.

--- a/docs/product-user-guide/src/main/asciidoc/rules-authoring-assets-ref.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/rules-authoring-assets-ref.adoc
@@ -10,7 +10,6 @@
 
 The following table highlights each rule-authoring asset in {CENTRAL} to help you decide or confirm the best method for creating rules in your decision service.
 
-//@doc-link: Add links to all docs referenced in the "Documentation" column of table.
 .Rule-authoring assets in {CENTRAL}
 [cols="25%,45%,30%", options="header"]
 |===
@@ -26,7 +25,7 @@ a|
 * Support template keys and values for creating rule templates
 * Support hit policies, real-time validation, and other additional features not supported in other assets
 * Are optimal for creating rules in a controlled tabular format to minimize compilation errors
-|Designing a decision service using guided decision tables
+|{URL_GUIDED_DECISION_TABLES}[_{GUIDED_DECISION_TABLES}_]
 
 
 |Uploaded decision tables
@@ -35,7 +34,7 @@ a|
 * Support template keys and values for creating rule templates
 * Are optimal for creating rules in decision tables already managed outside of {CENTRAL}
 * Have strict syntax requirements for rules to be compiled properly when uploaded
-|Designing a decision service using uploaded decision tables
+|{URL_UPLOADED_DECISION_TABLES}[_{UPLOADED_DECISION_TABLES}_]
 
 
 |Guided rules
@@ -43,7 +42,7 @@ a|
 * Are individual rules that you create in a UI-based rule designer in {CENTRAL}
 * Provide fields and options for acceptable input
 * Are optimal for creating single rules in a controlled format to minimize compilation errors
-|Designing a decision service using guided rules
+|{URL_GUIDED_RULES}[_{GUIDED_RULES}_]
 
 
 |Guided rule templates
@@ -52,7 +51,7 @@ a|
 * Provide fields and options for acceptable input
 * Support template keys and values for creating rule templates (fundamental to the purpose of this asset)
 * Are optimal for creating many rules with the same rule structure but with different defined field values
-|Designing a decision service using guided rule templates
+|{URL_GUIDED_RULE_TEMPLATES}[_{GUIDED_RULE_TEMPLATES}_]
 
 
 |DRL rules
@@ -62,5 +61,5 @@ a|
 * Can be created in certain standalone environments and integrated with {PRODUCT}
 * Are optimal for creating rules that require advanced DRL options
 * Have strict syntax requirements for rules to be compiled properly
-|Designing a decision service using DRL rules
+|{URL_DRL_RULES}[_{DRL_RULES}_]
 |===

--- a/docs/shared-kie-docs/src/main/asciidoc/Product/document-attributes-ba.adoc
+++ b/docs/shared-kie-docs/src/main/asciidoc/Product/document-attributes-ba.adoc
@@ -1,8 +1,11 @@
 :PRODUCT: Red Hat Business Automation
 
-:URL_COMPONENT_PRODUCT: red-hat-jboss-bpm-suite
+:URL_COMPONENT_PRODUCT: red_hat_business_automation
 
 :KIE_SERVER: Process Server
 :A_KIE_SERVER: a Process Server
+:KIE_SERVERS: Process Servers
 
 :CENTRAL: Business Central
+
+:ENGINE: process engine

--- a/docs/shared-kie-docs/src/main/asciidoc/Product/document-attributes-dm.adoc
+++ b/docs/shared-kie-docs/src/main/asciidoc/Product/document-attributes-dm.adoc
@@ -1,9 +1,11 @@
 :PRODUCT: Red Hat Decision Manager
 
-:URL_COMPONENT_PRODUCT: red-hat-jboss-brms
+:URL_COMPONENT_PRODUCT: red_hat_decision_manager
 
 :KIE_SERVER: Decision Server
 :A_KIE_SERVER: a Decision Server
 :KIE_SERVERS: Decision Servers
 
 :CENTRAL: Decision Central
+
+:ENGINE: decision engine

--- a/docs/shared-kie-docs/src/main/asciidoc/Product/document-attributes.adoc
+++ b/docs/shared-kie-docs/src/main/asciidoc/Product/document-attributes.adoc
@@ -36,9 +36,24 @@ endif::BA[]
 :KIE_SERVER_BAS: Process Server
 :KIE_SERVER_DM: Decision Server
 
-// We need to clarify what to do for everything below, given the new 2018 naming, structure, etc.
+// Assembly names (some of these will likely be moved product-specific attrs docs in the future, i.e., document-attributes-dm.adoc and ..-ba.adoc)
+:DM_ON_OPENSHIFT: Deploying {PRODUCT} on Red Hat OpenShift Container Platform
+:DRL_RULES: Designing a decision service using DRL rules
+:GUIDED_DECISION_TABLES: Designing a decision service using guided decision tables
+:GUIDED_RULE_TEMPLATES: Designing a decision service using guided rule templates
+:GUIDED_RULES: Designing a decision service using guided rules
+:UPLOADED_DECISION_TABLES: Designing a decision service using uploaded decision tables
+:GETTING_STARTED_DECISION_SERVICE: Getting started with decision services
+:INSTALLING_PLANNER: Installing and configuring {PLANNER}
+:INSTALLING_DM_ON_PREMISE: Installing {PRODUCT} on premise
+:MIGRATING_BRMS_TO_DM: Migrating from Red Hat BRMS 6.4 to {PRODUCT} {PRODUCT_VERSION}
+:MODIFYING_ROSTER_FOR_PLANNER: Modifying the employee roster sample for {PLANNER}
+:RUNNING_ROSTER_FOR_PLANNER: Running the employee roster sample for {PLANNER}
+:PACKAGING_DEPLOYING_DECISION_SERVICE: Packaging and deploying a decision service
+:RELEASE_NOTES_DM: Release notes for {PRODUCT} {PRODUCT_VERSION}
+:TESTING_DECISION_SERVICE: Testing a decision service
 
-// Book names
+// Legacy book names
 :ADMIN_GUIDE: {PRODUCT} Administration and Configuration Guide
 :PLANNER_GUIDE: {PRODUCT} {PLANNER} Guide
 :DEVELOPMENT_GUIDE: {PRODUCT_BA} Development Guide
@@ -51,14 +66,29 @@ endif::BA[]
 :USER_GUIDE: {PRODUCT} User Guide
 
 // URL components
-
 :URL_COMPONENT_FORMAT: single
-:URL_BASE_ENTERPRISE: https://access.redhat.com/documentation/en-us/{URL_COMPONENT_PRODUCT}/{ENTERPRISE_VERSION}/{URL_COMPONENT_FORMAT}
+:URL_BASE_ENTERPRISE: https://access.qa.redhat.com/documentation/en-us/{URL_COMPONENT_PRODUCT}/{ENTERPRISE_VERSION}/{URL_COMPONENT_FORMAT}
 :URL_BASE_BPMSUITE: https://access.redhat.com/documentation/en-us/red-hat-jboss-bpm-suite/{ENTERPRISE_VERSION}/{URL_COMPONENT_FORMAT}
 :URL_BASE_GITHUB_DM: https://github.com/jboss-container-images/rhdm-7-openshift-image/tree/rhdm70-dev
 
-// URLs (Books for both configs)
+// URLs for assemblies (some of these will likely be moved product-specific attrs docs in the future, i.e., document-attributes-dm.adoc and ..-ba.adoc)
+:URL_DM_ON_OPENSHIFT: {URL_BASE_ENTERPRISE}/deploying_red_hat_decision_manager_on_red_hat_openshift_container_platform
+:URL_DRL_RULES: {URL_BASE_ENTERPRISE}/designing_a_decision_service_using_drl_rules
+:URL_GUIDED_DECISION_TABLES: {URL_BASE_ENTERPRISE}/designing_a_decision_service_using_guided_decision_tables
+:URL_GUIDED_RULE_TEMPLATES: {URL_BASE_ENTERPRISE}/designing_a_decision_service_using_guided_rule_templates
+:URL_GUIDED_RULES: {URL_BASE_ENTERPRISE}/designing_a_decision_service_using_guided_rules
+:URL_UPLOADED_DECISION_TABLES: {URL_BASE_ENTERPRISE}/designing_a_decision_service_using_uploaded_decision_tables
+:URL_GETTING_STARTED_DECISION_SERVICE: {URL_BASE_ENTERPRISE}/getting_started_with_decision_services
+:URL_INSTALLING_PLANNER: {URL_BASE_ENTERPRISE}/installing_and_configuring_business_optimizer
+:URL_INSTALLING_DM_ON_PREMISE: {URL_BASE_ENTERPRISE}/installing_red_hat_decision_manager_on_premise
+:URL_MIGRATING_BRMS_TO_DM: {URL_BASE_ENTERPRISE}/migrating_from_red_hat_jboss_brms_6.4_to_red_hat_decision_manager_7.0
+:URL_MODIFYING_ROSTER_FOR_PLANNER: {URL_BASE_ENTERPRISE}/modifying_the_employee_roster_sample_for_business_optimizer
+:URL_RUNNING_ROSTER_FOR_PLANNER: {URL_BASE_ENTERPRISE}/running_the_employee_roster_sample_for_business_optimizer
+:URL_PACKAGING_DEPLOYING_DECISION_SERVICE: {URL_BASE_ENTERPRISE}/packaging_and_deploying_a_decision_service
+:URL_RELEASE_NOTES_DM: {URL_BASE_ENTERPRISE}/release_notes_for_red_hat_decision_manager_7.0
+:URL_TESTING_DECISION_SERVICE: {URL_BASE_ENTERPRISE}/Testing_a_decision_service
 
+// URLs for legacy books (NOT functional anymore, due to changed URL_COMPONENT_PRODUCT, but retained for reference)
 :URL_ADMIN_GUIDE: {URL_BASE_ENTERPRISE}/administration-and-configuration-guide
 :URL_GETTING_STARTED_GUIDE: {URL_BASE_ENTERPRISE}/getting-started-guide
 :URL_IBM_GUIDE: {URL_BASE_ENTERPRISE}/ibm-websphere-installation-and-configuration-guide
@@ -68,8 +98,7 @@ endif::BA[]
 :URL_USER_GUIDE: {URL_BASE_ENTERPRISE}/user-guide
 :URL_PLANNER_GUIDE: {URL_BASE_ENTERPRISE}/business_resource_planner_guide
 
-// URLs (BPM Suite books-only books)
-
+// URLs for BPM Suite books only
 :URL_DEVELOPMENT_GUIDE: {URL_BASE_BPMSUITE}/development-guide
 :URL_MIGRATION_GUIDE: {URL_BASE_BPMSUITE}/migration-guide
 :ndash: &ndash;


### PR DESCRIPTION
Ready for upstream master.

See [JIRA](https://issues.jboss.org/browse/BXMSDOC-2169) for details.