### PR TITLE
BXMSDOC-4237-master: Updated community RN structure to accommodate single sourcing with enterprise.

### DIFF
--- a/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes-chapter.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes-chapter.adoc
@@ -1,6 +1,11 @@
+[id='droolsreleasenoteschapter']
 
-[[_droolsreleasenoteschapter]]
 = Release Notes
+
+//IMPORTANT: For 7.24 and later, use the following include format:
+//include::ReleaseNotes/ReleaseNotesDrools.7.24.0.Final/ReleaseNotesDrools.7.24.0.Final-section.adoc[leveloffset=+1]
+//include::{shared-dir}/Workbench/ReleaseNotes/ReleaseNotesWorkbench.7.24.0.Final/ReleaseNotesWorkbench.7.24.0.Final-section.adoc[leveloffset=+1]
+
 include::{shared-dir}/Workbench/ReleaseNotes/ReleaseNotesWorkbench.7.23.0.Final-section.adoc[leveloffset=+1]
 
 include::{shared-dir}/Workbench/ReleaseNotes/ReleaseNotesWorkbench.7.19.0.Final-section.adoc[leveloffset=+1]

--- a/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.6.0.0.Final-section.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.6.0.0.Final-section.adoc
@@ -1,5 +1,5 @@
 [[_drools.releasenotesdrools.6.0.0]]
-= What is New and Noteworthy in Drools 6.0.0
+= New and Noteworthy in Drools 6.0.0
 
 == PHREAK - Lazy rule matching algorithm
 

--- a/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.6.1.0.Final-section.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.6.1.0.Final-section.adoc
@@ -1,5 +1,5 @@
 [[_drools.releasenotesdrools.6.1.0]]
-= What is New and Noteworthy in Drools 6.1.0
+= New and Noteworthy in Drools 6.1.0
 
 == JMX support for KieScanner
 

--- a/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.6.2.0.Final-section.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.6.2.0.Final-section.adoc
@@ -1,5 +1,5 @@
 [[_drools.releasenotesdrools.6.2.0]]
-= What is New and Noteworthy in Drools 6.2.0
+= New and Noteworthy in Drools 6.2.0
 
 == Propagation modes
 

--- a/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.6.3.0.Final-section.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.6.3.0.Final-section.adoc
@@ -1,5 +1,5 @@
 [[_drools.releasenotesdrools.6.3.0]]
-= What is New and Noteworthy in Drools 6.3.0
+= New and Noteworthy in Drools 6.3.0
 
 == Browsing graphs of objects with OOPath
 

--- a/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.6.4.0.Final-section.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.6.4.0.Final-section.adoc
@@ -1,5 +1,5 @@
 [[_drools.releasenotesdrools.6.4.0]]
-= What is New and Noteworthy in Drools 6.4.0
+= New and Noteworthy in Drools 6.4.0
 
 == Better Java 8 compatibility
 

--- a/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.6.5.0.Final-section.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.6.5.0.Final-section.adoc
@@ -1,5 +1,5 @@
 [[_drools.releasenotesdrools.6.5.0]]
-= What is New and Noteworthy in Drools 6.5.0
+= New and Noteworthy in Drools 6.5.0
 
 == Configurable ThreadFactory
 

--- a/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.7.0.0.Final-section.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.7.0.0.Final-section.adoc
@@ -1,6 +1,6 @@
 [[_drools.releasenotesdrools.7.0.0]]
 
-= What is New and Noteworthy in Drools 7.0
+= New and Noteworthy in Drools 7.0
 
 == Core Engine
 

--- a/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.7.1.0.Final-section.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.7.1.0.Final-section.adoc
@@ -1,4 +1,4 @@
 [[_drools.releasenotesdrools.7.1.0]]
 
-= What is New and Noteworthy in Drools 7.1
+= New and Noteworthy in Drools 7.1
 

--- a/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.7.11.0.Final-section.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.7.11.0.Final-section.adoc
@@ -1,6 +1,6 @@
 [[_drools.releasenotesdrools.7.11.0]]
 
-= What is New and Noteworthy in Drools 7.11
+= New and Noteworthy in Drools 7.11
 
 == Minor API changes of Kie DMN open source engine
 

--- a/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.7.12.0.Final-section.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.7.12.0.Final-section.adoc
@@ -1,6 +1,6 @@
 [[_drools.releasenotesdrools.7.12.0]]
 
