### PR TITLE
BXMSDOC-2732 (for upstream 7.5.x): Removed subtitle text from all docs in 7.5.x branch (for DM 7.0)

### DIFF
--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/ba/master-docinfo.xml
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/ba/master-docinfo.xml
@@ -1,8 +1,6 @@
 <productname>{PRODUCT}</productname>
 <productnumber>{PRODUCT_VERSION}</productnumber>
 <subtitle>
-	For {PRODUCT} {PRODUCT_VERSION}
-	 
 </subtitle>
 <abstract>
 	<para>A guide for administrators and advanced users dealing with {PRODUCT} setup, configuration, and advanced usage.</para>

--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/dm/master-docinfo.xml
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/dm/master-docinfo.xml
@@ -1,8 +1,6 @@
 <productname>{PRODUCT}</productname>
 <productnumber>{PRODUCT_VERSION}</productnumber>
 <subtitle>
-	For {PRODUCT} {PRODUCT_VERSION}
-	 
 </subtitle>
 <abstract>
 	<para>A guide for administrators and advanced users dealing with {PRODUCT} setup, configuration, and advanced usage.</para>

--- a/docs/product-assembly_business-optimizer-ER-sample-openshift/src/main/asciidoc/ba/master-docinfo.xml
+++ b/docs/product-assembly_business-optimizer-ER-sample-openshift/src/main/asciidoc/ba/master-docinfo.xml
@@ -1,8 +1,6 @@
 <productname>{PRODUCT}</productname>
 <productnumber>{PRODUCT_VERSION}</productnumber>
 <subtitle>
-	For {PRODUCT} {PRODUCT_VERSION}
-
 </subtitle>
 <abstract>
 	<para>This document describes how to run and use the OptaShift Employee Rostering example included as an add-on in {PRODUCT} {PRODUCT_VERSION}.</para>

--- a/docs/product-assembly_business-optimizer-ER-sample-openshift/src/main/asciidoc/dm/master-docinfo.xml
+++ b/docs/product-assembly_business-optimizer-ER-sample-openshift/src/main/asciidoc/dm/master-docinfo.xml
@@ -1,8 +1,6 @@
 <productname>{PRODUCT}</productname>
 <productnumber>{PRODUCT_VERSION}</productnumber>
 <subtitle>
-	For {PRODUCT} {PRODUCT_VERSION}
-
 </subtitle>
 <abstract>
 	<para>This document describes how to run and use the OptaShift Employee Rostering example included as an add-on in {PRODUCT} {PRODUCT_VERSION}.</para>

--- a/docs/product-assembly_business-optimizer-modifying-ER-template-IDE/src/main/asciidoc/ba/master-docinfo.xml
+++ b/docs/product-assembly_business-optimizer-modifying-ER-template-IDE/src/main/asciidoc/ba/master-docinfo.xml
@@ -1,8 +1,6 @@
 <productname>{PRODUCT}</productname>
 <productnumber>{PRODUCT_VERSION}</productnumber>
 <subtitle>
-	For {PRODUCT} {PRODUCT_VERSION}
-
 </subtitle>
 <abstract>
 	<para>This document describes how to run and use the OptaShift Employee Rostering example included as an add-on in {PRODUCT} {PRODUCT_VERSION}.</para>

--- a/docs/product-assembly_business-optimizer-modifying-ER-template-IDE/src/main/asciidoc/dm/master-docinfo.xml
+++ b/docs/product-assembly_business-optimizer-modifying-ER-template-IDE/src/main/asciidoc/dm/master-docinfo.xml
@@ -1,8 +1,6 @@
 <productname>{PRODUCT}</productname>
 <productnumber>{PRODUCT_VERSION}</productnumber>
 <subtitle>
-	For {PRODUCT} {PRODUCT_VERSION}
-
 </subtitle>
 <abstract>
 	<para>This document describes how to run and modify the OptaShift Employee Rostering template included as an add-on in {PRODUCT} {PRODUCT_VERSION}.</para>

--- a/docs/product-assembly_business-optimizer-running-ER-sample/src/main/asciidoc/ba/master-docinfo.xml
+++ b/docs/product-assembly_business-optimizer-running-ER-sample/src/main/asciidoc/ba/master-docinfo.xml
@@ -1,8 +1,6 @@
 <productname>{PRODUCT}</productname>
 <productnumber>{PRODUCT_VERSION}</productnumber>
 <subtitle>
-	For {PRODUCT} {PRODUCT_VERSION}
-
 </subtitle>
 <abstract>
 	<para>Create and run the Employee Rostering example for {PLANNER}.</para>

