### PR TITLE
BXMSDOC-2267 (for upstream 7.5.x): Uncommented cross-refs to test scenarios doc and updated test scenarios doc attribute and its URL attribute

### DIFF
--- a/docs/product-assembly_decision-tables/src/main/asciidoc/main.adoc
+++ b/docs/product-assembly_decision-tables/src/main/asciidoc/main.adoc
@@ -36,9 +36,8 @@ include::product-user-guide/decision-tables-attributes-ref.adoc[leveloffset=+2]
 include::product-user-guide/decision-tables-upload-proc.adoc[leveloffset=+1]
 
 == Next steps
-{URL_PACKAGING_DEPLOYING_DECISION_SERVICE}[_{PACKAGING_DEPLOYING_DECISION_SERVICE}_]
-//* {URL_TESTING_DECISION_SERVICE}[_{TESTING_DECISION_SERVICE}_]
-//Once the second and more links are available, make this a bulleted list.
+* {URL_TESTING_DECISION_SERVICE}[_{TESTING_DECISION_SERVICE}_]
+* {URL_PACKAGING_DEPLOYING_DECISION_SERVICE}[_{PACKAGING_DEPLOYING_DECISION_SERVICE}_]
 
 // Versioning info
 include::product-shared-docs/versioning-information.adoc[]

--- a/docs/product-assembly_drl-rules/src/main/asciidoc/main.adoc
+++ b/docs/product-assembly_drl-rules/src/main/asciidoc/main.adoc
@@ -40,9 +40,8 @@ include::product-user-guide/drl-rules-java-create-proc.adoc[leveloffset=+2]
 include::product-user-guide/drl-rules-maven-create-proc.adoc[leveloffset=+2]
 
 == Next steps
-{URL_PACKAGING_DEPLOYING_DECISION_SERVICE}[_{PACKAGING_DEPLOYING_DECISION_SERVICE}_]
-//* {URL_TESTING_DECISION_SERVICE}[_{TESTING_DECISION_SERVICE}_]
-//Once the second and more links are available, make this a bulleted list.
+* {URL_TESTING_DECISION_SERVICE}[_{TESTING_DECISION_SERVICE}_]
+* {URL_PACKAGING_DEPLOYING_DECISION_SERVICE}[_{PACKAGING_DEPLOYING_DECISION_SERVICE}_]
 
 // Versioning info
 include::product-shared-docs/versioning-information.adoc[]

