### PR TITLE
[7.14.x] JBPM-7997: garbled message in start process form when OS locale is Japanese

### DIFF
--- a/doc-content/enterprise-only/admin-and-config/managing-business-central-githook-notifications-internationalize-con.adoc
+++ b/doc-content/enterprise-only/admin-and-config/managing-business-central-githook-notifications-internationalize-con.adoc
@@ -5,3 +5,9 @@ You can internationalize the notification messages by placing different `*.prope
 
 For example, you have specified the system property to point to `Messages.properties`. Now you can create localized message properties files like `Messages_en.properties` for English, `Messages_fr.properties` for French, `Messages_it.properties` for Italian, and so on. The notification service will choose the one based on the user language and if there are no available translations
 for a language then it will use the default ones specified in the `Messages.properties` file.
+
+[IMPORTANT]
+====
+The notification service only supports the `ISO 8859-1` (`LATIN 1`) character set in the `*.properties` file. If you want to
+use extended characters, please escape them using their Unicode code.
+====


### PR DESCRIPTION
Adding a note to regarding encodings

@ederign @gadeyredhat could you please take a look?

This is part of an ensemble, please merge with:
https://github.com/kiegroup/kie-wb-common/pull/2358
https://github.com/kiegroup/jbpm-wb/pull/1263
https://github.com/kiegroup/kie-docs/pull/1320