### PR TITLE
[AF-1775] SSH Ciphers and MAC configured via args on startup 

### DIFF
--- a/doc-content/enterprise-only/installation/install-standalone-properties-con.adoc
+++ b/doc-content/enterprise-only/installation/install-standalone-properties-con.adoc
@@ -27,8 +27,8 @@ If the default or assigned port is already in use, a new port is automatically s
 * `org.uberfire.nio.git.ssh.cert.dir`: Location of the `.security` directory where local certificates will be stored. Default: working directory
 * `org.uberfire.nio.git.ssh.passphrase`: Passphrase to access your operating system's public keystore when cloning Git repositories with SCP style URLs, for example `git@github.com:user/repository.git`.
 * `org.uberfire.nio.git.ssh.algorithm`: Algorithm used by SSH. Default: `RSA`
-* `org.uberfire.nio.git.ssh.ciphers`: The ciphers could be passed as a comma separated string, available values `aes128-ctr, aes192-ctr, aes256-ctr, arcfour128, arcfour256, aes192-cbc, aes256-cbc`, if the property isn't used all the ciphers availables are loaded.
-* `org.uberfire.nio.git.ssh.macs`: The macs could be passed as a comma separated string, available values `hmac-md5, hmac-md5-96, hmac-sha1, hmac-sha1-96, hmac-sha2-256, hmac-sha2-512`, if the property isn't used all the MACs availables are loaded.
+* `org.uberfire.nio.git.ssh.ciphers`: A comma-separated string of ciphers. The available ciphers are `aes128-ctr, aes192-ctr, aes256-ctr, arcfour128, arcfour256, aes192-cbc, aes256-cbc`. If the property is not used, all available ciphers are loaded.
+* `org.uberfire.nio.git.ssh.macs`: A comma-separated string of message authentication codes (MACs). The available MACs are `hmac-md5, hmac-md5-96, hmac-sha1, hmac-sha1-96, hmac-sha2-256, hmac-sha2-512`. If the property is not used, all available MACs are loaded.
 +
 [NOTE]
 ====

--- a/doc-content/enterprise-only/installation/install-standalone-properties-con.adoc
+++ b/doc-content/enterprise-only/installation/install-standalone-properties-con.adoc
@@ -27,8 +27,8 @@ If the default or assigned port is already in use, a new port is automatically s
 * `org.uberfire.nio.git.ssh.cert.dir`: Location of the `.security` directory where local certificates will be stored. Default: working directory
 * `org.uberfire.nio.git.ssh.passphrase`: Passphrase to access your operating system's public keystore when cloning Git repositories with SCP style URLs, for example `git@github.com:user/repository.git`.
 * `org.uberfire.nio.git.ssh.algorithm`: Algorithm used by SSH. Default: `RSA`
-* `org.uberfire.nio.git.ssh.ciphers`: A comma-separated string of ciphers. The available ciphers are `aes128-ctr, aes192-ctr, aes256-ctr, arcfour128, arcfour256, aes192-cbc, aes256-cbc`. If the property is not used, all available ciphers are loaded.
-* `org.uberfire.nio.git.ssh.macs`: A comma-separated string of message authentication codes (MACs). The available MACs are `hmac-md5, hmac-md5-96, hmac-sha1, hmac-sha1-96, hmac-sha2-256, hmac-sha2-512`. If the property is not used, all available MACs are loaded.
+* `org.uberfire.nio.git.ssh.ciphers`: A comma-separated string of ciphers. The available ciphers are `aes128-ctr`, `aes192-ctr`, `aes256-ctr`, `arcfour128`, `arcfour256`, `aes192-cbc`, `aes256-cbc`. If the property is not used, all available ciphers are loaded.
+* `org.uberfire.nio.git.ssh.macs`: A comma-separated string of message authentication codes (MACs). The available MACs are `hmac-md5`, `hmac-md5-96`, `hmac-sha1`, `hmac-sha1-96`, `hmac-sha2-256`, `hmac-sha2-512`. If the property is not used, all available MACs are loaded.
 +
 [NOTE]
 ====

