### PR TITLE
Bxmsdoc 2274 7.18 Tomcat installation misses 'datadesignerobject' setting

### DIFF
--- a/doc-content/enterprise-only/installation/run-standalone-properties-con.adoc
+++ b/doc-content/enterprise-only/installation/run-standalone-properties-con.adoc
@@ -63,3 +63,6 @@ If you plan to use RSA or any algorithm other than DSA, make sure you set up you
 Use this property for {CENTRAL} only. If you share a runtime environment with any other component, isolate the configuration and apply it only to {CENTRAL}.
 ====
 * `org.uberfire.gzip.enable`: Enables or disables Gzip compression on GzipFilter. Default: `true`
+ifeval::["{context}" == "install-on-jws"]
+* `designerdataobjects`: Disables the data object functionality. Set the value of this parameter to `false`.
+endif::[]


### PR DESCRIPTION
BXMSDOC-2274 added Ddesignerdataobjects=false