### PR TITLE
[7.18.x] Remove step with uncommenting of <distributable> tag

### DIFF
--- a/doc-content/enterprise-only/installation/clustering-download-eap-bc-proc.adoc
+++ b/doc-content/enterprise-only/installation/clustering-download-eap-bc-proc.adoc
@@ -17,7 +17,6 @@ Download and install {EAP} 7.2 and {PRODUCT} {PRODUCT_VERSION} on each node of t
 * *Version: {PRODUCT_VERSION}*
 .. Download  *{PRODUCT} {PRODUCT_VERSION_LONG}* {CENTRAL} Deployable for {EAP} 7 (`{PRODUCT_INIT}-{PRODUCT_VERSION_LONG}-{URL_COMPONENT_CENTRAL}-eap7-deployable.zip`).
 . Extract the `{PRODUCT_INIT}-{PRODUCT_VERSION_LONG}-{URL_COMPONENT_CENTRAL}-eap7-deployable.zip` file to a temporary directory. In the following commands this directory is called `__TEMP_DIR__`.
-. Open the `_TEMP_DIR_/{PRODUCT_INIT}-{PRODUCT_VERSION_LONG}-{URL_COMPONENT_CENTRAL}-eap7-deployable/jboss-eap-7.2/standalone/deployments/{URL_COMPONENT_CENTRAL}.war/WEB-INF/web.xml/` file, uncomment the `<distributable/>` tag, and save the `web.xml` file.
 . Copy the contents of `_TEMP_DIR_/{PRODUCT_INIT}-{PRODUCT_VERSION_LONG}-{URL_COMPONENT_CENTRAL}-eap7-deployable/jboss-eap-7.2` to `_EAP_HOME_`.
 . Download and apply the latest {PRODUCT} patch, if available.
 . Navigate to the `__EAP_HOME__/bin` directory.


### PR DESCRIPTION
<distributable> tag should not be uncommented. We don't use the eap clustering.