--- a/doc-content/enterprise-only/installation/install-standalone-properties-con.adoc
+++ b/doc-content/enterprise-only/installation/install-standalone-properties-con.adoc
@@ -11,6 +11,7 @@
 * `org.uberfire.nio.git.daemon.enabled`: Enables or disables the Git daemon. Default: `true`
 * `org.uberfire.nio.git.daemon.host`: If the Git daemon is enabled, it uses this property as the local host identifier. Default: `localhost`
 * `org.uberfire.nio.git.daemon.port`: If the Git daemon is enabled, it uses this property for the port number. Default: `9418`
+
 +
 [NOTE]
 ====
@@ -27,6 +28,8 @@ If the default or assigned port is already in use, a new port is automatically s
 * `org.uberfire.nio.git.ssh.cert.dir`: Location of the `.security` directory where local certificates will be stored. Default: working directory
 * `org.uberfire.nio.git.ssh.passphrase`: Passphrase to access your operating system's public keystore when cloning Git repositories with SCP style URLs, for example `git@github.com:user/repository.git`.
 * `org.uberfire.nio.git.ssh.algorithm`: Algorithm used by SSH. Default: `RSA`
+* `org.uberfire.nio.git.ssh.cyphers`: The ciphers could be passed as a comma separated string, available values `aes128-ctr, aes192-ctr, aes256-ctr, arcfour128, arcfour256, aes192-cbc, aes256-cbc`.
+* `org.uberfire.nio.git.ssh.macs`: The macs could be passed as a comma separated string, available values `hmac-md5, hmac-md5-96, hmac-sha1, hmac-sha1-96, hmac-sha2-256, hmac-sha2-512`.
 +
 [NOTE]
 ====

--- a/doc-content/enterprise-only/installation/install-standalone-properties-con.adoc
+++ b/doc-content/enterprise-only/installation/install-standalone-properties-con.adoc
@@ -11,7 +11,6 @@
 * `org.uberfire.nio.git.daemon.enabled`: Enables or disables the Git daemon. Default: `true`
 * `org.uberfire.nio.git.daemon.host`: If the Git daemon is enabled, it uses this property as the local host identifier. Default: `localhost`
 * `org.uberfire.nio.git.daemon.port`: If the Git daemon is enabled, it uses this property for the port number. Default: `9418`
-
 +
 [NOTE]
 ====

--- a/doc-content/enterprise-only/installation/install-standalone-properties-con.adoc
+++ b/doc-content/enterprise-only/installation/install-standalone-properties-con.adoc
@@ -27,7 +27,7 @@ If the default or assigned port is already in use, a new port is automatically s
 * `org.uberfire.nio.git.ssh.cert.dir`: Location of the `.security` directory where local certificates will be stored. Default: working directory
 * `org.uberfire.nio.git.ssh.passphrase`: Passphrase to access your operating system's public keystore when cloning Git repositories with SCP style URLs, for example `git@github.com:user/repository.git`.
 * `org.uberfire.nio.git.ssh.algorithm`: Algorithm used by SSH. Default: `RSA`
-* `org.uberfire.nio.git.ssh.cyphers`: The ciphers could be passed as a comma separated string, available values `aes128-ctr, aes192-ctr, aes256-ctr, arcfour128, arcfour256, aes192-cbc, aes256-cbc`, if the property isn't used all the ciphers availables are loaded.
+* `org.uberfire.nio.git.ssh.ciphers`: The ciphers could be passed as a comma separated string, available values `aes128-ctr, aes192-ctr, aes256-ctr, arcfour128, arcfour256, aes192-cbc, aes256-cbc`, if the property isn't used all the ciphers availables are loaded.
 * `org.uberfire.nio.git.ssh.macs`: The macs could be passed as a comma separated string, available values `hmac-md5, hmac-md5-96, hmac-sha1, hmac-sha1-96, hmac-sha2-256, hmac-sha2-512`, if the property isn't used all the MACs availables are loaded.
 +
 [NOTE]