--- a/docs/product-assembly_business-optimizer-running-ER-sample/src/main/asciidoc/dm/master-docinfo.xml
+++ b/docs/product-assembly_business-optimizer-running-ER-sample/src/main/asciidoc/dm/master-docinfo.xml
@@ -1,8 +1,6 @@
 <productname>{PRODUCT}</productname>
 <productnumber>{PRODUCT_VERSION}</productnumber>
 <subtitle>
-	For {PRODUCT} {PRODUCT_VERSION}
-
 </subtitle>
 <abstract>
 	<para>Create and run the Employee Rostering example for {PLANNER}.</para>

--- a/docs/product-assembly_business-optimizer/src/main/asciidoc/ba/master-docinfo.xml
+++ b/docs/product-assembly_business-optimizer/src/main/asciidoc/ba/master-docinfo.xml
@@ -1,8 +1,6 @@
 <productname>{PRODUCT}</productname>
 <productnumber>{PRODUCT_VERSION}</productnumber>
 <subtitle>
-	For {PRODUCT} {PRODUCT_VERSION}
-
 </subtitle>
 <abstract>
 	<para>This topic describes how to design a decision service using uploaded decision tables in {PRODUCT} {PRODUCT_VERSION}.</para>

--- a/docs/product-assembly_business-optimizer/src/main/asciidoc/dm/master-docinfo.xml
+++ b/docs/product-assembly_business-optimizer/src/main/asciidoc/dm/master-docinfo.xml
@@ -1,8 +1,6 @@
 <productname>{PRODUCT}</productname>
 <productnumber>{PRODUCT_VERSION}</productnumber>
 <subtitle>
-	For {PRODUCT} {PRODUCT_VERSION}
-
 </subtitle>
 <abstract>
 	<para>This document describes how to install and configure {PLANNER} in {PRODUCT} {PRODUCT_VERSION}.</para>

--- a/docs/product-assembly_decision-manager/src/main/asciidoc/ba/master-docinfo.xml
+++ b/docs/product-assembly_decision-manager/src/main/asciidoc/ba/master-docinfo.xml
@@ -1,8 +1,6 @@
 <productname>{PRODUCT}</productname>
 <productnumber>{PRODUCT_VERSION}</productnumber>
 <subtitle>
-	For {PRODUCT} {PRODUCT_VERSION}
-
 </subtitle>
 <abstract>
 	<para>This topic describes how to design a decision service using guided decision tables in {PRODUCT} {PRODUCT_VERSION}.</para>

--- a/docs/product-assembly_decision-manager/src/main/asciidoc/dm/master-docinfo.xml
+++ b/docs/product-assembly_decision-manager/src/main/asciidoc/dm/master-docinfo.xml
@@ -1,8 +1,6 @@
 <productname>{PRODUCT}</productname>
 <productnumber>{PRODUCT_VERSION}</productnumber>
 <subtitle>
-	For {PRODUCT} {PRODUCT_VERSION}
-
 </subtitle>
 <abstract>
 	<para>In this tutorial, you will create and test a driver's license suspension scenario.</para>

--- a/docs/product-assembly_decision-tables/src/main/asciidoc/ba/master-docinfo.xml
+++ b/docs/product-assembly_decision-tables/src/main/asciidoc/ba/master-docinfo.xml
@@ -1,8 +1,6 @@
 <productname>{PRODUCT}</productname>
 <productnumber>{PRODUCT_VERSION}</productnumber>
 <subtitle>
-	For {PRODUCT} {PRODUCT_VERSION}
-
 </subtitle>
 <abstract>
 	<para>This document describes how to design a decision service using uploaded decision tables in {PRODUCT} {PRODUCT_VERSION}.</para>

--- a/docs/product-assembly_decision-tables/src/main/asciidoc/dm/master-docinfo.xml
+++ b/docs/product-assembly_decision-tables/src/main/asciidoc/dm/master-docinfo.xml
@@ -1,8 +1,6 @@
 <productname>{PRODUCT}</productname>
 <productnumber>{PRODUCT_VERSION}</productnumber>
 <subtitle>
-	For {PRODUCT} {PRODUCT_VERSION}
-
 </subtitle>
 <abstract>
 	<para>This document describes how to design a decision service using uploaded decision tables in {PRODUCT} {PRODUCT_VERSION}.</para>

--- a/docs/product-assembly_dm-7.0-release-notes/src/main/asciidoc/ba/master-docinfo.xml
+++ b/docs/product-assembly_dm-7.0-release-notes/src/main/asciidoc/ba/master-docinfo.xml
@@ -1,8 +1,6 @@
 <productname>{PRODUCT}</productname>
 <productnumber>{PRODUCT_VERSION}</productnumber>
 <subtitle>
-	For {PRODUCT} {PRODUCT_VERSION}
-
 </subtitle>
 <abstract>
 	<para>This topic describes how to design a decision service using guided decision tables in {PRODUCT} {PRODUCT_VERSION}.</para>

