### PR TITLE
Correct EAP URL versions from 7.3 to 7.2, change link titles to attributes, and update REBUILD variable

### DIFF
--- a/_artifacts/document-attributes.adoc
+++ b/_artifacts/document-attributes.adoc
@@ -1,5 +1,5 @@
 
-:REBUILT: Wednesday, February 6, 2019
+:REBUILT: Wednesday, March 27, 2019
 
 :ENTERPRISE_VERSION: 7.3
 :COMMUNITY_VERSION: 7.18

--- a/assemblies/assembly_case-management-getting-started/main.adoc
+++ b/assemblies/assembly_case-management-getting-started/main.adoc
@@ -15,7 +15,7 @@ As a business rules and processes developer, you can use case management assets 
 
 .Prerequisites
 
-* {EAP_LONG} {EAP_VERSION} is installed. For installation information, see https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.3/html-single/installation_guide/[_Red Hat JBoss EAP 7.3.0 Installation Guide_].
+* {EAP_LONG} {EAP_VERSION} is installed. For installation information, see https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.2/html-single/installation_guide/[_{EAP_LONG} {EAP_VERSION} Installation Guide_].
 * {PRODUCT} is installed and configured with {KIE_SERVER}. For more information see {URL_INSTALLING_ON_EAP}[_{INSTALLING_ON_EAP}_].
 //xreflink
 * {PRODUCT} is running and you can log in to {CENTRAL} with the `kie-server`, `user`, and `admin` roles.

--- a/assemblies/assembly_decision-manager/main.adoc
+++ b/assemblies/assembly_decision-manager/main.adoc
@@ -15,7 +15,7 @@ As a business rules developer, you can use {CENTRAL} in {PRODUCT} to design a va
 For more information about the DMN components and implementation in {PRODUCT}, see {URL_DMN_MODELS}[_{DMN_MODELS}_].
 
 .Prerequisites
-* {EAP_LONG} {EAP_VERSION} is installed. For installation information, see https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.2/html-single/installation_guide/[_Red Hat JBoss EAP 7.2.0 Installation Guide_].
+* {EAP_LONG} {EAP_VERSION} is installed. For installation information, see https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.2/html-single/installation_guide/[_{EAP_LONG} {EAP_VERSION} Installation Guide_].
 * {PRODUCT} is installed and configured with {KIE_SERVER}. For more information, see {URL_INSTALLING_ON_EAP}[_{INSTALLING_ON_EAP}_].
 //xreflink
 * {PRODUCT} is running and you can log in to {CENTRAL} with the `developer` role. For more information, see {URL_PLANNING_INSTALL}[_{PLANNING_INSTALL}_].

--- a/assemblies/assembly_decision-services-using-guided-rules/main.adoc
+++ b/assemblies/assembly_decision-services-using-guided-rules/main.adoc
@@ -15,7 +15,7 @@ As a business rules developer, you can use {CENTRAL} in {PRODUCT} to design a va
 This document focuses on how to create and test a new project in {CENTRAL} for an example traffic violation decision service.
 
 .Prerequisites
-* {EAP_LONG} {EAP_VERSION} is installed. For installation information, see https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.2/html-single/installation_guide/[_Red Hat JBoss EAP 7.2.0 Installation Guide_].
+* {EAP_LONG} {EAP_VERSION} is installed. For installation information, see https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.2/html-single/installation_guide/[_{EAP_LONG} {EAP_VERSION} Installation Guide_].
 * {PRODUCT} is installed and configured with {KIE_SERVER}. For more information, see {URL_INSTALLING_ON_EAP}[_{INSTALLING_ON_EAP}_].
 //xreflink
 * {PRODUCT} is running and you can log in to {CENTRAL} with the `developer` role. For more information, see {URL_PLANNING_INSTALL}[_{PLANNING_INSTALL}_].

--- a/assemblies/assembly_designing-and-building-cases/main.adoc
+++ b/assemblies/assembly_designing-and-building-cases/main.adoc
@@ -20,7 +20,7 @@ Case management differs from Business Process Management (BPM). It focuses more 
 The {URL_GETTING_STARTED_CASES}[_{GETTING_STARTED_CASES}_] tutorial describes how to create and test a new IT_Orders project in {CENTRAL}. After reviewing the concepts in this guide, follow the procedures in the tutorial to ensure that you are able to successfully create, deploy, and test your own case project.
 
 .Prerequisites
-* {EAP_LONG} {EAP_VERSION} is installed. For information about installing {EAP_LONG} {EAP_VERSION}, see https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.3/html-single/installation_guide/[_Red Hat JBoss EAP 7.3.0 Installation Guide_].
+* {EAP_LONG} {EAP_VERSION} is installed. For information about installing {EAP_LONG} {EAP_VERSION}, see https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.2/html-single/installation_guide/[_{EAP_LONG} {EAP_VERSION} Installation Guide_].
 * {PRODUCT} is installed. For information about installing {PRODUCT}, see {URL_PLANNING_INSTALL}[_{PLANNING_INSTALL}_].
 * {PRODUCT} is running and you can log in to {CENTRAL} with the `user` role. For information about users and permissions, see {URL_PLANNING_INSTALL}[_{PLANNING_INSTALL}_].
 * The Showcase application is deployed. For information about how to install and log in to the Showcase application, see {URL_SHOWCASE_APPLICATION_CASE_MANAGEMENT}[_{SHOWCASE_APPLICATION_CASE_MANAGEMENT}_].