-= What is New and Noteworthy in Drools 7.12
+= New and Noteworthy in Drools 7.12
 
 == End of support for `drools-rhq-plugin` component
 

--- a/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.7.13.0.Final-section.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.7.13.0.Final-section.adoc
@@ -1,6 +1,6 @@
 [[_drools.releasenotesdrools.7.13.0]]
 
-= What is New and Noteworthy in Drools 7.13
+= New and Noteworthy in Drools 7.13
 
 == Allow to declare serialVersionUID on classes generated from declared types
 

--- a/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.7.14.0.Final-section.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.7.14.0.Final-section.adoc
@@ -1,6 +1,6 @@
 [[_drools.releasenotesdrools.7.14.0]]
 
-= What is New and Noteworthy in Drools 7.14
+= New and Noteworthy in Drools 7.14
 
 == File-system based KieScanner
 

--- a/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.7.15.0.Final-section.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.7.15.0.Final-section.adoc
@@ -1,6 +1,6 @@
 [[_drools.releasenotesdrools.7.15.0]]
 
-= What is New and Noteworthy in Drools 7.15
+= New and Noteworthy in Drools 7.15
 
 == Broken DMN resources detected in {PRODUCT} project builds
 

--- a/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.7.17.0.Final-section.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.7.17.0.Final-section.adoc
@@ -1,6 +1,6 @@
 [[_drools.releasenotesdrools.7.17.0]]
 
-= What is New and Noteworthy in Drools 7.17
+= New and Noteworthy in Drools 7.17
 
 == Minor changes in DMN FEEL built-in functions' parameter names
 

--- a/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.7.18.0.Final-section.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.7.18.0.Final-section.adoc
@@ -1,6 +1,6 @@
 [[_drools.releasenotesdrools.7.18.0]]
 
-= What is New and Noteworthy in Drools 7.18
+= New and Noteworthy in Drools 7.18
 
 == New Builder Options
 

--- a/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.7.24.0.Final/ReleaseNotesDrools.7.24.0.Final-section.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.7.24.0.Final/ReleaseNotesDrools.7.24.0.Final-section.adoc
@@ -1,0 +1,6 @@
+[id='drools.releasenotesdrools.7.24.0']
+
+= New and Noteworthy in Drools 7.24.0
+
+// IMPORTANT: For 7.24 and later, save each release note as its own module file in the release folder that this `*-section.adoc` file is in, and then include each release note file in the space below in the following format:
+//include::file-name.adoc[leveloffset=+1]

--- a/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.7.7.0.Final-section.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.7.7.0.Final-section.adoc
@@ -1,6 +1,6 @@
 [[_drools.releasenotesdrools.7.7.0]]
 
-= What is New and Noteworthy in Drools 7.7
+= New and Noteworthy in Drools 7.7
 :context: N&N-7.7
 
 include::{shared-dir}/KIE/BuildDeployUtilizeAndRun/executable-model-con.adoc[leveloffset=+1]

--- a/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.7.9.0.Final-section.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.7.9.0.Final-section.adoc
@@ -1,6 +1,6 @@
 [[_drools.releasenotesdrools.7.9.0]]
 
-= What is New and Noteworthy in Drools 7.9
+= New and Noteworthy in Drools 7.9
 
 == Moved ExecutableCommand to KIE public API
 

--- a/doc-content/jbpm-docs/src/main/asciidoc/ReleaseNotes-chapter.adoc
+++ b/doc-content/jbpm-docs/src/main/asciidoc/ReleaseNotes-chapter.adoc
@@ -1,9 +1,15 @@
-[[_jbpmreleasenotes]]
+[id='jbpmreleasenotes']
+
 = Release Notes
+
+//IMPORTANT: For 7.24 and later, use the following include format:
+//== jBPM 7.24
+//include::ReleaseNotes/Release.7.24.0.Final/Release.7.24.0.Final-section.adoc[leveloffset=+2]
+//include::{shared-dir}/Workbench/ReleaseNotes/ReleaseNotesWorkbench.7.24.0.Final/ReleaseNotesWorkbench.7.24.0.Final-section.adoc[leveloffset=+2]
 
 == jBPM 7.23
 
-include::{shared-dir}/Workbench/ReleaseNotes/ReleaseNotesWorkbench.7.23.0.Final-section.adoc[leveloffset=+1]
+include::{shared-dir}/Workbench/ReleaseNotes/ReleaseNotesWorkbench.7.23.0.Final-section.adoc[leveloffset=+2]
 
 == jBPM 7.22
 