--- a/doc-content/enterprise-only/installation/install-standalone-properties-con.adoc
+++ b/doc-content/enterprise-only/installation/install-standalone-properties-con.adoc
@@ -27,8 +27,8 @@ If the default or assigned port is already in use, a new port is automatically s
 * `org.uberfire.nio.git.ssh.cert.dir`: Location of the `.security` directory where local certificates will be stored. Default: working directory
 * `org.uberfire.nio.git.ssh.passphrase`: Passphrase to access your operating system's public keystore when cloning Git repositories with SCP style URLs, for example `git@github.com:user/repository.git`.
 * `org.uberfire.nio.git.ssh.algorithm`: Algorithm used by SSH. Default: `RSA`
-* `org.uberfire.nio.git.ssh.cyphers`: The ciphers could be passed as a comma separated string, available values `aes128-ctr, aes192-ctr, aes256-ctr, arcfour128, arcfour256, aes192-cbc, aes256-cbc`.
-* `org.uberfire.nio.git.ssh.macs`: The macs could be passed as a comma separated string, available values `hmac-md5, hmac-md5-96, hmac-sha1, hmac-sha1-96, hmac-sha2-256, hmac-sha2-512`.
+* `org.uberfire.nio.git.ssh.cyphers`: The ciphers could be passed as a comma separated string, available values `aes128-ctr, aes192-ctr, aes256-ctr, arcfour128, arcfour256, aes192-cbc, aes256-cbc`, if the property isn't used all the ciphers availables are loaded.
+* `org.uberfire.nio.git.ssh.macs`: The macs could be passed as a comma separated string, available values `hmac-md5, hmac-md5-96, hmac-sha1, hmac-sha1-96, hmac-sha2-256, hmac-sha2-512`, if the property isn't used all the MACs availables are loaded.
 +
 [NOTE]
 ====

--- a/doc-content/enterprise-only/installation/run-standalone-properties-con.adoc
+++ b/doc-content/enterprise-only/installation/run-standalone-properties-con.adoc
@@ -35,8 +35,8 @@ If the default or assigned port is already in use, a new port is automatically s
 * `org.uberfire.nio.git.ssh.cert.dir`: Location of the `.security` directory where local certificates are stored. Default: the working directory.
 * `org.uberfire.nio.git.ssh.passphrase`: Pass phrase used to access the public key store of your operating system when cloning git repositories with SCP style URLs. Example: `git@github.com:user/repository.git`.
 * `org.uberfire.nio.git.ssh.algorithm`: Algorithm used by SSH. Default value: `RSA`.
-* `org.uberfire.nio.git.ssh.cyphers`: The ciphers could be passed as a comma separated string, available values `aes128-ctr, aes192-ctr, aes256-ctr, arcfour128, arcfour256, aes192-cbc, aes256-cbc`.
-* `org.uberfire.nio.git.ssh.macs`: The macs could be passed as a comma separated string, available values `hmac-md5, hmac-md5-96, hmac-sha1, hmac-sha1-96, hmac-sha2-256, hmac-sha2-512`.
+* `org.uberfire.nio.git.ssh.cyphers`: The ciphers could be passed as a comma separated string, available values `aes128-ctr, aes192-ctr, aes256-ctr, arcfour128, arcfour256, aes192-cbc, aes256-cbc`, if the property isn't used all the ciphers availables are loaded.
+* `org.uberfire.nio.git.ssh.macs`: The macs could be passed as a comma separated string, available values `hmac-md5, hmac-md5-96, hmac-sha1, hmac-sha1-96, hmac-sha2-256, hmac-sha2-512`, if the property isn't used all the MACs availables are loaded.
 +
 [NOTE]
 ====