--- a/docs/product-assembly_dm-7.0-release-notes/src/main/asciidoc/dm/master-docinfo.xml
+++ b/docs/product-assembly_dm-7.0-release-notes/src/main/asciidoc/dm/master-docinfo.xml
@@ -1,8 +1,6 @@
 <productname>{PRODUCT}</productname>
 <productnumber>{PRODUCT_VERSION}</productnumber>
 <subtitle>
-	For {PRODUCT} {PRODUCT_VERSION}
-
 </subtitle>
 <abstract>
 	<para>This document contains release notes for {PRODUCT} {PRODUCT_VERSION}</para>

--- a/docs/product-assembly_dm-on-openshift/src/main/asciidoc/ba/master-docinfo.xml
+++ b/docs/product-assembly_dm-on-openshift/src/main/asciidoc/ba/master-docinfo.xml
@@ -1,8 +1,6 @@
 <productname>{PRODUCT}</productname>
 <productnumber>{PRODUCT_VERSION}</productnumber>
 <subtitle>
-	For {PRODUCT} {PRODUCT_VERSION}
-
 </subtitle>
 <abstract>
 	<para>This topic describes deploying {PRODUCT} {PRODUCT_VERSION} in an OpenShift environment.</para>

--- a/docs/product-assembly_dm-on-openshift/src/main/asciidoc/dm/master-docinfo.xml
+++ b/docs/product-assembly_dm-on-openshift/src/main/asciidoc/dm/master-docinfo.xml
@@ -1,8 +1,6 @@
 <productname>{PRODUCT}</productname>
 <productnumber>{PRODUCT_VERSION}</productnumber>
 <subtitle>
-	For {PRODUCT} {PRODUCT_VERSION}
-
 </subtitle>
 <abstract>
 	<para>This document describes deploying {PRODUCT} {PRODUCT_VERSION} in an OpenShift environment.</para>

--- a/docs/product-assembly_dmn-models/src/main/asciidoc/ba/master-docinfo.xml
+++ b/docs/product-assembly_dmn-models/src/main/asciidoc/ba/master-docinfo.xml
@@ -1,8 +1,6 @@
 <productname>{PRODUCT}</productname>
 <productnumber>{PRODUCT_VERSION}</productnumber>
 <subtitle>
-	For {PRODUCT} {PRODUCT_VERSION}
-
 </subtitle>
 <abstract>
 	<para>This document describes how to design a decision service using Decision Model and Notation (DMN) models in {PRODUCT} {PRODUCT_VERSION}.</para>

--- a/docs/product-assembly_dmn-models/src/main/asciidoc/dm/master-docinfo.xml
+++ b/docs/product-assembly_dmn-models/src/main/asciidoc/dm/master-docinfo.xml
@@ -1,8 +1,6 @@
 <productname>{PRODUCT}</productname>
 <productnumber>{PRODUCT_VERSION}</productnumber>
 <subtitle>
-	For {PRODUCT} {PRODUCT_VERSION}
-
 </subtitle>
 <abstract>
 	<para>This document describes how to design a decision service using Decision Model and Notation (DMN) models in {PRODUCT} {PRODUCT_VERSION}.</para>

--- a/docs/product-assembly_drl-rules/src/main/asciidoc/ba/master-docinfo.xml
+++ b/docs/product-assembly_drl-rules/src/main/asciidoc/ba/master-docinfo.xml
@@ -1,8 +1,6 @@
 <productname>{PRODUCT}</productname>
 <productnumber>{PRODUCT_VERSION}</productnumber>
 <subtitle>
-	For {PRODUCT} {PRODUCT_VERSION}
-
 </subtitle>
 <abstract>
 	<para>This document describes how to design a decision service using DRL rules in {PRODUCT} {PRODUCT_VERSION}.</para>

--- a/docs/product-assembly_drl-rules/src/main/asciidoc/dm/master-docinfo.xml
+++ b/docs/product-assembly_drl-rules/src/main/asciidoc/dm/master-docinfo.xml
@@ -1,8 +1,6 @@
 <productname>{PRODUCT}</productname>
 <productnumber>{PRODUCT_VERSION}</productnumber>
 <subtitle>
-	For {PRODUCT} {PRODUCT_VERSION}
-
 </subtitle>
 <abstract>
 	<para>This document describes how to design a decision service using DRL rules in {PRODUCT} {PRODUCT_VERSION}.</para>

--- a/docs/product-assembly_guided-decision-tables/src/main/asciidoc/ba/master-docinfo.xml
+++ b/docs/product-assembly_guided-decision-tables/src/main/asciidoc/ba/master-docinfo.xml
@@ -1,8 +1,6 @@
 <productname>{PRODUCT}</productname>
 <productnumber>{PRODUCT_VERSION}</productnumber>
 <subtitle>
