### PR TITLE
BXMSDOC-4252-master: Update decision service gsg with violation sample project info.

### DIFF
--- a/assemblies/assembly_decision-manager/dm/master-docinfo.xml
+++ b/assemblies/assembly_decision-manager/dm/master-docinfo.xml
@@ -3,6 +3,6 @@
 <subtitle>
 </subtitle>
 <abstract>
-	<para>This document describes how to create and test an example traffic violations decision service based on a Decision Model and Notation (DMN) model in {PRODUCT} {PRODUCT_VERSION}.</para>
+	<para>This document describes how to create and test an example traffic violation decision service using a Decision Model and Notation (DMN) model in {PRODUCT} {PRODUCT_VERSION}. The procedures in this document are based on the Traffic_Violation sample project included in {CENTRAL}.</para>
 </abstract>
 <xi:include href="Common_Content/Legal_Notice.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/assemblies/assembly_decision-manager/main.adoc
+++ b/assemblies/assembly_decision-manager/main.adoc
@@ -10,7 +10,7 @@ include::_artifacts/document-attributes.adoc[]
 include::_artifacts/author-group.adoc[]
 
 // Purpose statement for the assembly
-As a business rules developer, you can use {CENTRAL} in {PRODUCT} to design a variety of decision services. {PRODUCT} provides example projects with example decisions directly in {CENTRAL} as a reference. This document describes how to create and test a new project in {CENTRAL} for an example traffic violations decision service based on a Decision Model and Notation (DMN) model.
+As a business rules developer, you can use {CENTRAL} in {PRODUCT} to design a variety of decision services. {PRODUCT} provides example projects with example business assets directly in {CENTRAL} as a reference. This document describes how to create and test an example traffic violation project based on the *Traffic_Violation* sample project included in {CENTRAL}. This sample project uses a Decision Model and Notation (DMN) model to define driver penalty and suspension rules in a traffic violation decision service. You can follow the steps in this document to create the project and the assets it contains, or open and review the existing *Traffic_Violation* sample project.
 
 For more information about the DMN components and implementation in {PRODUCT}, see {URL_DMN_MODELS}[_{DMN_MODELS}_].
 
@@ -21,6 +21,9 @@ For more information about the DMN components and implementation in {PRODUCT}, s
 * {PRODUCT} is running and you can log in to {CENTRAL} with the `developer` role. For more information, see {URL_PLANNING_INSTALL}[_{PLANNING_INSTALL}_].
 
 // Modules - concepts, procedures, refs, etc.
+
+include::{drools-dir}/Examples/decision-examples-central-con.adoc[leveloffset=+1]
+include::{drools-dir}/Examples/decision-examples-central-proc.adoc[leveloffset=+2]
 
 include::{drools-dir}/DMN/dmn-gs-new-project-creating-proc.adoc[leveloffset=+1]
 
@@ -35,9 +38,6 @@ include::{drools-dir}/DMN/dmn-gs-testing-test-scenario-proc.adoc[leveloffset=+2]
 
 include::{drools-dir}/DMN/dmn-execution-con.adoc[leveloffset=+1]
 include::{drools-dir}/DMN/dmn-execution-rest-proc.adoc[leveloffset=+2]
-
-include::{drools-dir}/Examples/decision-examples-central-con.adoc[leveloffset=+1]
-include::{drools-dir}/Examples/decision-examples-central-proc.adoc[leveloffset=+2]
 
 == Additional resources
 * {URL_DMN_MODELS}[_{DMN_MODELS}_]

--- a/assemblies/assembly_decision-manager/pam/master-docinfo.xml
+++ b/assemblies/assembly_decision-manager/pam/master-docinfo.xml
@@ -3,6 +3,6 @@
 <subtitle>
 </subtitle>
 <abstract>
-	<para>This document describes how to create and test an example traffic violations decision service based on a Decision Model and Notation (DMN) model in {PRODUCT} {PRODUCT_VERSION}.</para>
+	<para>This document describes how to create and test an example traffic violation decision service using a Decision Model and Notation (DMN) model in {PRODUCT} {PRODUCT_VERSION}. The procedures in this document are based on the Traffic_Violation sample project included in {CENTRAL}.</para>
 </abstract>
 <xi:include href="Common_Content/Legal_Notice.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/doc-content/drools-docs/src/main/asciidoc/DMN/dmn-gs-new-project-creating-proc.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/DMN/dmn-gs-new-project-creating-proc.adoc
@@ -1,7 +1,7 @@
 [id='dmn-gs-new-project-creating-proc']
 = Creating the traffic violations project
 
-For this example, create a new project called `traffic-violation`. A project is a container for assets such as data objects, DMN assets, and test scenarios.
+For this example, create a new project called `traffic-violation`. A project is a container for assets such as data objects, DMN assets, and test scenarios. This example project that you are creating is similar to the existing *Traffic_Violation* sample project in {CENTRAL}.
 
 .Procedure
 . Log in to {CENTRAL}.

--- a/doc-content/drools-docs/src/main/asciidoc/Examples/decision-examples-central-con.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/Examples/decision-examples-central-con.adoc
@@ -26,7 +26,8 @@ ifdef::PAM,JBPM[]
 * *IT_Orders*: (Process automation and case management) Example ordering case using business process and case management assets. Places an IT hardware order based on needs and approvals.
 //* *Traffic Violation*: (Process Automation) Example traffic violations process using business process and DMN assets. Determines the traffic violation type and calculates the fine based on the violation type.
 endif::[]
-* *Mortgages*: (Decision management) Example loan approval process using decision assets. Determines loan eligibility based on applicant data and qualifications.
+* *Traffic_Violation*: (Decision management with DMN) Example traffic violation decision service using a Decision Model and Notation (DMN) model. Determines driver penalty and suspension based on traffic violations.
+* *Mortgages*: (Decision management with rules) Example loan approval process using rule-based decision assets. Determines loan eligibility based on applicant data and qualifications.
 * *Employee_Rostering*: (Business optimization) Example employee rostering optimization using decision and solver assets. Assigns employees to shifts based on skills.
 * *OptaCloud*: (Business optimization) Example resource allocation optimization using decision and solver assets. Assigns processes to computers with limited resources.
 * *Course_Scheduling*: (Business optimization) Example course scheduling and curriculum decision process. Assigns lectures to rooms and determines a student's curriculum based on factors, such as course conflicts and class room capacity.


### PR DESCRIPTION
@etirelli, @csherrar, can you review and approve this PR for the traffic violation sample update to the decision service getting started guide? I added the violation project to the list of sample projects in BC and I updated the doc preface to mention that users can either follow the steps in the doc to create the project and assets or just open and review the sample project. I'm leaving it to Clifton, when he updates the doc overall, to decide whether to align the naming of the project in the steps to be exactly as the sample project, or to keep them slightly different on purpose to distinguish them.

Links:
* [Doc preview for PAM](http://file.rdu.redhat.com/~sterobin/BXMSDOC-4252_PAM/)
* [JIRA](https://issues.jboss.org/browse/BXMSDOC-4252)