### PR TITLE
BusinessApplications: Add missing Keycloak class sample to Keycloak c…

### DIFF
--- a/doc-content/jbpm-docs/src/main/asciidoc/BusinessApplications/ConfigureApplication-section.adoc
+++ b/doc-content/jbpm-docs/src/main/asciidoc/BusinessApplications/ConfigureApplication-section.adoc
@@ -32,7 +32,7 @@ Authentication is enabled for single test user named `user` with password `user`
 Additionally there is default `kieserver` user that allows to easy connect to
 jBPM Console in development mode.
 
-Both authenitcation and authorization is based on Spring Security and can be
+Both authentication and authorization is based on Spring Security and can be
 configured in `DefaultWebSecurityConfig.java` that is included in the generated
 service project (`src/main/java/com/company/service/DefaultWebSecurityConfig.java`)
 
@@ -131,6 +131,61 @@ keycloak.resource=springboot-app
 keycloak.public-client=true
 keycloak.principal-attribute=preferred_username
 keycloak.enable-basic-auth=true
+----
+
+* Modify `DefaultWebSecurityConfig.java` to ensure that Spring Security will work correctly with Keycloak
+
+[source, java]
+----
+import org.keycloak.adapters.KeycloakConfigResolver;
+import org.keycloak.adapters.springboot.KeycloakSpringBootConfigResolver;
+import org.keycloak.adapters.springsecurity.authentication.KeycloakAuthenticationProvider;
+import org.keycloak.adapters.springsecurity.config.KeycloakWebSecurityConfigurerAdapter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.core.authority.mapping.SimpleAuthorityMapper;
+import org.springframework.security.core.session.SessionRegistryImpl;
+import org.springframework.security.web.authentication.session.RegisterSessionAuthenticationStrategy;
+import org.springframework.security.web.authentication.session.SessionAuthenticationStrategy;
+
+@Configuration("kieServerSecurity")
+@EnableWebSecurity
+public class DefaultWebSecurityConfig extends KeycloakWebSecurityConfigurerAdapter {
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        super.configure(http);
+        http
+        .csrf().disable()
+        .authorizeRequests()
+            .anyRequest().authenticated()
+            .and()
+        .httpBasic();
+    }
+
+    @Autowired
+    public void configureGlobal(AuthenticationManagerBuilder auth) throws Exception {
+        KeycloakAuthenticationProvider keycloakAuthenticationProvider = keycloakAuthenticationProvider();
+        SimpleAuthorityMapper mapper = new SimpleAuthorityMapper();
+        mapper.setPrefix("");
+        keycloakAuthenticationProvider.setGrantedAuthoritiesMapper(mapper);
+        auth.authenticationProvider(keycloakAuthenticationProvider);
+    }
+
+    @Bean
+    public KeycloakConfigResolver KeycloakConfigResolver() {
+       return new KeycloakSpringBootConfigResolver();
+    }
+
+    @Override
+    protected SessionAuthenticationStrategy sessionAuthenticationStrategy() {
+        return new RegisterSessionAuthenticationStrategy(new SessionRegistryImpl());
+    }
+}
 ----
 
 These are the steps to configure you business application to use Keycloak as


### PR DESCRIPTION
…onfiguration

@mswiderski 2 things have been done here:
* I have included basically KeycloakWebSecurityConfig from Keycloak sample app, but I left the name to be DefaultWebSecurityConfig so users don't have to rename the class.
* I have also noticed that in [KieServerApplication.java](https://github.com/kiegroup/droolsjbpm-integration/blob/f82b8010423b7a27356ba4a182cb748148eaf145/kie-spring-boot/kie-spring-boot-samples/keycloak-kie-server-spring-boot-sample/src/main/java/org/kie/server/springboot/samples/KieServerApplication.java#L55-L59) there is another bean declaration. So I added this in docs as well, but at the same time I found out that we already declare it in [JBPMAutoConfiguration.java](https://github.com/kiegroup/droolsjbpm-integration/blob/15b8555ccdd4dc1ef31d6fdc3c446dbf1f6259b4/kie-spring-boot/kie-spring-boot-autoconfiguration/jbpm-spring-boot-autoconfiguration/src/main/java/org/jbpm/springboot/autoconfigure/JBPMAutoConfiguration.java#L289-L293). So maybe the declaration in KieServerApplication.java is not needed at all?

@emmurphy1 this is the code snippet we discussed. Once this is merged it can go to the product docs as well.