### PR TITLE
BXMSDOC-2246 (for upstream 7.5.x): Update REBUILT variable and new doc attributes for Mar 2 2018 patch publish

### DIFF
--- a/docs/shared-kie-docs/src/main/asciidoc/Product/document-attributes.adoc
+++ b/docs/shared-kie-docs/src/main/asciidoc/Product/document-attributes.adoc
@@ -1,5 +1,5 @@
 
-:REBUILT: Thu Feb 15, 2018
+:REBUILT: Fri Mar 2, 2018
 
 // Book Conditionals
 :ENTERPRISE_ONLY:
@@ -46,6 +46,8 @@ endif::BA[]
 :GETTING_STARTED_DECISION_SERVICE: Getting started with decision services
 :INSTALLING_PLANNER: Installing and configuring {PLANNER}
 :INSTALLING_DM_ON_PREMISE: Installing {PRODUCT} on premise
+:INSTALLING_DS_ON_WAS: Installing and configuring {KIE_SERVER} on IBM WebSphere Application Server
+:INSTALLING_DS_ON_WLS: Installing and configuring {KIE_SERVER} on Oracle WebLogic Server
 :MIGRATING_BRMS_TO_DM: Migrating from Red Hat BRMS 6.4 to {PRODUCT} {PRODUCT_VERSION}
 :MODIFYING_ROSTER_FOR_PLANNER: Modifying the employee roster sample for {PLANNER}
 :RUNNING_ROSTER_FOR_PLANNER: Running the employee roster sample for {PLANNER}
@@ -81,12 +83,16 @@ endif::BA[]
 :URL_GETTING_STARTED_DECISION_SERVICE: {URL_BASE_ENTERPRISE}/getting_started_with_decision_services
 :URL_INSTALLING_PLANNER: {URL_BASE_ENTERPRISE}/installing_and_configuring_business_optimizer
 :URL_INSTALLING_DM_ON_PREMISE: {URL_BASE_ENTERPRISE}/installing_red_hat_decision_manager_on_premise
+:URL_INSTALLING_DS_ON_WAS: {URL_BASE_ENTERPRISE}/installing_and_configuring_decision_server_on_ibm_websphere_application_server
+:URL_INSTALLING_DS_ON_WLS: {URL_BASE_ENTERPRISE}/installing_and_configuring_decision_server_on_oracle_weblogic_server
 :URL_MIGRATING_BRMS_TO_DM: {URL_BASE_ENTERPRISE}/migrating_from_red_hat_jboss_brms_6.4_to_red_hat_decision_manager_7.0
 :URL_MODIFYING_ROSTER_FOR_PLANNER: {URL_BASE_ENTERPRISE}/modifying_the_employee_roster_sample_for_business_optimizer
 :URL_RUNNING_ROSTER_FOR_PLANNER: {URL_BASE_ENTERPRISE}/running_the_employee_roster_sample_for_business_optimizer
 :URL_PACKAGING_DEPLOYING_DECISION_SERVICE: {URL_BASE_ENTERPRISE}/packaging_and_deploying_a_decision_service
 :URL_RELEASE_NOTES_DM: {URL_BASE_ENTERPRISE}/release_notes_for_red_hat_decision_manager_7.0
 :URL_TESTING_DECISION_SERVICE: {URL_BASE_ENTERPRISE}/testing_a_decision_service_using_test_scenarios
+
+
 
 // URLs for legacy books (NOT functional anymore, due to changed URL_COMPONENT_PRODUCT, but retained for reference)
 :URL_ADMIN_GUIDE: {URL_BASE_ENTERPRISE}/administration-and-configuration-guide


### PR DESCRIPTION
Ready for upstream 7.5.x.

Links:
- [JIRA](https://issues.jboss.org/browse/BXMSDOC-2246) 
- [Contrib Guide](http://ccs-jenkins.gsslab.brq.redhat.com:8080/view/Topic%20branches/job/doc-Red_Hat_JBoss_BxMS_Contribution_Guide-branch-shared-repo/lastSuccessfulBuild/artifact/index.html#_publishing_ba_dm_guides_using_pantheon) steps taken.