@@ -24,12 +30,12 @@ include::ReleaseNotes/Release.7.19.0.Final-section.adoc[leveloffset=+2]
 == jBPM 7.18
 
 include::ReleaseNotes/Release.7.18.0.Final-section.adoc[leveloffset=+2]
-include::{shared-dir}/Workbench/ReleaseNotes/ReleaseNotesWorkbench.7.18.0.Final-section.adoc[leveloffset=+1]
+include::{shared-dir}/Workbench/ReleaseNotes/ReleaseNotesWorkbench.7.18.0.Final-section.adoc[leveloffset=+2]
 
 == jBPM 7.17
 
 include::ReleaseNotes/Release.7.17.0.Final-section.adoc[leveloffset=+2]
-include::{shared-dir}/Workbench/ReleaseNotes/ReleaseNotesWorkbench.7.17.0.Final-section.adoc[leveloffset=+1]
+include::{shared-dir}/Workbench/ReleaseNotes/ReleaseNotesWorkbench.7.17.0.Final-section.adoc[leveloffset=+2]
 
 == jBPM 7.16
 
@@ -44,7 +50,7 @@ include::{shared-dir}/Workbench/ReleaseNotes/ReleaseNotesWorkbench.7.15.0.Final-
 == jBPM 7.14
 
 include::ReleaseNotes/Release.7.14.0.Final-section.adoc[leveloffset=+2]
-include::{shared-dir}/Workbench/ReleaseNotes/ReleaseNotesWorkbench.7.14.0.Final-section.adoc[leveloffset=+1]
+include::{shared-dir}/Workbench/ReleaseNotes/ReleaseNotesWorkbench.7.14.0.Final-section.adoc[leveloffset=+2]
 
 == jBPM 7.13
 

--- a/doc-content/jbpm-docs/src/main/asciidoc/ReleaseNotes/Release.7.24.0.Final/Release.7.24.0.Final-section.adoc
+++ b/doc-content/jbpm-docs/src/main/asciidoc/ReleaseNotes/Release.7.24.0.Final/Release.7.24.0.Final-section.adoc
@@ -1,0 +1,8 @@
+[id='jbpmreleasenotes7240']
+
+= New and Noteworthy in jBPM 7.24.0
+
+The following features were added to jBPM 7.24.0
+
+// IMPORTANT: For 7.24 and later, save each release note as its own module file in the release folder that this `*-section.adoc` file is in, and then include each release note file in the space below in the following format:
+//include::file-name.adoc[leveloffset=+1]

--- a/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/ReleaseNotes/ReleaseNotesWorkbench.7.16.0.Final-section.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/ReleaseNotes/ReleaseNotesWorkbench.7.16.0.Final-section.adoc
@@ -1,6 +1,6 @@
 [[_drools.releasenotesworkbench.7.16.0.final]]
 
-= What is New and Noteworthy in KIE Workbench 7.16.0
+= New and Noteworthy in Business Central 7.16.0
 
 == DMN and Test Scenario keyboard control
 
@@ -10,5 +10,3 @@ For both DMN and Test Scenario tables, the following keyboard control support wa
 ** In a DMN table, the top-left cell is selected by default. Next to standard navigation, press *Enter* to select a nested expression and *Esc* to return to the parent expression.
 ** In a Test Scenario table, no cell is selected by default. Press *Shift+Home* to select the first available cell.
 * *Table editing:* After you select a cell in a DMN or Test Scenario table, you can input a new value into the cell or change the already added value. To edit a cell, press *Enter*. To stop the editing, press *Shift+Tab*.
-
-

--- a/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/ReleaseNotes/ReleaseNotesWorkbench.7.17.0.Final-section.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/ReleaseNotes/ReleaseNotesWorkbench.7.17.0.Final-section.adoc
@@ -1,6 +1,6 @@
 [[_drools.releasenotesworkbench.7.17.0.final]]
 
-= What is New and Noteworthy in KIE Workbench 7.17.0
+= New and Noteworthy in Business Central 7.17.0
 
 == Test Scenario (Preview) enabled by default
 
@@ -13,4 +13,3 @@ Test Scenario (Preview) now support DMN model testing
 == DMN Decision Service support
 
 A DMN decision service node is now available in the DMN designer palette in {CENTRAL}.
-