-	For {PRODUCT} {PRODUCT_VERSION}
-
 </subtitle>
 <abstract>
 	<para>This document describes how to design a decision service using guided decision tables in {PRODUCT} {PRODUCT_VERSION}.</para>

--- a/docs/product-assembly_guided-decision-tables/src/main/asciidoc/dm/master-docinfo.xml
+++ b/docs/product-assembly_guided-decision-tables/src/main/asciidoc/dm/master-docinfo.xml
@@ -1,8 +1,6 @@
 <productname>{PRODUCT}</productname>
 <productnumber>{PRODUCT_VERSION}</productnumber>
 <subtitle>
-	For {PRODUCT} {PRODUCT_VERSION}
-
 </subtitle>
 <abstract>
 	<para>This document describes how to design a decision service using guided decision tables in {PRODUCT} {PRODUCT_VERSION}.</para>

--- a/docs/product-assembly_guided-rule-templates/src/main/asciidoc/ba/master-docinfo.xml
+++ b/docs/product-assembly_guided-rule-templates/src/main/asciidoc/ba/master-docinfo.xml
@@ -1,8 +1,6 @@
 <productname>{PRODUCT}</productname>
 <productnumber>{PRODUCT_VERSION}</productnumber>
 <subtitle>
-	For {PRODUCT} {PRODUCT_VERSION}
-
 </subtitle>
 <abstract>
 	<para>This document describes how to design a decision service using guided rule templates in {PRODUCT} {PRODUCT_VERSION}.</para>

--- a/docs/product-assembly_guided-rule-templates/src/main/asciidoc/dm/master-docinfo.xml
+++ b/docs/product-assembly_guided-rule-templates/src/main/asciidoc/dm/master-docinfo.xml
@@ -1,8 +1,6 @@
 <productname>{PRODUCT}</productname>
 <productnumber>{PRODUCT_VERSION}</productnumber>
 <subtitle>
-	For {PRODUCT} {PRODUCT_VERSION}
-
 </subtitle>
 <abstract>
 	<para>This document describes how to design a decision service using guided rule templates in {PRODUCT} {PRODUCT_VERSION}.</para>

--- a/docs/product-assembly_guided-rules/src/main/asciidoc/ba/master-docinfo.xml
+++ b/docs/product-assembly_guided-rules/src/main/asciidoc/ba/master-docinfo.xml
@@ -1,8 +1,6 @@
 <productname>{PRODUCT}</productname>
 <productnumber>{PRODUCT_VERSION}</productnumber>
 <subtitle>
-	For {PRODUCT} {PRODUCT_VERSION}
-
 </subtitle>
 <abstract>
 	<para>This document describes how to design a decision service using guided rules in {PRODUCT} {PRODUCT_VERSION}.</para>

--- a/docs/product-assembly_guided-rules/src/main/asciidoc/dm/master-docinfo.xml
+++ b/docs/product-assembly_guided-rules/src/main/asciidoc/dm/master-docinfo.xml
@@ -1,8 +1,6 @@
 <productname>{PRODUCT}</productname>
 <productnumber>{PRODUCT_VERSION}</productnumber>
 <subtitle>
-	For {PRODUCT} {PRODUCT_VERSION}
-
 </subtitle>
 <abstract>
 	<para>This document describes how to design a decision service using guided rules in {PRODUCT} {PRODUCT_VERSION}.</para>

--- a/docs/product-assembly_installing-dm-on-premise/src/main/asciidoc/ba/master-docinfo.xml
+++ b/docs/product-assembly_installing-dm-on-premise/src/main/asciidoc/ba/master-docinfo.xml
@@ -1,8 +1,6 @@
 <productname>{PRODUCT}</productname>
 <productnumber>{PRODUCT_VERSION}</productnumber>
 <subtitle>
-	For {PRODUCT} {PRODUCT_VERSION}
-
 </subtitle>
 <abstract>
 	<para>This topic describes how to design a decision service using guided decision tables in {PRODUCT} {PRODUCT_VERSION}.</para>

--- a/docs/product-assembly_installing-dm-on-premise/src/main/asciidoc/dm/master-docinfo.xml
+++ b/docs/product-assembly_installing-dm-on-premise/src/main/asciidoc/dm/master-docinfo.xml
@@ -1,8 +1,6 @@
 <productname>{PRODUCT}</productname>
 <productnumber>{PRODUCT_VERSION}</productnumber>
 <subtitle>
-	For {PRODUCT} {PRODUCT_VERSION}
-
 </subtitle>
 <abstract>
 	<para>This document explains how to install and run {PRODUCT} {PRODUCT_VERSION} on {EAP_LONG} 7.1 and Red Hat JBoss Web Server with Tomcat 8.</para>

