### PR TITLE
BXMSDOC-1531-master: Added note in APIs doc about not using KIE Scanner with processes.

### DIFF
--- a/doc-content/shared-kie-docs/src/main/asciidoc/KieServer/kie-server-commands-samples-ref.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/KieServer/kie-server-commands-samples-ref.adoc
@@ -697,6 +697,8 @@ UpdateScannerCommand::
 --
 Starts or stops a KIE scanner that controls polling for updated KIE container deployments.
 
+NOTE: Avoid using a KIE scanner with business processes. Using a KIE scanner with processes can lead to unforeseen updates that can then cause errors in long-running processes when changes are not compatible with running process instances.
+
 .Command attributes
 [cols="30%,50%,20%", frame="all", options="header"]
 |===

--- a/doc-content/shared-kie-docs/src/main/asciidoc/KieServer/kie-server-rest-api-server-containers.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/KieServer/kie-server-rest-api-server-containers.adoc
@@ -905,7 +905,7 @@ Returns information about the KIE scanner used for automatic updates in a specif
 
 == [POST] /server/containers/{containerId}/scanner
 
-Starts or stops a KIE scanner that controls polling for updated KIE container deployments, if applicable.
+Starts or stops a KIE scanner that controls polling for updated KIE container deployments, if applicable. Avoid using a KIE scanner with business processes. Using a KIE scanner with processes can lead to unforeseen updates that can then cause errors in long-running processes when changes are not compatible with running process instances.
 
 .Request parameters
 [cols="25%,45%,15%,15%", frame="all", options="header"]


### PR DESCRIPTION
See [JIRA](https://issues.jboss.org/browse/BXMSDOC-1531) for details.