--- a/doc-content/enterprise-only/installation/run-standalone-properties-con.adoc
+++ b/doc-content/enterprise-only/installation/run-standalone-properties-con.adoc
@@ -35,6 +35,8 @@ If the default or assigned port is already in use, a new port is automatically s
 * `org.uberfire.nio.git.ssh.cert.dir`: Location of the `.security` directory where local certificates are stored. Default: the working directory.
 * `org.uberfire.nio.git.ssh.passphrase`: Pass phrase used to access the public key store of your operating system when cloning git repositories with SCP style URLs. Example: `git@github.com:user/repository.git`.
 * `org.uberfire.nio.git.ssh.algorithm`: Algorithm used by SSH. Default value: `RSA`.
+* `org.uberfire.nio.git.ssh.cyphers`: The ciphers could be passed as a comma separated string, available values `aes128-ctr, aes192-ctr, aes256-ctr, arcfour128, arcfour256, aes192-cbc, aes256-cbc`.
+* `org.uberfire.nio.git.ssh.macs`: The macs could be passed as a comma separated string, available values `hmac-md5, hmac-md5-96, hmac-sha1, hmac-sha1-96, hmac-sha2-256, hmac-sha2-512`.
 +
 [NOTE]
 ====

--- a/doc-content/enterprise-only/installation/run-standalone-properties-con.adoc
+++ b/doc-content/enterprise-only/installation/run-standalone-properties-con.adoc
@@ -35,8 +35,8 @@ If the default or assigned port is already in use, a new port is automatically s
 * `org.uberfire.nio.git.ssh.cert.dir`: Location of the `.security` directory where local certificates are stored. Default: the working directory.
 * `org.uberfire.nio.git.ssh.passphrase`: Pass phrase used to access the public key store of your operating system when cloning git repositories with SCP style URLs. Example: `git@github.com:user/repository.git`.
 * `org.uberfire.nio.git.ssh.algorithm`: Algorithm used by SSH. Default value: `RSA`.
-* `org.uberfire.nio.git.ssh.cyphers`: The ciphers could be passed as a comma separated string, available values `aes128-ctr, aes192-ctr, aes256-ctr, arcfour128, arcfour256, aes192-cbc, aes256-cbc`, if the property isn't used all the ciphers availables are loaded.
-* `org.uberfire.nio.git.ssh.macs`: The macs could be passed as a comma separated string, available values `hmac-md5, hmac-md5-96, hmac-sha1, hmac-sha1-96, hmac-sha2-256, hmac-sha2-512`, if the property isn't used all the MACs availables are loaded.
+* `org.uberfire.nio.git.ssh.cyphers`: A comma-separated string of ciphers. The available ciphers are `aes128-ctr, aes192-ctr, aes256-ctr, arcfour128, arcfour256, aes192-cbc, aes256-cbc`. If the property is not used, all available ciphers are loaded.
+* `org.uberfire.nio.git.ssh.macs`: A comma-separated string of message authentication codes (MACs). The available MACs are `hmac-md5, hmac-md5-96, hmac-sha1, hmac-sha1-96, hmac-sha2-256, hmac-sha2-512`. If the property is not used, all available MACs are loaded.
 +
 [NOTE]
 ====

--- a/doc-content/enterprise-only/installation/run-standalone-properties-con.adoc
+++ b/doc-content/enterprise-only/installation/run-standalone-properties-con.adoc
@@ -35,8 +35,8 @@ If the default or assigned port is already in use, a new port is automatically s
 * `org.uberfire.nio.git.ssh.cert.dir`: Location of the `.security` directory where local certificates are stored. Default: the working directory.
 * `org.uberfire.nio.git.ssh.passphrase`: Pass phrase used to access the public key store of your operating system when cloning git repositories with SCP style URLs. Example: `git@github.com:user/repository.git`.
 * `org.uberfire.nio.git.ssh.algorithm`: Algorithm used by SSH. Default value: `RSA`.