--- a/docs/product-assembly_installing-dsps-on-was/src/main/asciidoc/ba/master-docinfo.xml
+++ b/docs/product-assembly_installing-dsps-on-was/src/main/asciidoc/ba/master-docinfo.xml
@@ -1,8 +1,6 @@
 <productname>{PRODUCT}</productname>
 <productnumber>{PRODUCT_VERSION}</productnumber>
 <subtitle>
-	For {PRODUCT} {PRODUCT_VERSION}
-
 </subtitle>
 <abstract>
 	<para>This topic describes how to design a decision service using guided decision tables in {PRODUCT} {PRODUCT_VERSION}.</para>

--- a/docs/product-assembly_installing-dsps-on-was/src/main/asciidoc/dm/master-docinfo.xml
+++ b/docs/product-assembly_installing-dsps-on-was/src/main/asciidoc/dm/master-docinfo.xml
@@ -1,8 +1,6 @@
 <productname>{PRODUCT}</productname>
 <productnumber>{PRODUCT_VERSION}</productnumber>
 <subtitle>
-	For {PRODUCT} {PRODUCT_VERSION}
-
 </subtitle>
 <abstract>
 	<para>In this guide, you will install and configure IBM WebSphere Application Server for use with {KIE_SERVER}.</para>

--- a/docs/product-assembly_installing-dsps-on-wls/src/main/asciidoc/ba/master-docinfo.xml
+++ b/docs/product-assembly_installing-dsps-on-wls/src/main/asciidoc/ba/master-docinfo.xml
@@ -1,8 +1,6 @@
 <productname>{PRODUCT}</productname>
 <productnumber>{PRODUCT_VERSION}</productnumber>
 <subtitle>
-	For {PRODUCT} {PRODUCT_VERSION}
-
 </subtitle>
 <abstract>
 	<para>This document describes how to design a decision service using guided decision tables in {PRODUCT} {PRODUCT_VERSION}.</para>

--- a/docs/product-assembly_installing-dsps-on-wls/src/main/asciidoc/dm/master-docinfo.xml
+++ b/docs/product-assembly_installing-dsps-on-wls/src/main/asciidoc/dm/master-docinfo.xml
@@ -1,8 +1,6 @@
 <productname>{PRODUCT}</productname>
 <productnumber>{PRODUCT_VERSION}</productnumber>
 <subtitle>
-	For {PRODUCT} {PRODUCT_VERSION}
-
 </subtitle>
 <abstract>
 	<para>This document describes how to install {PRODUCT} on Oracle Weblogic Server.</para>

--- a/docs/product-assembly_migrating-from-BRMS-6.4-to-DM-7.0/src/main/asciidoc/ba/master-docinfo.xml
+++ b/docs/product-assembly_migrating-from-BRMS-6.4-to-DM-7.0/src/main/asciidoc/ba/master-docinfo.xml
@@ -1,8 +1,6 @@
 <productname>{PRODUCT}</productname>
 <productnumber>{PRODUCT_VERSION}</productnumber>
 <subtitle>
-	For {PRODUCT} {PRODUCT_VERSION}
-
 </subtitle>
 <abstract>
 	<para>This document describes how to migrate user data and APIs from Red Hat BRMS 6.4 to {PRODUCT} {PRODUCT_VERSION}.</para>

--- a/docs/product-assembly_migrating-from-BRMS-6.4-to-DM-7.0/src/main/asciidoc/dm/master-docinfo.xml
+++ b/docs/product-assembly_migrating-from-BRMS-6.4-to-DM-7.0/src/main/asciidoc/dm/master-docinfo.xml
@@ -1,8 +1,6 @@
 <productname>{PRODUCT} </productname>
 <productnumber>{PRODUCT_VERSION}</productnumber>
 <subtitle>
-	For {PRODUCT} {PRODUCT_VERSION}
-
 </subtitle>
 <abstract>
 	<para>This document describes how to migrate user data and APIs from Red Hat BRMS 6.4 to Red Hat Decision Manager 7.0.</para>

--- a/docs/product-assembly_packaging-deploying/src/main/asciidoc/ba/master-docinfo.xml
+++ b/docs/product-assembly_packaging-deploying/src/main/asciidoc/ba/master-docinfo.xml
@@ -1,8 +1,6 @@
 <productname>{PRODUCT}</productname>
 <productnumber>{PRODUCT_VERSION}</productnumber>
 <subtitle>
-	For {PRODUCT} {PRODUCT_VERSION}
-
 </subtitle>
 <abstract>
 	<para>This topic describes how to design a decision service using guided decision tables in {PRODUCT} {PRODUCT_VERSION}.</para>

--- a/docs/product-assembly_packaging-deploying/src/main/asciidoc/dm/master-docinfo.xml
+++ b/docs/product-assembly_packaging-deploying/src/main/asciidoc/dm/master-docinfo.xml
@@ -1,8 +1,6 @@
 <productname>{PRODUCT}</productname>
 <productnumber>{PRODUCT_VERSION}</productnumber>
 <subtitle>
