### PR TITLE
Replace tabs with whitespaces to fix rule indentation

### DIFF
--- a/docs/product-user-guide/src/main/asciidoc/guided-rule-templates-tables-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/guided-rule-templates-tables-proc.adoc
@@ -22,27 +22,27 @@ Example:
 [source,java]
 ----
 rule "PaymentRules_6"
-	dialect "mvel"
-	when
-		Customer( internetService == false ,
-			phoneService == false ,
-			TVService == true )
-	then
-		RecurringPayment fact0 = new RecurringPayment();
-		fact0.setAmount( 5 );
-		insertLogical( fact0 );
+    dialect "mvel"
+    when
+        Customer( internetService == false ,
+                  phoneService == false ,
+                  TVService == true )
+    then
+        RecurringPayment fact0 = new RecurringPayment();
+        fact0.setAmount( 5 );
+        insertLogical( fact0 );
 end
 
 rule "PaymentRules_5"
-	dialect "mvel"
-	when
-		Customer( internetService == false ,
-			phoneService == true ,
-			TVService == false )
-	then
-		RecurringPayment fact0 = new RecurringPayment();
-		fact0.setAmount( 5 );
-		insertLogical( fact0 );
+    dialect "mvel"
+    when
+    Customer( internetService == false ,
+              phoneService == true ,
+              TVService == false )
+    then
+    RecurringPayment fact0 = new RecurringPayment();
+    fact0.setAmount( 5 );
+    insertLogical( fact0 );
 end
 ...
 //Other rules omitted for brevity.


### PR DESCRIPTION
Hi @sterobin, during looking on [BXMSDOC-2962](https://issues.jboss.org/browse/BXMSDOC-2962), I notcied not ideal indentation in rule example shown below. I am trying to fix by this PR.

![screenshot from 2018-07-24 08-47-51](https://user-images.githubusercontent.com/8044780/43121971-cae3ce6c-8f1f-11e8-9282-22535627e3f0.png)


