### PR TITLE
BXMSDOC-1936-master: Add note on Swagger systerm property to KIE APIs doc.

### DIFF
--- a/doc-content/shared-kie-docs/src/main/asciidoc/KieServer/controller-rest-api-endpoints-ref.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/KieServer/controller-rest-api-endpoints-ref.adoc
@@ -8,4 +8,9 @@ For the full list of {CONTROLLER} REST API endpoints and descriptions, use one o
 * http://jbpm.org/learn/documentation.html[Controller REST API] on the jBPM Documentation page (static)
 * Swagger UI for the {CONTROLLER} REST API at `\http://SERVER:PORT/CONTROLLER/docs` (dynamic, requires running {CONTROLLER})
 +
-NOTE: If you are using the {CONTROLLER} built in to {CENTRAL}, the Swagger page associated with the {CONTROLLER} is identified as the "{CENTRAL} API" for {CENTRAL} REST services. If you are using the {HEADLESS_CONTROLLER} without {CENTRAL}, the Swagger page associated with the {HEADLESS_CONTROLLER} is identified as the "Controller API". The {CONTROLLER} REST API endpoints in both cases are the same.
+[NOTE]
+====
+By default, the Swagger web interface for the {CONTROLLER} is enabled by the `org.kie.workbench.swagger.disabled=false` system property. To disable the Swagger web interface for the {CONTROLLER}, set this system property to `true`.
+
+If you are using the {CONTROLLER} built in to {CENTRAL}, the Swagger page associated with the {CONTROLLER} is identified as the "{CENTRAL} API" for {CENTRAL} REST services. If you are using the {HEADLESS_CONTROLLER} without {CENTRAL}, the Swagger page associated with the {HEADLESS_CONTROLLER} is identified as the "Controller API". The {CONTROLLER} REST API endpoints in both cases are the same.
+====

--- a/doc-content/shared-kie-docs/src/main/asciidoc/KieServer/controller-rest-api-endpoints-ref.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/KieServer/controller-rest-api-endpoints-ref.adoc
@@ -12,5 +12,5 @@ For the full list of {CONTROLLER} REST API endpoints and descriptions, use one o
 ====
 By default, the Swagger web interface for the {CONTROLLER} is enabled by the `org.kie.workbench.swagger.disabled=false` system property. To disable the Swagger web interface for the {CONTROLLER}, set this system property to `true`.
 
-If you are using the {CONTROLLER} built in to {CENTRAL}, the Swagger page associated with the {CONTROLLER} is identified as the "{CENTRAL} API" for {CENTRAL} REST services. If you are using the {HEADLESS_CONTROLLER} without {CENTRAL}, the Swagger page associated with the {HEADLESS_CONTROLLER} is identified as the "Controller API". The {CONTROLLER} REST API endpoints in both cases are the same.
+If you are using the {CONTROLLER} built in to {CENTRAL}, the Swagger page associated with the {CONTROLLER} is identified as the "{CENTRAL} API" for {CENTRAL} REST services. If you are using the {HEADLESS_CONTROLLER} without {CENTRAL}, the Swagger page associated with the {HEADLESS_CONTROLLER} is identified as the "Controller API". In both cases, the {CONTROLLER} REST API endpoints are the same.
 ====

--- a/doc-content/shared-kie-docs/src/main/asciidoc/KieServer/controller-rest-api-requests-swagger-proc.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/KieServer/controller-rest-api-requests-swagger-proc.adoc
@@ -3,6 +3,9 @@
 
 The {CONTROLLER} REST API supports a Swagger web interface that you can use instead of a standalone REST client or curl utility to interact with your {KIE_SERVER} templates, instances, and associated KIE containers in {PRODUCT} without using the {CENTRAL} user interface.
 
+NOTE: By default, the Swagger web interface for the {CONTROLLER} is enabled by the `org.kie.workbench.swagger.disabled=false` system property. To disable the Swagger web interface for the {CONTROLLER}, set this system property to `true`.
+
+
 .Prerequisites
 * The {CONTROLLER} is installed and running.
 * You have `rest-all` user role access to the {CONTROLLER} if you installed {CENTRAL}, or `kie-server` user role access to the {HEADLESS_CONTROLLER} installed separately from {CENTRAL}.

