### PR TITLE
 [DROOLS-4292] executable-model fails with more than 5 arguments query

### DIFF
--- a/doc-content/shared-kie-docs/src/main/asciidoc/KIE/BuildDeployUtilizeAndRun/executable-model-con.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/KIE/BuildDeployUtilizeAndRun/executable-model-con.adoc
@@ -12,6 +12,10 @@ that implement the executable model of the project rule base and re-create the K
 for constraints evaluation, so you no longer need to use `mvel` expressions for interpreted evaluation nor the just-in-time (JIT) process to transform the `mvel`-based constraints into bytecode. This creates a quicker and more efficient run time.
 * *Development time:* An executable model enables you to develop and experiment with new features of the {DECISION_ENGINE} without needing to encode elements directly in the DRL format or modify the DRL parser to support them.
 
+There are some specific constraints to consider when targeting the executable model:
+
+* *Query argument number:* up to 10 arguments queries are supported.
+
 ifdef::DROOLS[]
 == Executable model domain-specific languages (DSLs)
 

--- a/doc-content/shared-kie-docs/src/main/asciidoc/KIE/BuildDeployUtilizeAndRun/executable-model-con.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/KIE/BuildDeployUtilizeAndRun/executable-model-con.adoc
@@ -12,9 +12,7 @@ that implement the executable model of the project rule base and re-create the K
 for constraints evaluation, so you no longer need to use `mvel` expressions for interpreted evaluation nor the just-in-time (JIT) process to transform the `mvel`-based constraints into bytecode. This creates a quicker and more efficient run time.
 * *Development time:* An executable model enables you to develop and experiment with new features of the {DECISION_ENGINE} without needing to encode elements directly in the DRL format or modify the DRL parser to support them.
 
-There are some specific constraints to consider when targeting the executable model:
-
-* *Query argument number:* up to 10 arguments queries are supported.
+NOTE: For query definitions in executable rule models, you can use up to 10 arguments only.
 
 ifdef::DROOLS[]
 == Executable model domain-specific languages (DSLs)


### PR DESCRIPTION
Added paragraph on number of query arguments