### PR TITLE
revoked the disabling of maven-jar-plugin

### DIFF
--- a/doc-content/drools-docs/pom.xml
+++ b/doc-content/drools-docs/pom.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
+  <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-docs-guides</artifactId>
@@ -32,32 +32,12 @@
 
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>default-jar</id>
-            <phase>none</phase>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-install-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>default-install</id>
-            <phase>none</phase>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.asciidoctor</groupId>
         <artifactId>asciidoctor-maven-plugin</artifactId>
-	<configuration>
+        <configuration>
           <imagesDir>${project.basedir}/../../_images</imagesDir>
           <attributes>
-	    <artifact-dir>${project.basedir}/../../_artifacts</artifact-dir>
+            <artifact-dir>${project.basedir}/../../_artifacts</artifact-dir>
           </attributes>
         </configuration>
       </plugin>

--- a/doc-content/jbpm-docs/pom.xml
+++ b/doc-content/jbpm-docs/pom.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
+  <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-docs-guides</artifactId>
@@ -32,32 +32,12 @@
 
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>default-jar</id>
-            <phase>none</phase>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-install-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>default-install</id>
-            <phase>none</phase>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.asciidoctor</groupId>
         <artifactId>asciidoctor-maven-plugin</artifactId>
-	<configuration>
+        <configuration>
           <imagesDir>${project.basedir}/../../_images</imagesDir>
           <attributes>
-	    <artifact-dir>${project.basedir}/../../_artifacts</artifact-dir>
+            <artifact-dir>${project.basedir}/../../_artifacts</artifact-dir>
           </attributes>
         </configuration>
       </plugin>

--- a/doc-content/optaplanner-wb-es-docs/pom.xml
+++ b/doc-content/optaplanner-wb-es-docs/pom.xml
@@ -25,32 +25,12 @@
 
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>default-jar</id>
-            <phase>none</phase>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-install-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>default-install</id>
-            <phase>none</phase>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.asciidoctor</groupId>
         <artifactId>asciidoctor-maven-plugin</artifactId>
-	<configuration>
+        <configuration>
           <imagesDir>${project.basedir}/../../_images</imagesDir>
           <attributes>
-	    <artifact-dir>${project.basedir}/../../_artifacts</artifact-dir>
+            <artifact-dir>${project.basedir}/../../_artifacts</artifact-dir>
           </attributes>
         </configuration>
       </plugin>


### PR DESCRIPTION
enabled the maven-jar-plugin again because the disabling of it causes much more problems then the problem:

[ERROR] Failed to execute goal org.apache.maven.plugins:maven-jar-plugin:3.1.0:jar (default-jar) on project appformer-js: You have to use a classifier to attach supplemental artifacts to the project instead of replacing them. -> [Help 1]

This error has to solved ASAP.