### PR TITLE
Upstream 7.7.x PR for BXMSDOC-3437: Corrected JMS JNDI queue names in WLS installation doc 

### DIFF
--- a/docs/product-installation-guide/src/main/asciidoc/jms-queues-ref.adoc
+++ b/docs/product-installation-guide/src/main/asciidoc/jms-queues-ref.adoc
@@ -11,16 +11,16 @@ The following are the required Java Message Service (JMS) queues that enable JMS
 |Used for
 
 |`KIE.SERVER.REQUEST`
-|`jms/queue/KIE.SERVER.REQUEST`
+|`jms/KIE.SERVER.REQUEST`
 | Sending all requests to {KIE_SERVER}
 
 |`KIE.SERVER.RESPONSE`
-|`jms/queue/KIE.SERVER.RESPONSE`
+|`jms/KIE.SERVER.RESPONSE`
 | Receiving all responses produced by {KIE_SERVER}
 
 ifdef::PAM[]
 |`KIE.SERVER.EXECUTOR`
-|`jms/queue/KIE.SERVER.EXECUTOR`
+|`jms/KIE.SERVER.EXECUTOR`
 | {KIE_SERVER} executor services
 endif::PAM[]
 |===

--- a/docs/product-oracle-weblogic-installation-and-configuration-guide/src/main/asciidoc/kie-server-wls-environment-set-proc.adoc
+++ b/docs/product-oracle-weblogic-installation-and-configuration-guide/src/main/asciidoc/kie-server-wls-environment-set-proc.adoc
@@ -23,7 +23,7 @@ If you do not increase the JVM memory size, {WEBLOGIC} freezes or causes deploym
 |Description
 
 |`kie.server.jms.queues.response`
-|`jms/queue/KIE.SERVER.RESPONSE`
+|`jms/KIE.SERVER.RESPONSE`
 |The JNDI name of JMS queue for responses used by the {KIE_SERVER}.
 
 |`org.kie.server.domain`

--- a/docs/product-oracle-weblogic-installation-and-configuration-guide/src/main/asciidoc/wls-jms-queues-create-proc.adoc
+++ b/docs/product-oracle-weblogic-installation-and-configuration-guide/src/main/asciidoc/wls-jms-queues-create-proc.adoc
@@ -11,7 +11,7 @@ JMS queues are the destination end points for point-to-point messaging. You must
 . In the WebLogic Administration Console, navigate to *Services* -> *Messaging* -> *JMS Modules* to see the list of JMS modules.
 . Select your previously created module, then click *New* to create a new JMS resource.
 . Select *Queue* and click *Next*.
-. For each of the following required queues, enter the name of the queue (for example, `KIE.SERVER.REQUEST`) and the JNDI name (for example, `jms/queue/KIE.SERVER.REQUEST`)
+. For each of the following required queues, enter the name of the queue (for example, `KIE.SERVER.REQUEST`) and the JNDI name (for example, `jms/KIE.SERVER.REQUEST`)
 and then click *Next*.
 . Choose the JMS module subdeployment that connects to the JMS server.
 . Click *Finish* to add the queue, and repeat for each required queue.


### PR DESCRIPTION
[JIRA](https://issues.jboss.org/browse/BXMSDOC-3437)
[RHPAM-7.0-WLS Installation doc preview](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-3437-7.0-JNDI-JMS-Names-PAM/#wls-jms-queues-create-proc)
[RHDM-7.0-WLS Installation doc preview](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-3437-7.0-JNDI-JMS-Names-DM/#wls-jms-queues-create-proc)