--- a/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/ReleaseNotes/ReleaseNotesWorkbench.7.18.0.Final-section.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/ReleaseNotes/ReleaseNotesWorkbench.7.18.0.Final-section.adoc
@@ -1,6 +1,6 @@
 [[_drools.releasenotesworkbench.7.18.0.final]]
 
-= What is New and Noteworthy in KIE Workbench 7.18.0
+= New and Noteworthy in Business Central 7.18.0
 
 == Guided rules designer filtering
 

--- a/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/ReleaseNotes/ReleaseNotesWorkbench.7.19.0.Final-section.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/ReleaseNotes/ReleaseNotesWorkbench.7.19.0.Final-section.adoc
@@ -1,6 +1,6 @@
 [[_drools.releasenotesworkbench.7.19.0.final]]
 
-= What is New and Noteworthy in KIE Workbench 7.19.0
+= New and Noteworthy in Business Central 7.19.0
 
 == DMN Automatic Layout
 Nodes in DMN decision requirements diagrams (DRDs) can be positioned automatically with the new *Perform automatic layout* toolbar button. This automatic layout feature orients DRD nodes vertically, from the bottom to the top of the  DRD. However, automatic layout currently does not support *Decision Service* nodes.

--- a/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/ReleaseNotes/ReleaseNotesWorkbench.7.23.0.Final-section.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/ReleaseNotes/ReleaseNotesWorkbench.7.23.0.Final-section.adoc
@@ -1,6 +1,6 @@
 [[_drools.releasenotesworkbench.7.23.0.final]]
 
-= What is New and Noteworthy in KIE Workbench 7.23.0
+= New and Noteworthy in Business Central 7.23.0
 
 == Enhanced BC collaboration features
 
@@ -74,4 +74,3 @@ Only the selected branches are persisted:
 
 .List of imported branches
 image::Workbench/Authoring/Importing/import-project-imported-branches.png[align="center"]
-

--- a/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/ReleaseNotes/ReleaseNotesWorkbench.7.24.0.Final/ReleaseNotesWorkbench.7.24.0.Final-section.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/ReleaseNotes/ReleaseNotesWorkbench.7.24.0.Final/ReleaseNotesWorkbench.7.24.0.Final-section.adoc
@@ -1,0 +1,6 @@
+[id='drools.releasenotesworkbench.7.24.0.final']
+
+= New and Noteworthy in Business Central 7.24.0
+
+// IMPORTANT: For 7.24 and later, save each release note as its own module file in the release folder that this `*-section.adoc` file is in, and then include each release note file in the space below in the following format:
+//include::file-name.adoc[leveloffset=+1]


### PR DESCRIPTION
@jomarko, @tarilabs, @cristianonicolai, @nmirasch @pefernan, you guys seem to be the top contributors to the community release notes, so would you mind briefly reviewing this PR for anything of question or concern? This is the change to the community RN file structure starting with 7.24 to accommodate single sourcing with enterprise (plus a few other needed tweaks), which I announced at length to you all, team leads, and BSIG in a few emails. 

For a detailed description/illustration of this change and the reasons for it, search your email for the BSIG message with subject line "Single sourcing community and enterprise release notes beginning 7.24 / 7.5 release".

Summary of what I changed:
* For Drools, jBPM, and Workbench, I added a release-specific folder within which the same-as-always "-section.adoc" file resides, and where all new release notes going forward will be stored and linked in the "-section.adoc" as includes instead of headed sections.
* Added commented-out in-line help text for the new section files and RN chapter files for correct include formatting.
* In Drools, changed "What's New and Noteworthy in ..." to just "New and Noteworthy in ..." for consistency with every other RN section and for concision.
* Changed "KIE Workbench" to "Business Central" in RN headers from 7.16 on (the version after which the workbench consolidation was announced, in 7.15). If we specifically called out that we changed the name of it from the former to the latter, it's confusing to keep calling it KIE Workbench in the title thereafter.
* A few incorrect level offsets in the jBPM RN chapter file.

What I did NOT change:
* The release notes structure in /shared-kie-docs/ReleaseNotes, /shared-kie-docs/KIE/ReleaseNotes, and /shared-kie-docs/KieServer/ReleaseNotes. The reasons are that these are either obsolete or likely will be soon (really should just include them with one of the other three folders), but more importantly, we don't know what the next update will be for these locations, so I can't put a placeholder like I've done for the three main ones for 7.24. Next time we add to these folders, if we do (we probably shouldn't) we can just follow suit, and I'll help facilitate when the time comes, as gatekeeper.