### PR TITLE
BXMSDOC-2037 Promote best practice configuration in managed mode

### DIFF
--- a/docs/product-installation-guide/src/main/asciidoc/eap-execution-server-configure-proc.adoc
+++ b/docs/product-installation-guide/src/main/asciidoc/eap-execution-server-configure-proc.adoc
@@ -1,35 +1,46 @@
 [id='eap_execution_server_configure_proc']
 = Configuring {KIE_SERVER} 
 
-If {KIE_SERVER} will be managed by {CENTRAL}, you must edit the `standalone.xml` file as described in this section.
+If {KIE_SERVER} will be managed by {CENTRAL}, you must edit the `standalone.xml` file in both the {KIE_SERVER} and {CENTRAL} installations, as described in this section.
 
 [NOTE]
 ====
-Only make these changes if {KIE_SERVER} will be managed by {CENTRAL}.
+Only make these changes if {KIE_SERVER} will be managed by {CENTRAL}. 
 ====
 
-Prerequisites
+.Prerequisites
 {PRODUCT} installed in an  `__EAP_HOME__` as described in one of the following sections:
 
 * <<installer-run-proc>>
 * <<installer-run-cli-proc>>
 * <<assembly_installing-on-eap-deployable>>
++
+[NOTE]
+====
+Red Hat recommends that you install {KIE_SERVER} and {CENTRAL} on different servers in production environments. However, if you install {KIE_SERVER} and {CENTRAL} on the same server, for example in a development environment, make these changes in the shared `standalone.xml` file. 
+====
 
 .Procedure
-. Make the following changes to the `__EAP_HOME__/standalone/configuration/standalone.xml` file:
-** Uncomment the following properties in the `<system-properties>` section:
+. In the {CENTRAL}  `__EAP_HOME__/standalone/configuration/standalone.xml` file, uncomment the following properties in the `<system-properties>` section and replace `<USERNAME>` and `<USER_PWD>` with the credentials of a user with the `admin` role:
 +
 [source,xml]
 ----
-   <property name="org.kie.server.location" value="http://localhost:8080/kie-execution-server/services/rest/server"/>
-   <property name="org.kie.server.controller" value="http://localhost:8080/business-central/rest/controller"/>
-   <property name="org.kie.server.controller.user" value="controllerUser"/>
-   <property name="org.kie.server.controller.pwd" value="controllerUser1234;"/>
-   <property name="org.kie.server.user" value="controllerUser"/>
-   <property name="org.kie.server.pwd" value="controllerUser1234;"/>
-   <property name="org.kie.server.id" value="default-kieserver"/>
+   <property name="org.kie.server.user" value="<USERNAME>"/>
+   <property name="org.kie.server.pwd" value="<USER_PWD>;"/>
 ----
-
+. In the {KIE_SERVER}  `__EAP_HOME__/standalone/configuration/standalone.xml` file, uncomment the following properties in the `<system-properties>` section.  
++
+[source,xml]
+----
+  <property name="org.kie.server.controller.user" value="<CONTROLLER_USER>"/>
+  <property name="org.kie.server.controller.pwd" value="<CONTROLLER_PWD;"/>
+  <property name="org.kie.server.id" value="<KIE_SERVER_ID>"/>
+  <property name="org.kie.server.location" value="http://localhost:8280/kie-server/services/rest/server"/>
+  <property name="org.kie.server.controller" value="http://localhost:8080/decision-central/rest/controller"/>
+----
+. In this file, replace the following values:
+* Replace `<CONTROLLER_USER>` and `<CONTROLLER_PWD>` with the credentials of a user with the `admin` role.
+* Replace `<KIE_SERVER_ID>` with the ID or name of the {KIE_SERVER} installation, for example, `rhdm700-decision-server-1`.
 . Uncomment the line with `controllerUser` in the following files:
 ** `__EAP_HOME__/standalone/configuration/application-users.properties`
 ** `__EAP_HOME__/standalone/configuration/application-roles.properties`


### PR DESCRIPTION
Updated Configuring Decision Server.
The rendered doc is [here](http://file.ork.redhat.com/~emmurphy/BXMSDOC-2237/#eap_execution_server_configure_proc).