--- a/docs/product-assembly_guided-decision-tables/src/main/asciidoc/main.adoc
+++ b/docs/product-assembly_guided-decision-tables/src/main/asciidoc/main.adoc
@@ -48,9 +48,8 @@ include::product-user-guide/guided-decision-tables-messages-ref.adoc[leveloffset
 include::product-user-guide/guided-decision-tables-validation-disable-proc.adoc[leveloffset=+2]
 
 == Next steps
-{URL_PACKAGING_DEPLOYING_DECISION_SERVICE}[_{PACKAGING_DEPLOYING_DECISION_SERVICE}_]
-//* {URL_TESTING_DECISION_SERVICE}[_{TESTING_DECISION_SERVICE}_]
-//Once the second and more links are available, make this a bulleted list.
+* {URL_TESTING_DECISION_SERVICE}[_{TESTING_DECISION_SERVICE}_]
+* {URL_PACKAGING_DEPLOYING_DECISION_SERVICE}[_{PACKAGING_DEPLOYING_DECISION_SERVICE}_]
 
 // Versioning info
 include::product-shared-docs/versioning-information.adoc[]

--- a/docs/product-assembly_guided-rule-templates/src/main/asciidoc/main.adoc
+++ b/docs/product-assembly_guided-rule-templates/src/main/asciidoc/main.adoc
@@ -36,9 +36,8 @@ include::product-user-guide/rules-attributes-ref.adoc[leveloffset=+3]
 include::product-user-guide/guided-rule-templates-tables-proc.adoc[leveloffset=+1]
 
 == Next steps
-{URL_PACKAGING_DEPLOYING_DECISION_SERVICE}[_{PACKAGING_DEPLOYING_DECISION_SERVICE}_]
-//* {URL_TESTING_DECISION_SERVICE}[_{TESTING_DECISION_SERVICE}_]
-//Once the second and more links are available, make this a bulleted list.
+* {URL_TESTING_DECISION_SERVICE}[_{TESTING_DECISION_SERVICE}_]
+* {URL_PACKAGING_DEPLOYING_DECISION_SERVICE}[_{PACKAGING_DEPLOYING_DECISION_SERVICE}_]
 
 // Versioning info
 include::product-shared-docs/versioning-information.adoc[]

--- a/docs/product-assembly_guided-rules/src/main/asciidoc/main.adoc
+++ b/docs/product-assembly_guided-rules/src/main/asciidoc/main.adoc
@@ -34,9 +34,8 @@ include::product-user-guide/guided-rules-options-proc.adoc[leveloffset=+2]
 include::product-user-guide/rules-attributes-ref.adoc[leveloffset=+3]
 
 == Next steps
-{URL_PACKAGING_DEPLOYING_DECISION_SERVICE}[_{PACKAGING_DEPLOYING_DECISION_SERVICE}_]
-//* {URL_TESTING_DECISION_SERVICE}[_{TESTING_DECISION_SERVICE}_]
-//Once the second and more links are available, make this a bulleted list.
+* {URL_TESTING_DECISION_SERVICE}[_{TESTING_DECISION_SERVICE}_]
+* {URL_PACKAGING_DEPLOYING_DECISION_SERVICE}[_{PACKAGING_DEPLOYING_DECISION_SERVICE}_]
 
 // Versioning info
 include::product-shared-docs/versioning-information.adoc[]

--- a/docs/shared-kie-docs/src/main/asciidoc/Product/document-attributes.adoc
+++ b/docs/shared-kie-docs/src/main/asciidoc/Product/document-attributes.adoc
@@ -51,7 +51,7 @@ endif::BA[]
 :RUNNING_ROSTER_FOR_PLANNER: Running the employee roster sample for {PLANNER}
 :PACKAGING_DEPLOYING_DECISION_SERVICE: Packaging and deploying a decision service
 :RELEASE_NOTES_DM: Release notes for {PRODUCT} {PRODUCT_VERSION}
-:TESTING_DECISION_SERVICE: Testing a decision service
+:TESTING_DECISION_SERVICE: Testing a decision service using test scenarios
 
 // Legacy book names
 :ADMIN_GUIDE: {PRODUCT} Administration and Configuration Guide
@@ -86,7 +86,7 @@ endif::BA[]
 :URL_RUNNING_ROSTER_FOR_PLANNER: {URL_BASE_ENTERPRISE}/running_the_employee_roster_sample_for_business_optimizer
 :URL_PACKAGING_DEPLOYING_DECISION_SERVICE: {URL_BASE_ENTERPRISE}/packaging_and_deploying_a_decision_service
 :URL_RELEASE_NOTES_DM: {URL_BASE_ENTERPRISE}/release_notes_for_red_hat_decision_manager_7.0
-:URL_TESTING_DECISION_SERVICE: {URL_BASE_ENTERPRISE}/Testing_a_decision_service
+:URL_TESTING_DECISION_SERVICE: {URL_BASE_ENTERPRISE}/testing_a_decision_service_using_test_scenarios
 
 // URLs for legacy books (NOT functional anymore, due to changed URL_COMPONENT_PRODUCT, but retained for reference)
 :URL_ADMIN_GUIDE: {URL_BASE_ENTERPRISE}/administration-and-configuration-guide


### PR DESCRIPTION
Ready for upstream 7.5.x. See [JIRA](https://issues.jboss.org/browse/BXMSDOC-2267) for details.