### PR TITLE
BXMSDOC-2907-master: Add content about KIE repo cache settings in packaging doc.

### DIFF
--- a/doc-content/enterprise-only/project-data/project-kmodule-configure-proc.adoc
+++ b/doc-content/enterprise-only/project-data/project-kmodule-configure-proc.adoc
@@ -114,9 +114,22 @@ KieSession kieSession1 = kContainer.newKieSession(),
 KieBase kBase2 = kContainer.getKieBase();
 StatelessKieSession kieSession3 = kContainer.newStatelessKieSession();
 ----
+
+To increase or decrease the maximum number of KIE modules or artifact versions that are cached in the {DECISION_ENGINE}, you can modify the values of the following system properties in your {PRODUCT} distribution:
+
+* `kie.repository.project.cache.size`: Maximum number of KIE modules that are cached in the {DECISION_ENGINE}. Default value: `100`
+* `kie.repository.project.versions.cache.size`: Maximum number of versions of the same artifact that are cached in the {DECISION_ENGINE}. Default value: `10`
+
+For the full list of KIE repository configurations,
+ifdef::DM,PAM[]
+download the *{PRODUCT} [VERSION] Source Distribution* ZIP file from the https://access.redhat.com/jbossnetwork/restricted/listSoftware.html[Red Hat Customer Portal] and navigate to `~/{PRODUCT_FILE}-sources/src/drools-$VERSION/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieRepositoryImpl.java`.
+endif::[]
+ifdef::DROOLS,JBPM,OP[]
+see the {PRODUCT} https://github.com/kiegroup/drools/blob/master/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/KieRepositoryImpl.java[KieRepositoryImpl.java] page on GitHub.
+endif::[]
 --
 
-For more information about the `kmodule.xml` file, download the *{PRODUCT} [VERSION] Source Distribution* ZIP file from the https://access.redhat.com/jbossnetwork/restricted/listSoftware.html[Red Hat Customer Portal] and see the `kmodule.xsd` XML schema located at `$FILE_HOME/{PRODUCT_INIT}-$VERSION-sources/kie-api-parent-$VERSION/kie-api/src/main/resources/org/kie/api/`.
+For more information about the `kmodule.xml` file, download the *{PRODUCT} [VERSION] Source Distribution* ZIP file from the https://access.redhat.com/jbossnetwork/restricted/listSoftware.html[Red Hat Customer Portal] (if not downloaded already) and see the `kmodule.xsd` XML schema located at `$FILE_HOME/{PRODUCT_INIT}-$VERSION-sources/kie-api-parent-$VERSION/kie-api/src/main/resources/org/kie/api/`.
 
 ifdef::DM[]
 [NOTE]


### PR DESCRIPTION
See [JIRA](https://issues.jboss.org/browse/BXMSDOC-2907) for details.