### PR TITLE
BXMSDOC-3961-master: Add note about XStream issue on Java 11 for PMML.

### DIFF
--- a/doc-content/drools-docs/src/main/asciidoc/PMML/pmml-invocation-kie-server-proc.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/PMML/pmml-invocation-kie-server-proc.adoc
@@ -186,9 +186,9 @@ public class ApplyScorecardModel {
 . Execute the class instance to send the PMML invocation request to {KIE_SERVER}.
 +
 --
-Alternatively, you can use JMS and REST interfaces to send the `ApplyPmmlModelCommand` command to {KIE_SERVER}. For REST requests, you use the `ApplyPmmlModelCommand` command as a `POST` request to `\http://SERVER:PORT/kie-server/services/rest/server/containers/instances/{containerId}` in JAXB or JSON request format.
+Alternatively, you can use JMS and REST interfaces to send the `ApplyPmmlModelCommand` command to {KIE_SERVER}. For REST requests, you use the `ApplyPmmlModelCommand` command as a `POST` request to `\http://SERVER:PORT/kie-server/services/rest/server/containers/instances/{containerId}` in JSON, JAXB, or XStream request format.
 
-NOTE: XStream request format is currently not supported for PMML model execution in {KIE_SERVER}, but will be supported in a future release.
+NOTE: XStream request format for PMML model execution in {KIE_SERVER} is currently not supported with Java 11.
 
 .Example POST endpoint
 [source]


### PR DESCRIPTION
@lanceleverich, @jiripetrlik, can you please verify this small update to the PMML doc for 7.4? Per [RHDM-867](https://issues.jboss.org/browse/RHDM-867). This is the only required change for this doc, from our previous conversations.

Links:
* [Doc preview](http://file.rdu.redhat.com/~sterobin/BXMSDOC-3961_PAM/#pmml-invocation-kie-server-proc_pmml-models)
* [JIRA](https://issues.jboss.org/browse/BXMSDOC-3960)