-* `org.uberfire.nio.git.ssh.cyphers`: A comma-separated string of ciphers. The available ciphers are `aes128-ctr, aes192-ctr, aes256-ctr, arcfour128, arcfour256, aes192-cbc, aes256-cbc`. If the property is not used, all available ciphers are loaded.
-* `org.uberfire.nio.git.ssh.macs`: A comma-separated string of message authentication codes (MACs). The available MACs are `hmac-md5, hmac-md5-96, hmac-sha1, hmac-sha1-96, hmac-sha2-256, hmac-sha2-512`. If the property is not used, all available MACs are loaded.
+* `org.uberfire.nio.git.ssh.cyphers`: A comma-separated string of ciphers. The available ciphers are `aes128-ctr`, `aes192-ctr`, `aes256-ctr`, `arcfour128`, `arcfour256`, `aes192-cbc`, `aes256-cbc`. If the property is not used, all available ciphers are loaded.
+* `org.uberfire.nio.git.ssh.macs`: A comma-separated string of message authentication codes (MACs). The available MACs are `hmac-md5`, `hmac-md5-96`, `hmac-sha1`, `hmac-sha1-96`, `hmac-sha2-256`, `hmac-sha2-512`. If the property is not used, all available MACs are loaded.
 +
 [NOTE]
 ====

--- a/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/Installation/Installation-section.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/Installation/Installation-section.adoc
@@ -53,8 +53,8 @@ If the default or assigned port is already in use, a new port is automatically s
 * **``org.uberfire.nio.git.ssh.enabled``**: Enables/disables ssh daemon. Default: `true`
 * **``org.uberfire.nio.git.ssh.host``**: If ssh daemon enabled, uses this property as local host identifier. Default: `localhost`
 * **``org.uberfire.nio.git.ssh.port``**: If ssh daemon enabled, uses this property as port number. Default: `8001`
-* **``org.uberfire.nio.git.ssh.cyphers``**: The ciphers could be passed as a comma separated string, available values `aes128-ctr, aes192-ctr, aes256-ctr, arcfour128, arcfour256, aes192-cbc, aes256-cbc`
-* **``org.uberfire.nio.git.ssh.macs``**: The macs could be passed as a comma separated string, available values `hmac-md5, hmac-md5-96, hmac-sha1, hmac-sha1-96, hmac-sha2-256, hmac-sha2-512`
+* **``org.uberfire.nio.git.ssh.cyphers``**: The ciphers could be passed as a comma separated string, available values `aes128-ctr, aes192-ctr, aes256-ctr, arcfour128, arcfour256, aes192-cbc, aes256-cbc`, if the property isn't used all the ciphers availables are loaded.
+* **``org.uberfire.nio.git.ssh.macs``**: The macs could be passed as a comma separated string, available values `hmac-md5, hmac-md5-96, hmac-sha1, hmac-sha1-96, hmac-sha2-256, hmac-sha2-512`, if the property isn't used all the MACs availables are loaded.
 +
 
 [NOTE]

--- a/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/Installation/Installation-section.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/Installation/Installation-section.adoc
@@ -53,8 +53,8 @@ If the default or assigned port is already in use, a new port is automatically s
 * **``org.uberfire.nio.git.ssh.enabled``**: Enables/disables ssh daemon. Default: `true`
 * **``org.uberfire.nio.git.ssh.host``**: If ssh daemon enabled, uses this property as local host identifier. Default: `localhost`
 * **``org.uberfire.nio.git.ssh.port``**: If ssh daemon enabled, uses this property as port number. Default: `8001`
