### PR TITLE
[7.11.x] AF-1549: jdbc drivers should not be download by default

### DIFF
--- a/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/Authoring/DataSourceManagement/DataSourceManagement-section.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/Authoring/DataSourceManagement/DataSourceManagement-section.adoc
@@ -184,8 +184,8 @@ image::Workbench/Authoring/DataSourceManagement/DefaultDrivers.png[align="center
 
 [NOTE]
 ====
-The by default drivers initialization can be disabled by setting the datasource.management.disableDefaultDrivers configuration property to true.
-It can be set by configuring the proper value in the datasource-management.properties file, or by passing the system property  -Ddatasource.management.disableDefaultDrivers=true to the JVM.
+The default drivers initialization can be enabled by setting the datasource.management.disableDefaultDrivers configuration property to false.
+It can be set by configuring the proper value in the datasource-management.properties file, or by passing the system property  -Ddatasource.management.disableDefaultDrivers=false to the JVM.
 For more information see Advanced Settings.
 ====
 
@@ -227,8 +227,8 @@ The datasource.management.wildfly.xxxxx  properties are only suited for the Wild
 |see Advanced Settings.
 
 |datasource.management.disableDefaultDrivers
-|false
-|Set to true for disabling the by default database drivers initialization.
+|true
+|Set to false to enable the default database drivers initialization.
 
 |datasource.management.wildfly.host
 |localhost
@@ -286,8 +286,8 @@ Values configured by using this mechanism will override the values configured in
 |This is the only option available for Tomcat 8 distributions, see Advanced Settings.
 
 |datasource.management.disableDefaultDrivers
-|false
-|Set to true for disabling the by default database drivers initialization.
+|true
+|Set to false to enable the default database drivers initialization.
 
 |datasource.management.DefChangeHandler
 |


### PR DESCRIPTION
Part of an ensemble:
* https://github.com/kiegroup/kie-docs/pull/1056
* https://github.com/kiegroup/kie-wb-common/pull/2102

Cherry-picked from https://github.com/kiegroup/kie-docs/pull/1055