### PR TITLE
Upstream PR to master from BXMSDOC-minorFix-master Changing instance of  `process-admin` to `developer`

### DIFF
--- a/assemblies/assembly_managing-assets/main.adoc
+++ b/assemblies/assembly_managing-assets/main.adoc
@@ -16,7 +16,7 @@ As a process administrator, you can use {CENTRAL} in {PRODUCT} to manage assets,
 * {EAP_LONG} 7.1.0 is installed. For installation information, see the https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.1/html-single/installation_guide/[_Red Hat JBoss EAP 7.1.0 Installation Guide_].
 * {PRODUCT} is installed and configured with {KIE_SERVER}. For more information see {URL_INSTALLING_ON_EAP}[_{INSTALLING_ON_EAP}_].
 //xreflink
-* {PRODUCT} is running and you can log in to {CENTRAL} with the `process-admin` role. For more information, see {URL_PLANNING_INSTALL}[_{PLANNING_INSTALL}_].
+* {PRODUCT} is running and you can log in to {CENTRAL} with the `developer` role. For more information, see {URL_PLANNING_INSTALL}[_{PLANNING_INSTALL}_].
 
 
 // Modules - concepts, procedures, refs, etc.

--- a/assemblies/assembly_managing-projects/main.adoc
+++ b/assemblies/assembly_managing-projects/main.adoc
@@ -16,7 +16,7 @@ As a process administrator, you can use {CENTRAL} in {PRODUCT} to manage new, sa
 * {EAP_LONG} 7.1.0 is installed. For installation information, see the https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.1/html-single/installation_guide/[_Red Hat JBoss EAP 7.1.0 Installation Guide_].
 * {PRODUCT} is installed and configured with {KIE_SERVER}. For more information, see {URL_INSTALLING_ON_EAP}[_{INSTALLING_ON_EAP}_].
 //xreflink
-* {PRODUCT} is running and you can log in to {CENTRAL} with the `process-admin` role. For more information, see {URL_PLANNING_INSTALL}[_{PLANNING_INSTALL}_].
+* {PRODUCT} is running and you can log in to {CENTRAL} with the `developer` role. For more information, see {URL_PLANNING_INSTALL}[_{PLANNING_INSTALL}_].
 
 
 // Modules - concepts, procedures, refs, etc.


### PR DESCRIPTION
No Jira for this fix

Minor change to two main.adoc files. Changed role from `process-admin` to `developer` in both the Managing assets and Managing projects docs.