### PR TITLE
Update KIERunning-section.adoc

### DIFF
--- a/doc-content/shared-kie-docs/src/main/asciidoc/KIE/BuildDeployUtilizeAndRun/KIERunning-section.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/KIE/BuildDeployUtilizeAndRun/KIERunning-section.adoc
@@ -338,7 +338,7 @@ Inserted facts, globals and query results can all be returned.
 List cmds = new ArrayList();
 cmds.add( CommandFactory.newSetGlobal( "list1", new ArrayList(), true ) );
 cmds.add( CommandFactory.newInsert( new Person( "jon", 102 ), "person" ) );
-cmds.add( CommandFactory.newQuery( "Get People" "getPeople" );
+cmds.add( CommandFactory.newQuery( "Get People", "getPeople" ) );
 
 // Execute the list
 ExecutionResults results =


### PR DESCRIPTION
The ```newQuery``` method should take two comma-separated arguments and ```cmds.add``` is missing a closing bracket.