### PR TITLE
Remove no longer effective system properties

### DIFF
--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/appe-properties.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/appe-properties.adoc
@@ -1027,7 +1027,7 @@ endif::BA[]
 *org.kie.demo*::
 +
 --
-Enables external cloning of a demo application from GitHub. This System Property takes precedence over `org.kie.example`.
+Enables external cloning of a demo application from GitHub.
 
 [cols="1,1", options="header"]
 |===
@@ -1036,38 +1036,6 @@ Enables external cloning of a demo application from GitHub. This System Property
 
 | `true` or `false`
 | `true`
-|===
---
-
-*org.kie.example*::
-+
---
-When set to `true`, creates an example organization unit and repository. This system property allows you to create projects and assets without creating your custom organization unit and repository. It is useful, for example, to simplify the getting started experience.
-
-[cols="1,1", options="header"]
-|===
-| Values
-| Default
-
-| `true` or `false`
-| `false`
-|===
---
-
-*org.kie.example.repositories*::
-+
---
-Sets the path to the directory containing example repositories. If you set this system property, repositories in the specified directory are automatically cloned into Business Central during startup. This property overrides `org.kie.example` and `org.kie.demo`.
-
-WARNING: You must download the example repositories from the https://access.redhat.com/jbossnetwork/restricted/softwareDetail.html?softwareId=48391&product=bpm.suite&version=6.4&downloadType=distributions[Customer Portal] and extract them to this directory before setting this system property.
-
-[cols="1,1", options="header"]
-|===
-| Values
-| Default
-
-| Path
-| N/A
 |===
 --
 
@@ -1634,81 +1602,6 @@ The location of the Quartz configuration file to activate the Quartz timer servi
 |===
 --
 endif::BA[]
-
-*org.uberfire.cluster.autostart*::
-+
---
-Delays VFS clustering until the application is fully initialized to avoid conflicts when all cluster members create local clones.
-
-[cols="1,1", options="header"]
-|===
-| Values
-| Default
-
-| `true` or `false`
-| `false`
-|===
---
-
-*org.uberfire.cluster.id*::
-+
---
-The name of the Helix cluster, for example: `kie-cluster`. You must set this property to the same value as defined in the Helix Controller.
-
-[cols="1,1", options="header"]
-|===
-| Values
-| Default
-
-| String
-| N/A
-|===
---
-
-*org.uberfire.cluster.local.id*::
-+
---
-The unique ID of the Helix cluster node. Note that ':' is replaced with '_', for example `node1_12345`.
-
-[cols="1,1", options="header"]
-|===
-| Values
-| Default
-
-| String
-| N/A
-|===
---
-
-*org.uberfire.cluster.vfs.lock*::
-+
---
-The name of the resource defined on the Helix cluster, for example: `kie-vfs`.
-
-[cols="1,1", options="header"]
-|===
-| Values
-| Default
-
-| String
-| N/A
-|===
---
-
-*org.uberfire.cluster.zk*::
-+
---
-The location of the Zookeeper servers.
-
-[cols="1,1", options="header"]
-|===
-| Values
-| Default
-
-| String of the form ``host1:port1``,``host2:port2``,``host3:port3``,...
-| N/A
-|===
---
 
 *org.uberfire.domain*::
 +

--- a/docs/product-installation-guide/src/main/asciidoc/install-standalone-properties-con.adoc
+++ b/docs/product-installation-guide/src/main/asciidoc/install-standalone-properties-con.adoc
@@ -17,11 +17,6 @@
 If you plan to use RSA or any algorithm other than DSA, make sure you setup properly your Application Server to use Bouncy Castle JCE library.
 ====
 * `org.uberfire.metadata.index.dir`: Place where Lucene .index folder will be stored. Default: working directory
-* `org.uberfire.cluster.id`: Name of the helix cluster, for example: kie-cluster
-* `org.uberfire.cluster.zk`: Connection string to zookeeper. This is of the form host1:port1,host2:port2,host3:port3, for example: localhost:2188
-* `org.uberfire.cluster.local.id`: Unique id of the helix cluster node, note that ‘`:`’ is replaced with ‘`\_`’, for example: node1_12345
-* `org.uberfire.cluster.vfs.lock`: Name of the resource defined on helix cluster, for example: kie-vfs
-* `org.uberfire.cluster.autostart`: Delays VFS clustering until the application is fully initialized to avoid conflicts when all cluster members create local clones. Default: false
 * `org.uberfire.ldap.regex.role_mapper`: Regex pattern used to map LDAP principal names to application role name. Note that the variable role must be part of the pattern as it is substited by the application role name when matching a principal value to role name. Default: Not used.
 * `org.uberfire.sys.repo.monitor.disabled`: Disable configuration monitor (do not disable unless you know what you’re doing). Default: false
 * `org.uberfire.secure.key`: Secret password used by password encryption. Default`: org.uberfire.admin
@@ -29,9 +24,7 @@ If you plan to use RSA or any algorithm other than DSA, make sure you setup prop
 * `org.uberfire.domain`: security-domain name used by uberfire. Default: ApplicationRealm
 * `org.guvnor.m2repo.dir`: Place where Maven repository folder will be stored. Default: working-directory/repositories/kie
 * `org.guvnor.project.gav.check.disabled`: Disable GAV checks. Default: false
-* `org.kie.example.repositories`: Folder from where demo repositories will be cloned. The demo repositories need to have been obtained and placed in this folder. Demo repositories can be obtained from the kie-wb-6.2.0-SNAPSHOT-example-repositories.zip artifact. This System Property takes precedence over org.kie.demo and org.kie.example. Default: Not used.
-* `org.kie.demo`: Enables external clone of a demo application from GitHub. This System Property takes precedence over org.kie.example. Default: true
-* `org.kie.example`: Enables example structure composed by Repository, Organization Unit and Project. Default: false
+* `org.kie.demo`: Enables external clone of a demo application from GitHub.
 * `org.kie.build.disable-project-explorer`: Disable automatic build of selected Project in Project Explorer. Default: false
 * `org.kie.verification.disable-dtable-realtime-verification`: Disables the realtime validation and verification of decision tables. Default: false
 * `org.kie.workbench.controller`: URL for connecting with a Kie Server Controller, for example: `ws://localhost:8080/kie-server-controller/websocket/controller`.

