### PR TITLE
[6.5.x] fixed URL to docbook DTD

### DIFF
--- a/dashbuilder-docs/src/main/docbook/en-US/master.xml
+++ b/dashbuilder-docs/src/main/docbook/en-US/master.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE book SYSTEM "http://docbook.org/xml/5.0/dtd/docbook.dtd" [
+<!DOCTYPE book SYSTEM "https://docbook.org/xml/5.0/dtd/docbook.dtd" [
     <!ENTITY project.version "undefined">
     ]>
 <book version="5.0"

--- a/drools-docs/src/main/docbook/en-US/master.xml
+++ b/drools-docs/src/main/docbook/en-US/master.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE book SYSTEM "http://docbook.org/xml/5.0/dtd/docbook.dtd" [
+<!DOCTYPE book SYSTEM "https://docbook.org/xml/5.0/dtd/docbook.dtd" [
     <!ENTITY project.version "undefined">
 ]>
 <book version="5.0"

--- a/jbpm-docs/src/main/docbook/en-US/master.xml
+++ b/jbpm-docs/src/main/docbook/en-US/master.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE book SYSTEM "http://docbook.org/xml/5.0/dtd/docbook.dtd" [
+<!DOCTYPE book SYSTEM "https://docbook.org/xml/5.0/dtd/docbook.dtd" [
     <!ENTITY project.version "undefined">
 ]>
 <book version="5.0"


### PR DESCRIPTION
fixing issue with build error https://kie-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/6.5.x/job/kie-docs-6.5.x/107/consoleText

```
[ERROR] Failed to execute goal org.jboss.maven.plugins:maven-jdocbook-plugin:2.3.9:generate (default-generate) on project jbpm-docs: XSLT problem: error performing translation [null] : org.xml.sax.SAXParseException; systemId: http://docbook.org/xml/5.0/dtd/docbook.dtd; lineNumber: 1; columnNumber: 1; The markup declarations contained or pointed to by the document type declaration must be well-formed. -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.jboss.maven.plugins:maven-jdocbook-plugin:2.3.9:generate (default-generate) on project jbpm-docs: XSLT problem
```