--- a/doc-content/shared-kie-docs/src/main/asciidoc/KieServer/controller-rest-api-requests-swagger-proc.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/KieServer/controller-rest-api-requests-swagger-proc.adoc
@@ -13,7 +13,7 @@ NOTE: By default, the Swagger web interface for the {CONTROLLER} is enabled by t
 .Procedure
 . In a web browser, navigate to `\http://SERVER:PORT/CONTROLLER/docs`, such as `\http://localhost:8080/{URL_COMPONENT_CENTRAL}/docs`, and log in with the user name and password of the {CONTROLLER} user with the `rest-all` role or the {HEADLESS_CONTROLLER} user with the `kie-server` role.
 +
-NOTE: If you are using the {CONTROLLER} built in to {CENTRAL}, the Swagger page associated with the {CONTROLLER} is identified as the "{CENTRAL} API" for {CENTRAL} REST services. If you are using the {HEADLESS_CONTROLLER} without {CENTRAL}, the Swagger page associated with the {HEADLESS_CONTROLLER} is identified as the "Controller API". The {CONTROLLER} REST API endpoints in both cases are the same.
+NOTE: If you are using the {CONTROLLER} built in to {CENTRAL}, the Swagger page associated with the {CONTROLLER} is identified as the "{CENTRAL} API" for {CENTRAL} REST services. If you are using the {HEADLESS_CONTROLLER} without {CENTRAL}, the Swagger page associated with the {HEADLESS_CONTROLLER} is identified as the "Controller API". In both cases, the {CONTROLLER} REST API endpoints are the same.
 +
 
 . In the Swagger page, select the relevant API endpoint to which you want to send a request, such as *Controller :: KIE Server templates and KIE containers* -> *[GET] /controller/management/servers* to retrieve {KIE_SERVER} templates from the {CONTROLLER}.

--- a/doc-content/shared-kie-docs/src/main/asciidoc/KieServer/kie-server-rest-api-endpoints-ref.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/KieServer/kie-server-rest-api-endpoints-ref.adoc
@@ -25,6 +25,8 @@ For the full list of {KIE_SERVER} REST API endpoints and descriptions, use one o
 
 * http://jbpm.org/learn/documentation.html[Execution Server REST API] on the jBPM Documentation page (static)
 * Swagger UI for the {KIE_SERVER} REST API at `\http://SERVER:PORT/kie-server/docs` (dynamic, requires running {KIE_SERVER})
++
+NOTE: By default, the Swagger web interface for {KIE_SERVER} is enabled by the `org.kie.swagger.server.ext.disabled=false` system property. To disable the Swagger web interface in {KIE_SERVER}, set this system property to `true`.
 
 ifdef::PAM,JBPM[]
 [discrete]

--- a/doc-content/shared-kie-docs/src/main/asciidoc/KieServer/kie-server-rest-api-requests-swagger-proc.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/KieServer/kie-server-rest-api-requests-swagger-proc.adoc
@@ -3,6 +3,8 @@
 
 The {KIE_SERVER} REST API supports a Swagger web interface that you can use instead of a standalone REST client or curl utility to interact with your KIE containers and business assets (such as business rules, processes, and solvers) in {PRODUCT} without using the {CENTRAL} user interface.
 
+NOTE: By default, the Swagger web interface for {KIE_SERVER} is enabled by the `org.kie.swagger.server.ext.disabled=false` system property. To disable the Swagger web interface in {KIE_SERVER}, set this system property to `true`.
+
 .Prerequisites
 * {KIE_SERVER} is installed and running.
 * You have `kie-server` user role access to {KIE_SERVER}.


### PR DESCRIPTION
@sutaakar, @cristianonicolai, @csherrar, can you please verify this update to the KIE APIs doc? I added the notes about Swagger system properties for KIE Server and Controller, per Karel's suggestion.

* [JIRA](https://issues.jboss.org/browse/BXMSDOC-1936)
* [Doc preview](http://file.rdu.redhat.com/~sterobin/BXMSDOC-1936/#kie-server-rest-api-requests-swagger-proc_kie-apis)