### PR TITLE
Upstream 7.14.x PR for BXMSDOC-3437: Corrected JMS JNDI queue names in WLS installation doc 

### DIFF
--- a/doc-content/enterprise-only/installation/jms-queues-ref.adoc
+++ b/doc-content/enterprise-only/installation/jms-queues-ref.adoc
@@ -11,16 +11,16 @@ The following are the required Java Message Service (JMS) queues that enable JMS
 |Used for
 
 |`KIE.SERVER.REQUEST`
-|`jms/queue/KIE.SERVER.REQUEST`
+|`jms/KIE.SERVER.REQUEST`
 | Sending all requests to {KIE_SERVER}
 
 |`KIE.SERVER.RESPONSE`
-|`jms/queue/KIE.SERVER.RESPONSE`
+|`jms/KIE.SERVER.RESPONSE`
 | Receiving all responses produced by {KIE_SERVER}
 
 ifdef::PAM[]
 |`KIE.SERVER.EXECUTOR`
-|`jms/queue/KIE.SERVER.EXECUTOR`
+|`jms/KIE.SERVER.EXECUTOR`
 | {KIE_SERVER} executor services
 endif::PAM[]
 |===

--- a/doc-content/enterprise-only/weblogic/wls-jms-queues-create-proc.adoc
+++ b/doc-content/enterprise-only/weblogic/wls-jms-queues-create-proc.adoc
@@ -11,7 +11,7 @@ JMS queues are the destination end points for point-to-point messaging. You must
 . In the WebLogic Administration Console, navigate to *Services* -> *Messaging* -> *JMS Modules* to see the list of JMS modules.
 . Select your previously created module, then click *New* to create a new JMS resource.
 . Select *Queue* and click *Next*.
-. For each of the following required queues, enter the name of the queue (for example, `KIE.SERVER.REQUEST`) and the JNDI name (for example, `jms/queue/KIE.SERVER.REQUEST`)
+. For each of the following required queues, enter the name of the queue (for example, `KIE.SERVER.REQUEST`) and the JNDI name (for example, `jms/KIE.SERVER.REQUEST`)
 and then click *Next*.
 . Choose the JMS module subdeployment that connects to the JMS server.
 . Click *Finish* to add the queue, and repeat for each required queue.


### PR DESCRIPTION
[JIRA](https://issues.jboss.org/browse/BXMSDOC-3437)
[RHPAM-7.2-WLS Installation doc preview](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-3437-7.2-JNDI-JMS-Names-PAM/#wls-jms-queues-create-proc)
[RHDM-7.2-WLS Installation doc preview](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-3437-7.2-JNDI-JMS-Names-DM/#wls-jms-queues-create-proc)