### PR TITLE
BXMSDOC-3875-master: Update doc attributes with correct DM-specific Central variables for file names and URL components.

### DIFF
--- a/_artifacts/document-attributes-dm.adoc
+++ b/_artifacts/document-attributes-dm.adoc
@@ -35,3 +35,8 @@
 :URL_COMPONENT_PLANNING_ENGINE: planner-engine
 
 :PRODUCT_DOWNLOAD_LINK: https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?downloadType=distributions&product=rhdm&productChanged=yes
+
+// Different in RHDM, and thus specified in each product attributes. The truly global CENTRAL attributes remain in document-attributes.adoc.
+:URL_COMPONENT_CENTRAL: decision-central
+:CENTRAL_CAPITAL_UNDER: DECISION_CENTRAL
+:CENTRAL_ONEWORD: decisioncentral

--- a/_artifacts/document-attributes-drools.adoc
+++ b/_artifacts/document-attributes-drools.adoc
@@ -35,3 +35,8 @@
 :URL_COMPONENT_DECISION_ENGINE: drools-engine
 :URL_COMPONENT_PROCESS_ENGINE: jbpm-engine
 :URL_COMPONENT_PLANNING_ENGINE: optaplanner-engine
+
+// Different in RHDM, and thus specified in each product attributes. The truly global CENTRAL attributes remain in document-attributes.adoc.
+:URL_COMPONENT_CENTRAL: business-central
+:CENTRAL_CAPITAL_UNDER: BUSINESS_CENTRAL
+:CENTRAL_ONEWORD: businesscentral

--- a/_artifacts/document-attributes-jbpm.adoc
+++ b/_artifacts/document-attributes-jbpm.adoc
@@ -37,3 +37,8 @@
 :URL_COMPONENT_DECISION_ENGINE: drools-engine
 :URL_COMPONENT_PROCESS_ENGINE: jbpm-engine
 :URL_COMPONENT_PLANNING_ENGINE: optaplanner-engine
+
+// Different in RHDM, and thus specified in each product attributes. The truly global CENTRAL attributes remain in document-attributes.adoc.
+:URL_COMPONENT_CENTRAL: business-central
+:CENTRAL_CAPITAL_UNDER: BUSINESS_CENTRAL
+:CENTRAL_ONEWORD: businesscentral

--- a/_artifacts/document-attributes-op.adoc
+++ b/_artifacts/document-attributes-op.adoc
@@ -36,3 +36,8 @@
 :URL_COMPONENT_DECISION_ENGINE: drools-engine
 :URL_COMPONENT_PROCESS_ENGINE: jbpm-engine
 :URL_COMPONENT_PLANNING_ENGINE: optaplanner-engine
+
+// Different in RHDM, and thus specified in each product attributes. The truly global CENTRAL attributes remain in document-attributes.adoc.
+:URL_COMPONENT_CENTRAL: business-central
+:CENTRAL_CAPITAL_UNDER: BUSINESS_CENTRAL
+:CENTRAL_ONEWORD: businesscentral

--- a/_artifacts/document-attributes-pam.adoc
+++ b/_artifacts/document-attributes-pam.adoc
@@ -35,3 +35,8 @@
 :URL_COMPONENT_PLANNING_ENGINE: planner-engine
 
 :PRODUCT_DOWNLOAD_LINK: https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?downloadType=distributions&product=rhpam&productChanged=yes
+
+// Different in RHDM, and thus specified in each product attributes. The truly global CENTRAL attributes remain in document-attributes.adoc.
+:URL_COMPONENT_CENTRAL: business-central
+:CENTRAL_CAPITAL_UNDER: BUSINESS_CENTRAL
+:CENTRAL_ONEWORD: businesscentral

--- a/_artifacts/document-attributes.adoc
+++ b/_artifacts/document-attributes.adoc
@@ -65,10 +65,7 @@ endif::OP[]
 
 // Component names
 :CENTRAL: Business Central
-:URL_COMPONENT_CENTRAL: business-central
 :URL_COMPONENT_CENTRAL_UNDER: business_central
-:CENTRAL_CAPITAL_UNDER: BUSINESS_CENTRAL
-:CENTRAL_ONEWORD: businesscentral
 :KIE_SERVER_PAM: Process Server
 :KIE_SERVER_DM: Decision Server
 :KIE_SERVER_PL: Planner Server


### PR DESCRIPTION
For RHDM, deliverables continue to be called decision-central, decisioncentral, etc., despite global change. So updating the previous global edit to doc variables in order to restore this.