### PR TITLE
Remove unsupported business central parameters

### DIFF
--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/access-control-con.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/access-control-con.adoc
@@ -19,10 +19,3 @@ endif::PAM[]
 Within {PRODUCT}, users may set up roles using LDAP to modify existing roles. Users may modify the roles in the workbench configuration to ensure the unique LDAP based roles conform to enterprise standards by editing the deployments directory located at `_JBOSS_HOME_/standalone/deployments/business-central.war/WEB-INF/classes/workbench-policy.propeties`.
 
 If authenticating user via LDAP over Git, administrators must set system property [property]``org.uberfire.domain`` to the name of login module it should use to authenticate users via the Git service. This must be set in the ``standalone.xml``file in EAP.
-
-[NOTE]
-====
-You can further customize Business Central with parameters _no_build_ or __no_search__.
-The parameters disable the build and search functionality.
-Include one or both parameters in the Business Central URL, for example `http://_SERVER_:PORT/business-central/kie-wb.jsp?no_build&no_search`.
-====

--- a/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-business-central-configuration.adoc
+++ b/docs/product-administration-and-configuration-guide/src/main/asciidoc/chap-business-central-configuration.adoc
@@ -32,14 +32,6 @@ Within {PRODUCT}, users may set up roles using LDAP to modify existing roles. Us
 
 If authenticating user via LDAP over Git, administrators must set system property [property]``org.uberfire.domain`` to the name of login module it should use to authenticate users via the Git service. This must be set in the ``standalone.xml``file in EAP.
 
-[NOTE]
-====
-You can further customize Business Central with parameters _no_build_ or __no_search__.
-The parameters disable the build and search functionality.
-Include one or both parameters in the Business Central URL, for example `http://_SERVER_:PORT/business-central/kie-wb.jsp?no_build&no_search`.
-====
-
-
 ifdef::PAM[]
 [float]
 === Authentication in Human Tasks


### PR DESCRIPTION
`no_build` and `no_search` parameters no longer available in business-central.

https://issues.jboss.org/browse/AF-703