### PR TITLE
[DROOLS-2805] Release notes for 7.9.0 Final are not linked correctly

### DIFF
--- a/docs/drools-docs/src/main/asciidoc/ReleaseNotes-chapter.adoc
+++ b/docs/drools-docs/src/main/asciidoc/ReleaseNotes-chapter.adoc
@@ -3,6 +3,8 @@
 = Release Notes
 :imagesdir: .
 
+include::ReleaseNotes/ReleaseNotesDrools.7.9.0.Final-section.adoc[leveloffset=+1]
+
 include::{shared-dir}/Workbench/ReleaseNotes/ReleaseNotesWorkbench.7.8.0.Final-section.adoc[leveloffset=+1]
 
 include::ReleaseNotes/ReleaseNotesDrools.7.7.0.Final-section.adoc[leveloffset=+1]

--- a/docs/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.7.9.0.Final-section.adoc
+++ b/docs/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.7.9.0.Final-section.adoc
@@ -1,5 +1,7 @@
-[[_wb.releasenotesworkbench.7.9.0.final]]
-= New and Noteworthy in KIE Workbench 7.9.0
+[[_drools.releasenotesdrools.7.9.0]]
+
+= What is New and Noteworthy in Drools 7.9
+:imagesdir: ..
 
 == Moved ExecutableCommand to KIE public API
 


### PR DESCRIPTION
Fix 7.9.0 Release notes of Drools

@mariofusco @kkufova 