-	For {PRODUCT} {PRODUCT_VERSION}
-
 </subtitle>
 <abstract>
 	<para>This document describes packaging and deploying a decision service for {PRODUCT} {PRODUCT_VERSION}</para>

--- a/docs/product-assembly_running-employee-rostering-in-wb/src/main/asciidoc/ba/master-docinfo.xml
+++ b/docs/product-assembly_running-employee-rostering-in-wb/src/main/asciidoc/ba/master-docinfo.xml
@@ -1,8 +1,6 @@
 <productname>{PRODUCT}</productname>
 <productnumber>{PRODUCT_VERSION}</productnumber>
 <subtitle>
-	For {PRODUCT} {PRODUCT_VERSION}
-
 </subtitle>
 <abstract>
 	<para>This document describes how to create and run the employee rostering example for {PLANNER} using {CENTRAL} in {PRODUCT} {PRODUCT_VERSION}.</para>

--- a/docs/product-assembly_running-employee-rostering-in-wb/src/main/asciidoc/dm/master-docinfo.xml
+++ b/docs/product-assembly_running-employee-rostering-in-wb/src/main/asciidoc/dm/master-docinfo.xml
@@ -1,8 +1,6 @@
 <productname>{PRODUCT}</productname>
 <productnumber>{PRODUCT_VERSION}</productnumber>
 <subtitle>
-	For {PRODUCT} {PRODUCT_VERSION}
-
 </subtitle>
 <abstract>
 	<para>This document describes how to create and run the employee rostering example for {PLANNER} using {CENTRAL} in {PRODUCT} {PRODUCT_VERSION}.</para>

--- a/docs/product-assembly_test-scenarios/src/main/asciidoc/ba/master-docinfo.xml
+++ b/docs/product-assembly_test-scenarios/src/main/asciidoc/ba/master-docinfo.xml
@@ -1,8 +1,6 @@
 <productname>{PRODUCT}</productname>
 <productnumber>{PRODUCT_VERSION}</productnumber>
 <subtitle>
-	For {PRODUCT} {PRODUCT_VERSION}
-
 </subtitle>
 <abstract>
 	<para>This document describes how to test a decision service using test scenarios in {PRODUCT} {PRODUCT_VERSION}.</para>

--- a/docs/product-assembly_test-scenarios/src/main/asciidoc/dm/master-docinfo.xml
+++ b/docs/product-assembly_test-scenarios/src/main/asciidoc/dm/master-docinfo.xml
@@ -1,8 +1,6 @@
 <productname>{PRODUCT}</productname>
 <productnumber>{PRODUCT_VERSION}</productnumber>
 <subtitle>
-	For {PRODUCT} {PRODUCT_VERSION}
-
 </subtitle>
 <abstract>
 	<para>This document describes how to test a decision service using test scenarios in {PRODUCT} {PRODUCT_VERSION}.</para>

--- a/docs/product-business-resource-planner-guide/src/main/asciidoc/ba/master-docinfo.xml
+++ b/docs/product-business-resource-planner-guide/src/main/asciidoc/ba/master-docinfo.xml
@@ -1,8 +1,6 @@
 <productname>{PRODUCT}</productname>
 <productnumber>{PRODUCT_VERSION}</productnumber>
 <subtitle>
-	For {PRODUCT} {PRODUCT_VERSION}
-	 
 </subtitle>
 <abstract>
 	<para>A guide to using API's in {PRODUCT} for developers.</para>

--- a/docs/product-business-resource-planner-guide/src/main/asciidoc/dm/master-docinfo.xml
+++ b/docs/product-business-resource-planner-guide/src/main/asciidoc/dm/master-docinfo.xml
@@ -1,8 +1,6 @@
 <productname>{PRODUCT}</productname>
 <productnumber>{PRODUCT_VERSION}</productnumber>
 <subtitle>
-	For {PRODUCT} {PRODUCT_VERSION}
-
 </subtitle>
 <abstract>
 	<para>This topic describes how to design a decision service using uploaded decision tables in {PRODUCT} {PRODUCT_VERSION}.</para>

--- a/docs/product-development-guide/src/main/asciidoc/ba/master-docinfo.xml
+++ b/docs/product-development-guide/src/main/asciidoc/ba/master-docinfo.xml
@@ -1,8 +1,6 @@
 <productname>{PRODUCT}</productname>
 <productnumber>{PRODUCT_VERSION}</productnumber>
 <subtitle>
-	For {PRODUCT} {PRODUCT_VERSION}
-	 
 </subtitle>
 <abstract>
 	<para>A guide to using API's in {PRODUCT} for developers.</para>

