### PR TITLE
Minor fix about timer migration restriction

### DIFF
--- a/doc-content/jbpm-docs/src/main/asciidoc/CoreEngine/Services-section.adoc
+++ b/doc-content/jbpm-docs/src/main/asciidoc/CoreEngine/Services-section.adoc
@@ -827,7 +827,7 @@ report.isSuccessful()
 
 * Adding a new task parallel to the single active task (all branches in AND gateway are not activated - process will stuck)
 
-* Changing or removing the active recurring timer events (won’t be changed in DB)
+* Removing the active timer events (won’t be changed in DB)
 
 * Fixing or updating inputs and outputs in an active task (task data aren’t migrated)
 


### PR DESCRIPTION
Since RHPAM-400 and RHPAM-1122,
- Changing active timers is possible as they are rescheduled
- Active recurring timers can be migrated
So remaining restriction is "Remove" only