--- a/docs/shared-kie-docs/src/main/asciidoc/Workbench/Installation/Installation-section.adoc
+++ b/docs/shared-kie-docs/src/main/asciidoc/Workbench/Installation/Installation-section.adoc
@@ -56,11 +56,6 @@ Here's a list of all system properties:
 If you plan to use RSA or any algorithm other than DSA, make sure you setup properly your Application Server to use Bouncy Castle JCE library.
 ====
 * **``org.uberfire.metadata.index.dir``**: Place where Lucene `$$.$$index` folder will be stored. Default: working directory
-* **``org.uberfire.cluster.id``**: Name of the helix cluster, for example: `kie-cluster`
-* **``org.uberfire.cluster.zk``**: Connection string to zookeeper. This is of the form ``host1:port1,host2:port2,host3:port3``, for example: `localhost:2188`
-* **``org.uberfire.cluster.local.id``**: Unique id of the helix cluster node, note that '``:``' is replaced with '``\_``', for example: `node1_12345`
-* **``org.uberfire.cluster.vfs.lock``**: Name of the resource defined on helix cluster, for example: `kie-vfs`
-* **``org.uberfire.cluster.autostart``**: Delays VFS clustering until the application is fully initialized to avoid conflicts when all cluster members create local clones. Default: `false`
 * **``org.uberfire.ldap.regex.role_mapper``**: Regex pattern used to map LDAP principal names to application role name.  Note that the variable `role` must be part of the pattern as it is substited by the application role name when matching a principal value to role name. Default: Not used.
 * **``org.uberfire.sys.repo.monitor.disabled``**: Disable configuration monitor (do not disable unless you know what you're doing). Default: `false`
 * **``org.uberfire.secure.key``**: Secret password used by password encryption. Default: `org.uberfire.admin`
@@ -68,9 +63,7 @@ If you plan to use RSA or any algorithm other than DSA, make sure you setup prop
 * **``org.uberfire.domain``**: security-domain name used by uberfire. Default: `ApplicationRealm`
 * **``org.guvnor.m2repo.dir``**: Place where Maven repository folder will be stored. Default: working-directory/repositories/kie
 * **``org.guvnor.project.gav.check.disabled``**: Disable GAV checks. Default: `false`
-* **``org.kie.example.repositories``**: Folder from where demo repositories will be cloned. The demo repositories need to have been obtained and placed in this folder. Demo repositories can be obtained from the kie-wb-6.2.0-SNAPSHOT-example-repositories.zip artifact. This System Property takes precedence over org.kie.demo and org.kie.example. Default: Not used.
-* **``org.kie.demo``**: Enables external clone of a demo application from GitHub. This System Property takes precedence over org.kie.example. Default: `true`
-* **``org.kie.example``**: Enables example structure composed by Repository, Organization Unit and Project. Default: `false`
+* **``org.kie.demo``**: Enables external clone of a demo application from GitHub.
 * **``org.kie.build.disable-project-explorer``**: Disable automatic build of selected Project in Project Explorer. Default: `false`
 * **``org.kie.verification.disable-dtable-realtime-verification``**: Disables the realtime validation and verification of decision tables. Default: `false`
 * **``org.kie.workbench.controller``**: URL for connecting with a Kie Server Controller, for example: `ws://localhost:8080/kie-server-controller/websocket/controller`.


### PR DESCRIPTION
Removing system properties which no loger work from workbench installation docs.
I grepped through the whole kiegroup code base and removed those which are no longer present anywhere.

@ederign could you please check if it's ok to remove all properties related to clustering? I didn't find any occurrence of those in our code base.

@Rikkola I also removed some properties related to importing examples. I suspect that "org.kie.demo" is also useless now, but there are many occurrences throughout our code base, so leaving that in..