--- a/docs/product-getting-started-guide/src/main/asciidoc/ba/master-docinfo.xml
+++ b/docs/product-getting-started-guide/src/main/asciidoc/ba/master-docinfo.xml
@@ -1,8 +1,6 @@
 <productname>{PRODUCT}</productname>
 <productnumber>{PRODUCT_VERSION}</productnumber>
 <subtitle>
-	For {PRODUCT} {PRODUCT_VERSION}
-	 
 </subtitle>
 <abstract>
 	<para>This guide provides information for getting started with {PRODUCT}.</para>

--- a/docs/product-getting-started-guide/src/main/asciidoc/dm/master-docinfo.xml
+++ b/docs/product-getting-started-guide/src/main/asciidoc/dm/master-docinfo.xml
@@ -1,8 +1,6 @@
 <productname>{PRODUCT}</productname>
 <productnumber>{PRODUCT_VERSION}</productnumber>
 <subtitle>
-	For {PRODUCT} {PRODUCT_VERSION}
-	 
 </subtitle>
 <abstract>
 	<para>This guide provides information for getting started with {PRODUCT}.</para>

--- a/docs/product-ibm-websphere-installation-and-configuration-guide/src/main/asciidoc/ba/master-docinfo.xml
+++ b/docs/product-ibm-websphere-installation-and-configuration-guide/src/main/asciidoc/ba/master-docinfo.xml
@@ -1,8 +1,6 @@
 <productname>{PRODUCT}</productname>
 <productnumber>{PRODUCT_VERSION}</productnumber>
 <subtitle>
-	For {PRODUCT} {PRODUCT_VERSION}
-	 
 </subtitle>
 <abstract>
 	<para>A guide to installing and configuring {PRODUCT} on IBM WebSphere Application Server.</para>

--- a/docs/product-ibm-websphere-installation-and-configuration-guide/src/main/asciidoc/dm/master-docinfo.xml
+++ b/docs/product-ibm-websphere-installation-and-configuration-guide/src/main/asciidoc/dm/master-docinfo.xml
@@ -1,8 +1,6 @@
 <productname>{KIE_SERVER}</productname>
 <productnumber>{PRODUCT_VERSION}</productnumber>
 <subtitle>
-	For {KIE_SERVER} {PRODUCT_VERSION}
-
 </subtitle>
 <abstract>
 	<para>In this guide, you will install and configure IBM WebSphere Application Server for use with {KIE_SERVER}.</para>

--- a/docs/product-installation-guide/src/main/asciidoc/ba/master-docinfo.xml
+++ b/docs/product-installation-guide/src/main/asciidoc/ba/master-docinfo.xml
@@ -1,8 +1,6 @@
 <productname>{PRODUCT}</productname>
 <productnumber>{PRODUCT_VERSION}</productnumber>
 <subtitle>
-	For {PRODUCT} {PRODUCT_VERSION}
-	 
 </subtitle>
 <abstract>
 	<para>This guide provides basic steps necessary for obtaining, installing, and running {PRODUCT} {PRODUCT_VERSION} {RELEASE}.</para>

--- a/docs/product-installation-guide/src/main/asciidoc/dm/master-docinfo.xml
+++ b/docs/product-installation-guide/src/main/asciidoc/dm/master-docinfo.xml
@@ -1,8 +1,6 @@
 <productname>{PRODUCT}</productname>
 <productnumber>{PRODUCT_VERSION}</productnumber>
 <subtitle>
-	For {PRODUCT} {PRODUCT_VERSION}
-	 
 </subtitle>
 <abstract>
 	<para>This guide provides basic steps necessary for obtaining, installing, and running {PRODUCT} {PRODUCT_VERSION} {RELEASE}.</para>

--- a/docs/product-migration-guide/src/main/asciidoc/ba/master-docinfo.xml
+++ b/docs/product-migration-guide/src/main/asciidoc/ba/master-docinfo.xml
@@ -1,8 +1,6 @@
 <productname>{PRODUCT}</productname>
 <productnumber>{PRODUCT_VERSION}</productnumber>
 <subtitle>
-	For {PRODUCT} {PRODUCT_VERSION}
-	 
 </subtitle>
 <abstract>
 	<para>The Guide will help you migrate from JBoss Enterprise BRMS Platform 5.3.1, and earlier versions of {PRODUCT}, to {PRODUCT} {PRODUCT_VERSION}.</para>

--- a/docs/product-openshift-kie-server-bpms/src/main/asciidoc/ba/master-docinfo.xml
+++ b/docs/product-openshift-kie-server-bpms/src/main/asciidoc/ba/master-docinfo.xml
@@ -1,8 +1,6 @@
 <productname>{PRODUCT}</productname>
 <productnumber>{PRODUCT_VERSION}</productnumber>
 <subtitle>
