### PR TITLE
BXMSDOC-2826 (for upstream 7.7.x): New external db section in Deploying OpenShift docs, for Misha

### DIFF
--- a/docs/product-assembly_openshift-authoring/src/main/asciidoc/main.adoc
+++ b/docs/product-assembly_openshift-authoring/src/main/asciidoc/main.adoc
@@ -32,6 +32,7 @@ include::product-assembly_pam-on-openshift/environment-authoring-single-proc.ado
 include::product-assembly_pam-on-openshift/environment-authoring-ha-proc.adoc[leveloffset=+2]
 include::product-assembly_pam-on-openshift/environment-authoring-single-modify-proc.adoc[leveloffset=+2]
 include::product-assembly_pam-on-openshift/environment-authoring-ha-modify-proc.adoc[leveloffset=+2]
+include::product-assembly_pam-on-openshift/externaldb-build-proc.adoc[leveloffset=+2]
 
 // Versioning info
 include::product-shared-docs/versioning-information.adoc[]

--- a/docs/product-assembly_openshift-authoring/src/main/asciidoc/main.adoc
+++ b/docs/product-assembly_openshift-authoring/src/main/asciidoc/main.adoc
@@ -1,4 +1,4 @@
-[id='assembly_dm-7.0-release-notes']
+[id='assembly_openshift-authoring]
 
 include::product-shared-docs/document-attributes.adoc[]
 
@@ -18,7 +18,7 @@ As a system engineer, you can deploy a {PRODUCT} authoring environment on {OPENS
 * You have logged in to the project using the OpenShift web console and using the `oc` command.
 * If you intend to scale any of the {CENTRAL} or {CENTRAL} Monitoring pods, your OpenShift environment supports persistent volumes with ReadWriteMany mode.
 +
-IMPORTANT: ReadWriteMany mode is not supported on OpenShift Online and OpenShift Dedicated.   
+IMPORTANT: ReadWriteMany mode is not supported on OpenShift Online and OpenShift Dedicated.
 
 
 include::product-assembly_pam-on-openshift/ba-openshift-overview-con.adoc[leveloffset=+1]

--- a/docs/product-assembly_openshift-immutable/src/main/asciidoc/main.adoc
+++ b/docs/product-assembly_openshift-immutable/src/main/asciidoc/main.adoc
@@ -34,5 +34,7 @@ include::product-assembly_pam-on-openshift/environment-immutable-monitoring-proc
 include::product-assembly_pam-on-openshift/environment-immutable-source-extract-proc.adoc[leveloffset=+2]
 include::product-assembly_pam-on-openshift/environment-immutable-server-proc.adoc[leveloffset=+2]
 include::product-assembly_pam-on-openshift/environment-immutable-modify-proc.adoc[leveloffset=+2]
+include::product-assembly_pam-on-openshift/externaldb-build-proc.adoc[leveloffset=+2]
+
 // Versioning info
 include::product-shared-docs/versioning-information.adoc[]

--- a/docs/product-assembly_openshift-immutable/src/main/asciidoc/main.adoc
+++ b/docs/product-assembly_openshift-immutable/src/main/asciidoc/main.adoc
@@ -1,4 +1,4 @@
-[id='assembly_dm-7.0-release-notes']
+[id='assembly_openshift-immutable]
 
 include::product-shared-docs/document-attributes.adoc[]
 
@@ -21,7 +21,7 @@ to add and update processes.
 * You have logged in to the project using the OpenShift web console and using the `oc` command.
 * If you intend to scale any of the {CENTRAL} or {CENTRAL} Monitoring pods, your OpenShift environment supports persistent volumes with ReadWriteMany mode.
 +
-IMPORTANT: ReadWriteMany mode is not supported on OpenShift Online and OpenShift Dedicated.   
+IMPORTANT: ReadWriteMany mode is not supported on OpenShift Online and OpenShift Dedicated.
 
 include::product-assembly_pam-on-openshift/ba-openshift-overview-con.adoc[leveloffset=+1]
 include::product-assembly_dm-on-openshift/dm-openshift-prepare-con.adoc[leveloffset=+1]

--- a/docs/product-assembly_openshift-managed/src/main/asciidoc/main.adoc
+++ b/docs/product-assembly_openshift-managed/src/main/asciidoc/main.adoc
@@ -32,5 +32,7 @@ include::product-assembly_pam-on-openshift/glusterfs-reconfig-proc.adoc[leveloff
 include::product-assembly_pam-on-openshift/environment-managed-con.adoc[leveloffset=+1]
 include::product-assembly_pam-on-openshift/environment-managed-deploy-proc.adoc[leveloffset=+2]
 include::product-assembly_pam-on-openshift/environment-managed-modify-proc.adoc[leveloffset=+2]
+include::product-assembly_pam-on-openshift/externaldb-build-proc.adoc[leveloffset=+2]
+
 // Versioning info
 include::product-shared-docs/versioning-information.adoc[]

--- a/docs/product-assembly_openshift-managed/src/main/asciidoc/main.adoc
+++ b/docs/product-assembly_openshift-managed/src/main/asciidoc/main.adoc
@@ -1,4 +1,4 @@
-[id='assembly_dm-7.0-release-notes']
+[id='assembly_openshift-managed]
 
 include::product-shared-docs/document-attributes.adoc[]
 
@@ -9,8 +9,8 @@ include::product-shared-docs/document-attributes.adoc[]
 include::product-shared-docs/author-group.adoc[]
 
 // Purpose statement for the assembly
-As a system engineer, you can deploy a {PRODUCT} managed server environment on {OPENSHIFT} 
-to provide an infrastructure to execute processes and other business assets. You can use 
+As a system engineer, you can deploy a {PRODUCT} managed server environment on {OPENSHIFT}
+to provide an infrastructure to execute processes and other business assets. You can use
 {CENTRAL} Monitoring to manage and update the processes running on {KIE_SERVERS} in this environment.
 
 .Prerequisites
@@ -20,7 +20,7 @@ to provide an infrastructure to execute processes and other business assets. You
 * You have logged in to the project using the OpenShift web console and using the `oc` command.
 * If you intend to scale any of the {CENTRAL} or {CENTRAL} Monitoring pods, your OpenShift environment supports persistent volumes with ReadWriteMany mode.
 +
-IMPORTANT: ReadWriteMany mode is not supported on OpenShift Online and OpenShift Dedicated.   
+IMPORTANT: ReadWriteMany mode is not supported on OpenShift Online and OpenShift Dedicated.
 
 
 include::product-assembly_pam-on-openshift/ba-openshift-overview-con.adoc[leveloffset=+1]

--- a/docs/product-assembly_pam-on-openshift/src/main/asciidoc/environment-authoring-ha-modify-proc.adoc
+++ b/docs/product-assembly_pam-on-openshift/src/main/asciidoc/environment-authoring-ha-modify-proc.adoc
@@ -27,7 +27,7 @@ Edit the `rhpam70-authoring-ha.yaml` template file to make any of the following 
 ** `MySQL deployment config`
 ** `MySQL persistent volume claim`
 
-NOTE: The standard {KIE_SERVER} image includes drivers for MySQL and PostgreSQL external database servers.
+IMPORTANT: The standard {KIE_SERVER} image includes drivers for MySQL and PostgreSQL external database servers. If you want to use another database server, you must build a custom {KIE_SERVER} image. For instructions, see <<externaldb-build-proc>>.
 
 * If you want to change the number of replicas initially created for {CENTRAL}, on the line below the comment `## Replicas for Business Central`, change the number of replicas to the desired value.
 

--- a/docs/product-assembly_pam-on-openshift/src/main/asciidoc/environment-authoring-ha-proc.adoc
+++ b/docs/product-assembly_pam-on-openshift/src/main/asciidoc/environment-authoring-ha-proc.adoc
@@ -43,6 +43,7 @@ If you want to place the built KJAR files into an external Maven repository, set
 ** *Maven repository username* (`MAVEN_REPO_USERNAME`): The username for the Maven repository. 
 ** *Maven repository password* (`MAVEN_REPO_PASSWORD`): The username for the Maven repository. 
 +
+include::externaldb-params.adoc[]
 . Complete the creation of the environment, depending on the method that you are using:
 * In the OpenShift Web UI, click *Create*.
 * Complete and run the command line.

--- a/docs/product-assembly_pam-on-openshift/src/main/asciidoc/environment-authoring-single-modify-proc.adoc
+++ b/docs/product-assembly_pam-on-openshift/src/main/asciidoc/environment-authoring-single-modify-proc.adoc
@@ -34,4 +34,4 @@ Edit the `rhpam70-authoring.yaml` template file to make any of the following cha
 ** `H2 volume mount`
 ** `H2 volume settings`
 
-NOTE: The standard {KIE_SERVER} image includes drivers for MySQL and PostgreSQL external database servers.
+IMPORTANT: The standard {KIE_SERVER} image includes drivers for MySQL and PostgreSQL external database servers. If you want to use another database server, you must build a custom {KIE_SERVER} image. For instructions, see <<externaldb-build-proc>>.

--- a/docs/product-assembly_pam-on-openshift/src/main/asciidoc/environment-authoring-single-proc.adoc
+++ b/docs/product-assembly_pam-on-openshift/src/main/asciidoc/environment-authoring-single-proc.adoc
@@ -42,6 +42,7 @@ If you want to place the built KJAR files into an external Maven repository, set
 ** *Maven repository username* (`MAVEN_REPO_USERNAME`): The username for the Maven repository. 
 ** *Maven repository password* (`MAVEN_REPO_PASSWORD`): The username for the Maven repository. 
 +
+include::externaldb-params.adoc[]
 . Complete the creation of the environment, depending on the method that you are using:
 * In the OpenShift Web UI, click *Create*.
 * Complete and run the command line.

--- a/docs/product-assembly_pam-on-openshift/src/main/asciidoc/environment-immutable-modify-proc.adoc
+++ b/docs/product-assembly_pam-on-openshift/src/main/asciidoc/environment-immutable-modify-proc.adoc
@@ -23,4 +23,4 @@ include::modifytemplate-intro.adoc[]
 ** `PostgreSQL deployment config`
 ** `PostgreSQL persistent volume claim`
 
-NOTE: The standard {KIE_SERVER} image includes drivers for MySQL and PostgreSQL external database servers.
+IMPORTANT: The standard {KIE_SERVER} image includes drivers for MySQL and PostgreSQL external database servers. If you want to use another database server, you must build a custom {KIE_SERVER} image. For instructions, see <<externaldb-build-proc>>.

--- a/docs/product-assembly_pam-on-openshift/src/main/asciidoc/environment-immutable-server-proc.adoc
+++ b/docs/product-assembly_pam-on-openshift/src/main/asciidoc/environment-immutable-server-proc.adoc
@@ -47,6 +47,7 @@ Alternatively, if you have deployed the monitoring infrastructure (see <<environ
 + 
 . If you want to use {Central} Monitoring or Smart Router, set the parameters that were displayed in the sample command line after you deployed the monitoring infrastructure (see <<environment-immutable-monitoring-proc>>).
 +
+include::externaldb-params.adoc[]
 . Complete the creation of the environment, depending on the method that you are using:
 * In the OpenShift Web UI, click *Create*.
 * Complete and run the command line.

--- a/docs/product-assembly_pam-on-openshift/src/main/asciidoc/environment-managed-deploy-proc.adoc
+++ b/docs/product-assembly_pam-on-openshift/src/main/asciidoc/environment-managed-deploy-proc.adoc
@@ -43,6 +43,8 @@ In this command line:
 You can also set the following user names and passwords:
 ** *KIE Admin User* (`KIE_ADMIN_USER`) and *KIE Admin Password* (`KIE_ADMIN_PWD`): The user name and password for the administrative user in {CENTRAL} Monitoring.
 ** *KIE Server User* (`KIE_SERVER_USER`) and *KIE Server Password* (`KIE_SERVER_PWD`): The user name and password that a client application must use to connect to any of the {KIE_SERVERS}.
++
+include::externaldb-params.adoc[]
 . Complete the creation of the environment. Depending on the method that you are using:
 * In the OpenShift Web UI, click *Create*.
 * Complete and run the command line.

--- a/docs/product-assembly_pam-on-openshift/src/main/asciidoc/environment-managed-modify-proc.adoc
+++ b/docs/product-assembly_pam-on-openshift/src/main/asciidoc/environment-managed-modify-proc.adoc
@@ -57,7 +57,7 @@ Repeat the following actions for every replicated {KIE_SERVER} pod number, for e
 **** `RHPAM_SERVICE_HOST`: The host name of the database server
 **** `RHPAM_DATABASE`: The database name
 
-NOTE: The standard {KIE_SERVER} image includes drivers for MySQL and PostgreSQL external database servers.
+IMPORTANT: The standard {KIE_SERVER} image includes drivers for MySQL and PostgreSQL external database servers. If you want to use another database server, you must build a custom {KIE_SERVER} image. For instructions, see <<externaldb-build-proc>>.
 
 * If you want to change the number of replicas initially created for {CENTRAL} Monitoring, on the line below the comment `## Replicas for Business Central Monitoring`, change the number of replicas to the desired value.
 

--- a/docs/product-assembly_pam-on-openshift/src/main/asciidoc/externaldb-build-proc.adoc
+++ b/docs/product-assembly_pam-on-openshift/src/main/asciidoc/externaldb-build-proc.adoc
@@ -10,22 +10,21 @@ You can use this build procedure to provide drivers for the following database s
 * IBM DB2
 * Oracle Database
 * Sybase
-* Apache Derby
 
 For the tested versions of the database servers, see https://access.redhat.com/articles/3405381#TestedConfigurations70[Red Hat Process Automation Manager 7 Supported Configurations].
 
 The build procedure creates a custom image that extends the existing {KIE_SERVER} image. It pushes this custom image into a new `ImageStream` in the `openshift` namespace with the same version tag as the original image.
 
 .Prerequisites
-. You have logged on to your project in the OpenShift environment using the `oc` command as a user with the `cluster-admin` role.
-. For IBM DB2, Oracle Database, or Sybase, you have downloaded the JDBC driver from the database server vendor.
+* You have logged on to your project in the OpenShift environment using the `oc` command as a user with the `cluster-admin` role.
+* For IBM DB2, Oracle Database, or Sybase, you have downloaded the JDBC driver from the database server vendor.
 
 .Procedure
 . For IBM DB2, Oracle Database, or Sybase, provide the JDBC driver JAR in a local directory or on an HTTP server. Within the local directory or HTTP server, the following paths are expected:
 +
 ** For IBM DB2, `<local_path_or_url>/com/ibm/db2/jcc/db2jcc4/10.5/db2jcc4-10.5.jar`
 ** For Oracle Database, `<local_path_or_url>/com/oracle/ojdbc7/12.1.0.1/ojdbc7-12.1.0.1.jar`
-** for Sybase, `<local_path_or_url>/com/sysbase/jconn4/16.0_PL05/jconn4-16.0_PL05.jar`
+** For Sybase, `<local_path_or_url>/com/sysbase/jconn4/16.0_PL05/jconn4-16.0_PL05.jar`
 +
 Where `<local_path_or_url>` is the path to the local directory or the URL for the HTTP server where the driver is provided.
 +
@@ -37,11 +36,10 @@ Where `<local_path_or_url>` is the path to the local directory or the URL for th
 ** For IBM DB2, `db2-driver-image`
 ** For Oracle Database, `oracle-driver-image`
 ** For Sybase, `sybase-driver-image`
-** For Apache Derby, `derby-driver-image`
 +
 . Run the following command:
 + 
-** For Microsoft SQL Server, MariaDB, or Apache Derby:
+** For Microsoft SQL Server or MariaDB:
 +
 [subs="verbatim,macros"]
 ----

--- a/docs/product-assembly_pam-on-openshift/src/main/asciidoc/externaldb-build-proc.adoc
+++ b/docs/product-assembly_pam-on-openshift/src/main/asciidoc/externaldb-build-proc.adoc
@@ -1,7 +1,7 @@
 [id='externaldb-build-proc']
 = Building a custom {KIE_SERVER} image for an external database
 
-If you want to use an external database server for a {KIE_SERVER} and this server is not MySQL nor PostgreSQL, you must build a custom {KIE_SERVER} image with drivers for this server before deploying your environment.
+If you want to use an external database server for a {KIE_SERVER} and this server is neither MySQL nor PostgreSQL, you must build a custom {KIE_SERVER} image with drivers for this server before deploying your environment.
 
 You can use this build procedure to provide drivers for the following database servers:
 
@@ -10,11 +10,14 @@ You can use this build procedure to provide drivers for the following database s
 * IBM DB2
 * Oracle Database
 * Sybase
+* Apache Derby
 
-For the supported versions of the database servers, see https://access.redhat.com/articles/3405381#TestedConfigurations70[Red Hat Process Automation Manager 7 Supported Configurations].
+For the tested versions of the database servers, see https://access.redhat.com/articles/3405381#TestedConfigurations70[Red Hat Process Automation Manager 7 Supported Configurations].
+
+The build procedure creates a custom image that extends the existing {KIE_SERVER} image. It pushes this custom image into a new `ImageStream` in the `openshift` namespace with the same version tag as the original image.
 
 .Prerequisites
-. You have logged on to your project in the OpenShift environment using the `oc` command.
+. You have logged on to your project in the OpenShift environment using the `oc` command as a user with the `cluster-admin` role.
 . For IBM DB2, Oracle Database, or Sybase, you have downloaded the JDBC driver from the database server vendor.
 
 .Procedure
@@ -34,10 +37,11 @@ Where `<local_path_or_url>` is the path to the local directory or the URL for th
 ** For IBM DB2, `db2-driver-image`
 ** For Oracle Database, `oracle-driver-image`
 ** For Sybase, `sybase-driver-image`
+** For Apache Derby, `derby-driver-image`
 +
 . Run the following command:
 + 
-** For Microsoft SQL Server or MariaDB:
+** For Microsoft SQL Server, MariaDB, or Apache Derby:
 +
 [subs="verbatim,macros"]
 ----
@@ -57,5 +61,3 @@ Where `<local_path_or_url>` is the path to the local directory or the URL for th
 ../build.sh --artifact-repo=/home/builder/drivers
 ../build.sh --artifact-repo=http://nexus.example.com/nexus/content/groups/public
 ----
-
-

--- a/docs/product-assembly_pam-on-openshift/src/main/asciidoc/externaldb-build-proc.adoc
+++ b/docs/product-assembly_pam-on-openshift/src/main/asciidoc/externaldb-build-proc.adoc
@@ -1,0 +1,61 @@
+[id='externaldb-build-proc']
+= Building a custom {KIE_SERVER} image for an external database
+
+If you want to use an external database server for a {KIE_SERVER} and this server is not MySQL nor PostgreSQL, you must build a custom {KIE_SERVER} image with drivers for this server before deploying your environment.
+
+You can use this build procedure to provide drivers for the following database servers:
+
+* Microsoft SQL Server
+* MariaDB
+* IBM DB2
+* Oracle Database
+* Sybase
+
+For the supported versions of the database servers, see https://access.redhat.com/articles/3405381#TestedConfigurations70[Red Hat Process Automation Manager 7 Supported Configurations].
+
+.Prerequisites
+. You have logged on to your project in the OpenShift environment using the `oc` command.
+. For IBM DB2, Oracle Database, or Sybase, you have downloaded the JDBC driver from the database server vendor.
+
+.Procedure
+. For IBM DB2, Oracle Database, or Sybase, provide the JDBC driver JAR in a local directory or on an HTTP server. Within the local directory or HTTP server, the following paths are expected:
++
+** For IBM DB2, `<local_path_or_url>/com/ibm/db2/jcc/db2jcc4/10.5/db2jcc4-10.5.jar`
+** For Oracle Database, `<local_path_or_url>/com/oracle/ojdbc7/12.1.0.1/ojdbc7-12.1.0.1.jar`
+** for Sybase, `<local_path_or_url>/com/sysbase/jconn4/16.0_PL05/jconn4-16.0_PL05.jar`
++
+Where `<local_path_or_url>` is the path to the local directory or the URL for the HTTP server where the driver is provided.
++
+. To install the source code for the custom build, download the `rhpam-7.0.0.GA-openshift-templates.zip` product deliverable file from the https://access.redhat.com/jbossnetwork/restricted/listSoftware.html[Software Downloads] page for {PRODUCT} {PRODUCT_VERSION}. Unzip the file and, using the command line, change to the `templates/contrib/jdbc` directory of the unzipped file.
+. Change to the following subdirectory:
++
+** For Microsoft SQL Server, `mssql-driver-image`
+** For MariaDB, `mariadb-driver-image`
+** For IBM DB2, `db2-driver-image`
+** For Oracle Database, `oracle-driver-image`
+** For Sybase, `sybase-driver-image`
++
+. Run the following command:
++ 
+** For Microsoft SQL Server or MariaDB:
++
+[subs="verbatim,macros"]
+----
+../build.sh
+----
++
+** For IBM DB2, Oracle Database, or Sybase:
++
+[subs="verbatim,macros"]
+----
+../build.sh --artifact-repo=<local_path_or_url>
+----
++
+Where `<local_path_or_url>` is the path to the local directory or the URL for the HTTP server where the driver is provided. For example:
++
+----
+../build.sh --artifact-repo=/home/builder/drivers
+../build.sh --artifact-repo=http://nexus.example.com/nexus/content/groups/public
+----
+
+

--- a/docs/product-assembly_pam-on-openshift/src/main/asciidoc/externaldb-build-proc.adoc
+++ b/docs/product-assembly_pam-on-openshift/src/main/asciidoc/externaldb-build-proc.adoc
@@ -28,7 +28,7 @@ The build procedure creates a custom image that extends the existing {KIE_SERVER
 +
 Where `<local_path_or_url>` is the path to the local directory or the URL for the HTTP server where the driver is provided.
 +
-. To install the source code for the custom build, download the `rhpam-7.0.0.GA-openshift-templates.zip` product deliverable file from the https://access.redhat.com/jbossnetwork/restricted/listSoftware.html[Software Downloads] page for {PRODUCT} {PRODUCT_VERSION}. Unzip the file and, using the command line, change to the `templates/contrib/jdbc` directory of the unzipped file.
+. To install the source code for the custom build, download the `{PRODUCT_FILE}-openshift-templates.zip` product deliverable file from the https://access.redhat.com/jbossnetwork/restricted/listSoftware.html[Software Downloads] page for {PRODUCT} {PRODUCT_VERSION}. Unzip the file and, using the command line, change to the `templates/contrib/jdbc` directory of the unzipped file.
 . Change to the following subdirectory:
 +
 ** For Microsoft SQL Server, `mssql-driver-image`

--- a/docs/product-assembly_pam-on-openshift/src/main/asciidoc/externaldb-build-proc.adoc
+++ b/docs/product-assembly_pam-on-openshift/src/main/asciidoc/externaldb-build-proc.adoc
@@ -38,24 +38,35 @@ Where `<local_path_or_url>` is the path to the local directory or the URL for th
 ** For Sybase, `sybase-driver-image`
 +
 . Run the following command:
-+ 
-** For Microsoft SQL Server or MariaDB:
 +
+--
+** For Microsoft SQL Server or MariaDB:
+
 [subs="verbatim,macros"]
 ----
 ../build.sh
 ----
-+
+
 ** For IBM DB2, Oracle Database, or Sybase:
-+
+
 [subs="verbatim,macros"]
 ----
 ../build.sh --artifact-repo=<local_path_or_url>
 ----
-+
+
 Where `<local_path_or_url>` is the path to the local directory or the URL for the HTTP server where the driver is provided. For example:
-+
+
 ----
 ../build.sh --artifact-repo=/home/builder/drivers
 ../build.sh --artifact-repo=http://nexus.example.com/nexus/content/groups/public
 ----
+
+If you want to configure your OpenShift docker registry address in the process, add also the `--registry=<registry_name.domain_name:port>` parameter to your build command.
+
+Examples:
+----
+../build.sh --registry=docker-registry.custom-domain:80
+
+../build.sh --artifact-repo=/home/builder/drivers --registry=docker-registry.custom-domain:80
+----
+--

--- a/docs/product-assembly_pam-on-openshift/src/main/asciidoc/externaldb-params.adoc
+++ b/docs/product-assembly_pam-on-openshift/src/main/asciidoc/externaldb-params.adoc
@@ -1,0 +1,34 @@
+. If you modified the template to use an external database server for the {KIE_SERVER}, set the following parameters:
++
+** KIE Server External Database Driver (`KIE_SERVER_EXTERNALDB_DRIVER`): the driver for the server, depending on the server type:
++
+*** mysql
+*** postgresql
+*** mariadb
+*** mssql
+*** db2
+*** oracle
+*** sybase
++
+** KIE Server External Database User (`KIE_SERVER_EXTERNALDB_USER`) and KIE Server External Database Password (`KIE_SERVER_EXTERNALDB_PWD`): The user name and password for the external database server.
+** KIE Server External Database URL (`KIE_SERVER_EXTERNALDB_URL`): The JDBC URL for the external database server.
+** KIE Server External Database Dialect (`KIE_SERVER_EXTERNALDB_DIALECT`): The Hibernate dialect for the server, depending on the server type:
++
+*** org.hibernate.dialect.MySQL5Dialect (used for MySQL and MariaDB)
+*** org.hibernate.dialect.PostgreSQLDialect
+*** org.hibernate.dialect.SQLServer2008Dialect (used for MS SQL)
+*** org.hibernate.dialect.DB2Dialect
+*** org.hibernate.dialect.Oracle10gDialect
+*** org.hibernate.dialect.SybaseASE15Dialect
++
+** KIE Server External Database Host (`KIE_SERVER_EXTERNALDB_HOST`): The host name of the external database server.
+** KIE Server External Database name (`KIE_SERVER_EXTERNALDB_DB`): The database name to use on the external database server. 
++
+. If you created a custom image for using an external database server other than MySQL or PostgreSQL, as described in <<externaldb-build-proc>>, set the KIE Server Image Stream Name (`KIE_SERVER_IMAGE_STREAM_NAME`) parameter to the following value:
++
+** For Microsoft SQL Server, `rhpam70-kieserver-mssql-openshift`
+** For MariaDB, `rhpam70-kieserver-mariadb-openshift`
+** For IBM DB2, `rhpam70-kieserver-db2-openshift`
+** For Oracle Database, `rhpam70-kieserver-oracle-openshift`
+** For Sybase, `rhpam70-kieserver-sybase-openshift`
++

--- a/docs/product-assembly_pam-on-openshift/src/main/asciidoc/externaldb-params.adoc
+++ b/docs/product-assembly_pam-on-openshift/src/main/asciidoc/externaldb-params.adoc
@@ -9,6 +9,7 @@
 *** db2
 *** oracle
 *** sybase
+*** derby
 +
 ** KIE Server External Database User (`KIE_SERVER_EXTERNALDB_USER`) and KIE Server External Database Password (`KIE_SERVER_EXTERNALDB_PWD`): The user name and password for the external database server.
 ** KIE Server External Database URL (`KIE_SERVER_EXTERNALDB_URL`): The JDBC URL for the external database server.
@@ -16,10 +17,11 @@
 +
 *** org.hibernate.dialect.MySQL5Dialect (used for MySQL and MariaDB)
 *** org.hibernate.dialect.PostgreSQLDialect
-*** org.hibernate.dialect.SQLServer2008Dialect (used for MS SQL)
+*** org.hibernate.dialect.SQLServer2012Dialect (used for MS SQL)
 *** org.hibernate.dialect.DB2Dialect
-*** org.hibernate.dialect.Oracle10gDialect
+*** org.hibernate.dialect.Oracle12cDialect
 *** org.hibernate.dialect.SybaseASE15Dialect
+*** org.hibernate.dialect.DerbyTenSevenDialect
 +
 ** KIE Server External Database Host (`KIE_SERVER_EXTERNALDB_HOST`): The host name of the external database server.
 ** KIE Server External Database name (`KIE_SERVER_EXTERNALDB_DB`): The database name to use on the external database server. 
@@ -31,4 +33,5 @@
 ** For IBM DB2, `rhpam70-kieserver-db2-openshift`
 ** For Oracle Database, `rhpam70-kieserver-oracle-openshift`
 ** For Sybase, `rhpam70-kieserver-sybase-openshift`
+** For Apache Derby, `rhpam70-kieserver-derby-openshift`
 +

--- a/docs/product-assembly_pam-on-openshift/src/main/asciidoc/externaldb-params.adoc
+++ b/docs/product-assembly_pam-on-openshift/src/main/asciidoc/externaldb-params.adoc
@@ -1,6 +1,6 @@
 . If you modified the template to use an external database server for the {KIE_SERVER}, set the following parameters:
 +
-** KIE Server External Database Driver (`KIE_SERVER_EXTERNALDB_DRIVER`): the driver for the server, depending on the server type:
+** KIE Server External Database Driver (`KIE_SERVER_EXTERNALDB_DRIVER`): The driver for the server, depending on the server type:
 +
 *** mysql
 *** postgresql
@@ -9,19 +9,17 @@
 *** db2
 *** oracle
 *** sybase
-*** derby
 +
 ** KIE Server External Database User (`KIE_SERVER_EXTERNALDB_USER`) and KIE Server External Database Password (`KIE_SERVER_EXTERNALDB_PWD`): The user name and password for the external database server.
 ** KIE Server External Database URL (`KIE_SERVER_EXTERNALDB_URL`): The JDBC URL for the external database server.
 ** KIE Server External Database Dialect (`KIE_SERVER_EXTERNALDB_DIALECT`): The Hibernate dialect for the server, depending on the server type:
 +
-*** org.hibernate.dialect.MySQL5Dialect (used for MySQL and MariaDB)
-*** org.hibernate.dialect.PostgreSQLDialect
-*** org.hibernate.dialect.SQLServer2012Dialect (used for MS SQL)
-*** org.hibernate.dialect.DB2Dialect
-*** org.hibernate.dialect.Oracle12cDialect
-*** org.hibernate.dialect.SybaseASE15Dialect
-*** org.hibernate.dialect.DerbyTenSevenDialect
+*** `org.hibernate.dialect.MySQL5Dialect` (used for MySQL and MariaDB)
+*** `org.hibernate.dialect.PostgreSQLDialect` 
+*** `org.hibernate.dialect.SQLServer2012Dialect` (used for MS SQL)
+*** `org.hibernate.dialect.DB2Dialect`
+*** `org.hibernate.dialect.Oracle12cDialect`
+*** `org.hibernate.dialect.SybaseASE15Dialect`
 +
 ** KIE Server External Database Host (`KIE_SERVER_EXTERNALDB_HOST`): The host name of the external database server.
 ** KIE Server External Database name (`KIE_SERVER_EXTERNALDB_DB`): The database name to use on the external database server. 
@@ -33,5 +31,4 @@
 ** For IBM DB2, `rhpam70-kieserver-db2-openshift`
 ** For Oracle Database, `rhpam70-kieserver-oracle-openshift`
 ** For Sybase, `rhpam70-kieserver-sybase-openshift`
-** For Apache Derby, `rhpam70-kieserver-derby-openshift`
 +


### PR DESCRIPTION
Ready for upstream 7.7.x.

See [JIRA](https://issues.jboss.org/browse/BXMSDOC-2826) for details.