### PR TITLE
BXMSDOC-2210 (for upstream master): Removed links to 'Testing a decision service' in all 'Designing' assemblies.

### DIFF
--- a/docs/product-assembly_decision-tables/src/main/asciidoc/main.adoc
+++ b/docs/product-assembly_decision-tables/src/main/asciidoc/main.adoc
@@ -36,8 +36,9 @@ include::product-user-guide/decision-tables-attributes-ref.adoc[leveloffset=+2]
 include::product-user-guide/decision-tables-upload-proc.adoc[leveloffset=+1]
 
 == Next steps
-* {URL_PACKAGING_DEPLOYING_DECISION_SERVICE}[_{PACKAGING_DEPLOYING_DECISION_SERVICE}_]
-* {URL_TESTING_DECISION_SERVICE}[_{TESTING_DECISION_SERVICE}_]
+{URL_PACKAGING_DEPLOYING_DECISION_SERVICE}[_{PACKAGING_DEPLOYING_DECISION_SERVICE}_]
+//* {URL_TESTING_DECISION_SERVICE}[_{TESTING_DECISION_SERVICE}_]
+//Once the second and more links are available, make this a bulleted list.
 
 // Versioning info
 include::product-shared-docs/versioning-information.adoc[]

--- a/docs/product-assembly_drl-rules/src/main/asciidoc/main.adoc
+++ b/docs/product-assembly_drl-rules/src/main/asciidoc/main.adoc
@@ -40,8 +40,9 @@ include::product-user-guide/drl-rules-java-create-proc.adoc[leveloffset=+2]
 include::product-user-guide/drl-rules-maven-create-proc.adoc[leveloffset=+2]
 
 == Next steps
-* {URL_PACKAGING_DEPLOYING_DECISION_SERVICE}[_{PACKAGING_DEPLOYING_DECISION_SERVICE}_]
-* {URL_TESTING_DECISION_SERVICE}[_{TESTING_DECISION_SERVICE}_]
+{URL_PACKAGING_DEPLOYING_DECISION_SERVICE}[_{PACKAGING_DEPLOYING_DECISION_SERVICE}_]
+//* {URL_TESTING_DECISION_SERVICE}[_{TESTING_DECISION_SERVICE}_]
+//Once the second and more links are available, make this a bulleted list.
 
 // Versioning info
 include::product-shared-docs/versioning-information.adoc[]

--- a/docs/product-assembly_guided-decision-tables/src/main/asciidoc/main.adoc
+++ b/docs/product-assembly_guided-decision-tables/src/main/asciidoc/main.adoc
@@ -48,8 +48,9 @@ include::product-user-guide/guided-decision-tables-messages-ref.adoc[leveloffset
 include::product-user-guide/guided-decision-tables-validation-disable-proc.adoc[leveloffset=+2]
 
 == Next steps
-* {URL_PACKAGING_DEPLOYING_DECISION_SERVICE}[_{PACKAGING_DEPLOYING_DECISION_SERVICE}_]
-* {URL_TESTING_DECISION_SERVICE}[_{TESTING_DECISION_SERVICE}_]
+{URL_PACKAGING_DEPLOYING_DECISION_SERVICE}[_{PACKAGING_DEPLOYING_DECISION_SERVICE}_]
+//* {URL_TESTING_DECISION_SERVICE}[_{TESTING_DECISION_SERVICE}_]
+//Once the second and more links are available, make this a bulleted list.
 
 // Versioning info
 include::product-shared-docs/versioning-information.adoc[]

--- a/docs/product-assembly_guided-rule-templates/src/main/asciidoc/main.adoc
+++ b/docs/product-assembly_guided-rule-templates/src/main/asciidoc/main.adoc
@@ -36,8 +36,9 @@ include::product-user-guide/rules-attributes-ref.adoc[leveloffset=+3]
 include::product-user-guide/guided-rule-templates-tables-proc.adoc[leveloffset=+1]
 
 == Next steps
-* {URL_PACKAGING_DEPLOYING_DECISION_SERVICE}[_{PACKAGING_DEPLOYING_DECISION_SERVICE}_]
-* {URL_TESTING_DECISION_SERVICE}[_{TESTING_DECISION_SERVICE}_]
+{URL_PACKAGING_DEPLOYING_DECISION_SERVICE}[_{PACKAGING_DEPLOYING_DECISION_SERVICE}_]
+//* {URL_TESTING_DECISION_SERVICE}[_{TESTING_DECISION_SERVICE}_]
+//Once the second and more links are available, make this a bulleted list.
 
 // Versioning info
 include::product-shared-docs/versioning-information.adoc[]

--- a/docs/product-assembly_guided-rules/src/main/asciidoc/main.adoc
+++ b/docs/product-assembly_guided-rules/src/main/asciidoc/main.adoc
@@ -34,8 +34,9 @@ include::product-user-guide/guided-rules-options-proc.adoc[leveloffset=+2]
 include::product-user-guide/rules-attributes-ref.adoc[leveloffset=+3]
 
 == Next steps
-* {URL_PACKAGING_DEPLOYING_DECISION_SERVICE}[_{PACKAGING_DEPLOYING_DECISION_SERVICE}_]
-* {URL_TESTING_DECISION_SERVICE}[_{TESTING_DECISION_SERVICE}_]
+{URL_PACKAGING_DEPLOYING_DECISION_SERVICE}[_{PACKAGING_DEPLOYING_DECISION_SERVICE}_]
+//* {URL_TESTING_DECISION_SERVICE}[_{TESTING_DECISION_SERVICE}_]
+//Once the second and more links are available, make this a bulleted list.
 
 // Versioning info
 include::product-shared-docs/versioning-information.adoc[]


### PR DESCRIPTION
Ready for upstream master.

See [JIRA](https://issues.jboss.org/browse/BXMSDOC-2210) for details.