-	For {PRODUCT} {PRODUCT_VERSION}
-	 
 </subtitle>
 <abstract>
  <para>Guide to using {xpaasproduct}</para>

--- a/docs/product-openshift-kie-server-brms/src/main/asciidoc/dm/master-docinfo.xml
+++ b/docs/product-openshift-kie-server-brms/src/main/asciidoc/dm/master-docinfo.xml
@@ -1,9 +1,6 @@
 <productname>{PRODUCT}</productname>
 <productnumber>{PRODUCT_VERSION}</productnumber>
 <subtitle>
-	For {PRODUCT} {PRODUCT_VERSION}
-	
-  Using {xpaasproduct} 
 </subtitle>
 <abstract>
  <para>Guide to using {xpaasproduct}</para>

--- a/docs/product-oracle-weblogic-installation-and-configuration-guide/src/main/asciidoc/ba/master-docinfo.xml
+++ b/docs/product-oracle-weblogic-installation-and-configuration-guide/src/main/asciidoc/ba/master-docinfo.xml
@@ -1,8 +1,6 @@
 <productname>{PRODUCT}</productname>
 <productnumber>{PRODUCT_VERSION}</productnumber>
 <subtitle>
-	For {PRODUCT} {PRODUCT_VERSION}
-	 
 </subtitle>
 <abstract>
 	<para>A guide to installing and configuring {PRODUCT} on Oracle Weblogic.</para>

--- a/docs/product-oracle-weblogic-installation-and-configuration-guide/src/main/asciidoc/dm/master-docinfo.xml
+++ b/docs/product-oracle-weblogic-installation-and-configuration-guide/src/main/asciidoc/dm/master-docinfo.xml
@@ -1,8 +1,6 @@
 <productname>{PRODUCT}</productname>
 <productnumber>{PRODUCT_VERSION}</productnumber>
 <subtitle>
-	For {PRODUCT} {PRODUCT_VERSION}
-	 
 </subtitle>
 <abstract>
 	<para>A guide to installing and configuring {PRODUCT} on Oracle Weblogic.</para>

--- a/docs/product-release-notes/src/main/asciidoc/ba/master-docinfo.xml
+++ b/docs/product-release-notes/src/main/asciidoc/ba/master-docinfo.xml
@@ -1,6 +1,7 @@
 <productname>{PRODUCT}</productname>
 <productnumber>{PRODUCT_VERSION}</productnumber>
-<subtitle>Release Notes for {PRODUCT}</subtitle>
+<subtitle>
+</subtitle>
 <abstract>
 	<para>Release notes for {PRODUCT} {PRODUCT_VERSION}.</para>
 </abstract>

--- a/docs/product-release-notes/src/main/asciidoc/dm/master-docinfo.xml
+++ b/docs/product-release-notes/src/main/asciidoc/dm/master-docinfo.xml
@@ -1,6 +1,7 @@
 <productname>{PRODUCT}</productname>
 <productnumber>{PRODUCT_VERSION}</productnumber>
-<subtitle>Release Notes for {PRODUCT}</subtitle>
+<subtitle>
+</subtitle>
 <abstract>
 	<para>Release notes for {PRODUCT} {PRODUCT_VERSION}.</para>
 </abstract>

--- a/docs/product-user-guide/src/main/asciidoc/ba/master-docinfo.xml
+++ b/docs/product-user-guide/src/main/asciidoc/ba/master-docinfo.xml
@@ -1,8 +1,6 @@
 <productname>{PRODUCT}</productname>
 <productnumber>{PRODUCT_VERSION}</productnumber>
 <subtitle>
-	For {PRODUCT} {PRODUCT_VERSION}
-	 
 </subtitle>
 <abstract>
 	<para>A guide to defining and managing business processes with {PRODUCT}.</para>

--- a/docs/product-user-guide/src/main/asciidoc/dm/master-docinfo.xml
+++ b/docs/product-user-guide/src/main/asciidoc/dm/master-docinfo.xml
@@ -1,8 +1,6 @@
 <productname>{PRODUCT}</productname>
 <productnumber>{PRODUCT_VERSION}</productnumber>
 <subtitle>
-	For {PRODUCT} {PRODUCT_VERSION}
-	 
 </subtitle>
 <abstract>
 	<para>A guide to defining and managing business processes with {PRODUCT}.</para>

--- a/docs/shared-kie-docs/src/main/asciidoc/Product/document-attributes.adoc
+++ b/docs/shared-kie-docs/src/main/asciidoc/Product/document-attributes.adoc
@@ -1,5 +1,5 @@
 
-:REBUILT: Friday, April 13, 2018
+:REBUILT: Friday, May 25, 2018
 
 // Book Conditionals
 :ENTERPRISE_ONLY:


### PR DESCRIPTION
Ready for upstream 7.5.x.

Already addressed for master and 7.7.x in a separate PR.