--- a/assemblies/assembly_executing-processes/main.adoc
+++ b/assemblies/assembly_executing-processes/main.adoc
@@ -13,7 +13,7 @@ include::_artifacts/author-group.adoc[]
 As a business analyst or business rules developer, you can use {CENTRAL} to create forms for human tasks, providing a rich interface for collecting data. In this example, you will create a simple pizza order form that a customer (Bill) will complete and send to the pizza place. The pizza place employee (Katy) will process the order and send an order confirmation message containing the total cost for the order.
 
 .Prerequisites
-* {EAP_LONG} {EAP_VERSION} is installed. For details, see https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.2/html-single/installation_guide/[_Red Hat JBoss EAP 7.2.0 Installation Guide_].
+* {EAP_LONG} {EAP_VERSION} is installed. For details, see https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.2/html-single/installation_guide/[_{EAP_LONG} {EAP_VERSION} Installation Guide_].
 * {PRODUCT} is installed and the {KIE_SERVER} is configured. For more information, see {URL_INSTALLING_ON_EAP}[_{INSTALLING_ON_EAP}_].
 * {PRODUCT} is running and you can log in to {CENTRAL} with the `developer` role.
 

--- a/assemblies/assembly_managing-and-monitoring-business-processes/main.adoc
+++ b/assemblies/assembly_managing-and-monitoring-business-processes/main.adoc
@@ -13,7 +13,7 @@ include::_artifacts/author-group.adoc[]
 As a process administrator, you can use {CENTRAL} in {PRODUCT} to manage and monitor process instances and tasks running on a number of projects. From {CENTRAL} you can start a new process instance, verify the state of all process instances, and abort processes. You can view the list of jobs and tasks associated with your processes, as well as understand and communicate any process errors.
 
 .Prerequisites
-* {EAP_LONG} {EAP_VERSION} is installed. For more information, see  https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.2/html-single/installation_guide/[_{EAP} {EAP_VERSION} Installation Guide_].
+* {EAP_LONG} {EAP_VERSION} is installed. For more information, see  https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.2/html-single/installation_guide/[_{EAP_LONG} {EAP_VERSION} Installation Guide_].
 * {PRODUCT} is installed. For more information, see {URL_PLANNING_INSTALL}[_{PLANNING_INSTALL}_].
 * {PRODUCT} is running and you can log in to {CENTRAL} with the `process-admin` role. For more information, see {URL_PLANNING_INSTALL}[_{PLANNING_INSTALL}_].
 

--- a/assemblies/assembly_managing-and-monitoring-execution-server/main.adoc
+++ b/assemblies/assembly_managing-and-monitoring-execution-server/main.adoc
@@ -13,7 +13,7 @@ include::_artifacts/author-group.adoc[]
 As a systems administrator, you can install, configure, and upgrade {PRODUCT} for production environments, quickly and easily troubleshoot system failures, and ensure that systems are running optimally.
 
 .Prerequisites
-* {EAP_LONG} {EAP_VERSION_LONG} is installed. For more information, see  https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.2/html-single/installation_guide/[_{EAP} {EAP_VERSION} Installation Guide_].
+* {EAP_LONG} {EAP_VERSION_LONG} is installed. For more information, see  https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.2/html-single/installation_guide/[_{EAP_LONG} {EAP_VERSION} Installation Guide_].
 * {PRODUCT} is installed. For more information, see {URL_PLANNING_INSTALL}[_{PLANNING_INSTALL}_].
 * {PRODUCT} is running and you can log in to {CENTRAL} with the `admin` role. For more information, see {URL_PLANNING_INSTALL}[_{PLANNING_INSTALL}_].
 

--- a/assemblies/assembly_showcase-application/main.adoc
+++ b/assemblies/assembly_showcase-application/main.adoc
@@ -20,7 +20,7 @@ Use this document to install the Showcase application and start a case instance 
 
 .Prerequisites
 
-* {EAP_LONG} {EAP_VERSION} is installed. For installation information, see the https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.3/html-single/installation_guide/[_Red Hat JBoss EAP 7.3.0 Installation Guide_].
+* {EAP_LONG} {EAP_VERSION} is installed. For installation information, see the https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.2/html-single/installation_guide/[_{EAP_LONG} {EAP_VERSION} Installation Guide_].
 * {PRODUCT} is installed on {EAP} and configured with {KIE_SERVER}. For more information see {URL_INSTALLING_ON_EAP}[_{INSTALLING_ON_EAP}_].
 * `KieLoginModule` is configured in `standalone-full.xml`. This required to connect to the {KIE_SERVER}. For more information about configuring the {KIE_SERVER}, see {URL_PLANNING_INSTALL}[_{PLANNING_INSTALL}_].
 * {PRODUCT} is running and you can log in to {CENTRAL} with a user that has both `kie-server` and `user` roles. For more information about roles, see {URL_PLANNING_INSTALL}[_{PLANNING_INSTALL}_].


### PR DESCRIPTION
* Correct EAP URL versions from 7.3 to 7.2

* Change link titles to attributes

* Update REBUILD variable to Wednesday, March 27, 2019