### PR TITLE
DROOLS-2597 : Standalone Authoring documentation header example should be better

### DIFF
--- a/docs/shared-kie-docs/src/main/asciidoc/Workbench/Embedding/Embedding-section.adoc
+++ b/docs/shared-kie-docs/src/main/asciidoc/Workbench/Embedding/Embedding-section.adoc
@@ -36,7 +36,7 @@ In order to embed Workbench in your application all you'll need is the Workbench
 |header
 |Defines the name of the header that should be displayed (useful for context menu headers).
 |yes
-|AppNavBar
+|UberfireBreadcrumbsContainer
 |===
 
 .Examples


### PR DESCRIPTION

https://issues.jboss.org/browse/DROOLS-2597

AppNavBar doesn't usually make sense with the standalone. Breadcrumb is better.