### PR TITLE
BXMSDOC-2881 (for upstream 7.7.x): Updated rebuilt variable for PAM 7.0 docs publish.

### DIFF
--- a/docs/shared-kie-docs/src/main/asciidoc/Product/document-attributes.adoc
+++ b/docs/shared-kie-docs/src/main/asciidoc/Product/document-attributes.adoc
@@ -1,5 +1,5 @@
 
-:REBUILT: Friday, June 29, 2018
+:REBUILT: Friday, July 13, 2018
 
 // Book Conditionals
 :ENTERPRISE_ONLY:


### PR DESCRIPTION
Ready for upstream 7.7.x.