### PR TITLE
BXMSDOC-2366 (for upstream master): Updated supported ContentType for REST Task in User Guide content, per 6.4 update.

### DIFF
--- a/docs/product-user-guide/src/main/asciidoc/appe-service-tasks.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/appe-service-tasks.adoc
@@ -159,7 +159,7 @@ To register `EmailWorkItemHandler`:
 +
 [source,java]
 ----
-new org.jbpm.process.workitem.email.EmailWorkItemHandler("localhost","25","me@localhost","password")
+new org.jbpm.process.workitem.email.EmailWorkItemHandler("localhost","25","me@localhost","password");
 ----
 +
 Alternatively, email server parameters can be supplied using a constructor in the `ProcessMain.java` file:
@@ -286,10 +286,10 @@ http://DOMAIN:PORT/restService/getCars?brand=#{carBrand}
 In this example, carBrand  is replaced by the value of the `carBrand` process variable during runtime.
 
 Method::
-The method of the request, such as GET, POST, or similar. The default method is GET.
+The method of the request, such as GET, POST, or other. The default method is GET.
 
 ContentType::
-The data type in case of sending data. This attribute is mandatory for POST and PUT requests. This is an optional parameter. If you want to use it, map it as a data input variable in the *Data I/O* dialogue of the task.
+The data type if you are sending data. The supported data types are `application/json` and `application/xml`. This attribute is mandatory for POST and PUT requests. If you want to use this attribute, map it as a data input variable in the *Data I/O* dialogue of the task.
 
 Content::
 The data you want to send. This attribute is mandatory for POST and PUT requests. This is an optional parameter. If you want to use it, map it as a data input variable in the *Data I/O* dialogue of the task.


### PR DESCRIPTION
Ready for upstream 7.7.x.

See [JIRA](https://issues.jboss.org/browse/BXMSDOC-2366) for details.