-* **``org.uberfire.nio.git.ssh.cyphers``**: A comma-separated string of ciphers. The available ciphers are `aes128-ctr, aes192-ctr, aes256-ctr, arcfour128, arcfour256, aes192-cbc, aes256-cbc`. If the property is not used, all available ciphers are loaded.
-* **``org.uberfire.nio.git.ssh.macs``**: A comma-separated string of message authentication codes (MACs). The available MACs are `hmac-md5, hmac-md5-96, hmac-sha1, hmac-sha1-96, hmac-sha2-256, hmac-sha2-512`. If the property is not used, all available MACs are loaded.
+* **``org.uberfire.nio.git.ssh.cyphers``**: A comma-separated string of ciphers. The available ciphers are `aes128-ctr`, `aes192-ctr`, `aes256-ctr`, `arcfour128`, `arcfour256`, `aes192-cbc`, `aes256-cbc`. If the property is not used, all available ciphers are loaded.
+* **``org.uberfire.nio.git.ssh.macs``**: A comma-separated string of message authentication codes (MACs). The available MACs are `hmac-md5`, `hmac-md5-96`, `hmac-sha1`, `hmac-sha1-96`, `hmac-sha2-256`, `hmac-sha2-512`. If the property is not used, all available MACs are loaded.
 +
 
 [NOTE]

--- a/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/Installation/Installation-section.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/Installation/Installation-section.adoc
@@ -53,6 +53,8 @@ If the default or assigned port is already in use, a new port is automatically s
 * **``org.uberfire.nio.git.ssh.enabled``**: Enables/disables ssh daemon. Default: `true`
 * **``org.uberfire.nio.git.ssh.host``**: If ssh daemon enabled, uses this property as local host identifier. Default: `localhost`
 * **``org.uberfire.nio.git.ssh.port``**: If ssh daemon enabled, uses this property as port number. Default: `8001`
+* **``org.uberfire.nio.git.ssh.cyphers``**: The ciphers could be passed as a comma separated string, available values `aes128-ctr, aes192-ctr, aes256-ctr, arcfour128, arcfour256, aes192-cbc, aes256-cbc`
+* **``org.uberfire.nio.git.ssh.macs``**: The macs could be passed as a comma separated string, available values `hmac-md5, hmac-md5-96, hmac-sha1, hmac-sha1-96, hmac-sha2-256, hmac-sha2-512`
 +
 
 [NOTE]

--- a/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/Installation/Installation-section.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/Installation/Installation-section.adoc
@@ -53,8 +53,8 @@ If the default or assigned port is already in use, a new port is automatically s
 * **``org.uberfire.nio.git.ssh.enabled``**: Enables/disables ssh daemon. Default: `true`
 * **``org.uberfire.nio.git.ssh.host``**: If ssh daemon enabled, uses this property as local host identifier. Default: `localhost`
 * **``org.uberfire.nio.git.ssh.port``**: If ssh daemon enabled, uses this property as port number. Default: `8001`
-* **``org.uberfire.nio.git.ssh.cyphers``**: The ciphers could be passed as a comma separated string, available values `aes128-ctr, aes192-ctr, aes256-ctr, arcfour128, arcfour256, aes192-cbc, aes256-cbc`, if the property isn't used all the ciphers availables are loaded.
-* **``org.uberfire.nio.git.ssh.macs``**: The macs could be passed as a comma separated string, available values `hmac-md5, hmac-md5-96, hmac-sha1, hmac-sha1-96, hmac-sha2-256, hmac-sha2-512`, if the property isn't used all the MACs availables are loaded.
+* **``org.uberfire.nio.git.ssh.cyphers``**: A comma-separated string of ciphers. The available ciphers are `aes128-ctr, aes192-ctr, aes256-ctr, arcfour128, arcfour256, aes192-cbc, aes256-cbc`. If the property is not used, all available ciphers are loaded.
+* **``org.uberfire.nio.git.ssh.macs``**: A comma-separated string of message authentication codes (MACs). The available MACs are `hmac-md5, hmac-md5-96, hmac-sha1, hmac-sha1-96, hmac-sha2-256, hmac-sha2-512`. If the property is not used, all available MACs are loaded.
 +
 
 [NOTE]


### PR DESCRIPTION
Description oforg.uberfire.nio.git.ssh.cyphers and 
org.uberfire.nio.git.ssh.macs

@porcelli @domhanak 

