### PR TITLE
Upstream master PR for BXMSDOC-4496: Removed the outdated content from the interacting with processes and tasks document.

### DIFF
--- a/assemblies/assembly_interacting-with-processes/main.adoc
+++ b/assemblies/assembly_interacting-with-processes/main.adoc
@@ -30,17 +30,17 @@ include::{enterprise-dir}/processes/interacting-with-processes-filter-tasks-con.
 include::{enterprise-dir}/processes/interacting-with-processes-tasks-basic-filters-proc.adoc[leveloffset=+2]
 include::{enterprise-dir}/processes/interacting-with-processes-tasks-advanced-filters-proc.adoc[leveloffset=+2]
 include::{enterprise-dir}/processes/interacting-with-processes-tasks-default-filters-proc.adoc[leveloffset=+2]
-include::{enterprise-dir}/processes/interacting-with-processes-tasks-viewing-task-variables-con.adoc[leveloffset=+2]
-include::{enterprise-dir}/processes/interacting-with-processes-viewing-task-variables-basic-filters-proc.adoc[leveloffset=+3]
-include::{enterprise-dir}/processes/interacting-with-processes-viewing-task-variables-advanced-filters-proc.adoc[leveloffset=+3]
+//include::{enterprise-dir}/processes/interacting-with-processes-tasks-viewing-task-variables-con.adoc[leveloffset=+2]
+include::{enterprise-dir}/processes/interacting-with-processes-viewing-task-variables-basic-filters-proc.adoc[leveloffset=+2]
+include::{enterprise-dir}/processes/interacting-with-processes-viewing-task-variables-advanced-filters-proc.adoc[leveloffset=+2]
 
 include::{enterprise-dir}/processes/interacting-with-processes-process-instances-filters-con.adoc[leveloffset=+1]
 include::{enterprise-dir}/processes/interacting-with-processes-process-instances-basic-filters-proc.adoc[leveloffset=+2]
 include::{enterprise-dir}/processes/interacting-with-processes-process-instances-advanced-filters-proc.adoc[leveloffset=+2]
 include::{enterprise-dir}/processes/interacting-with-processes-process-instances-default-filters-proc.adoc[leveloffset=+2]
-include::{enterprise-dir}/processes/interacting-with-processes-process-instances-viewing-process-variables-con.adoc[leveloffset=+2]
-include::{enterprise-dir}/processes/interacting-with-processes-viewing-process-instances-variables-basic-filters-proc.adoc[leveloffset=+3]
-include::{enterprise-dir}/processes/interacting-with-processes-viewing-process-instances-variables-advanced-filters-proc.adoc[leveloffset=+3]
+//include::{enterprise-dir}/processes/interacting-with-processes-process-instances-viewing-process-variables-con.adoc[leveloffset=+2]
+include::{enterprise-dir}/processes/interacting-with-processes-viewing-process-instances-variables-basic-filters-proc.adoc[leveloffset=+2]
+include::{enterprise-dir}/processes/interacting-with-processes-viewing-process-instances-variables-advanced-filters-proc.adoc[leveloffset=+2]
 
 include::{enterprise-dir}/processes/interacting-with-processes-setting-date-priority-proc.adoc[leveloffset=+1]
 
@@ -50,7 +50,7 @@ include::{enterprise-dir}/processes/interacting-with-processes-viewing-task-hist
 
 include::{enterprise-dir}/processes/interacting-with-processes-viewing-process-instance-history-log-proc.adoc[leveloffset=+1]
 
-include::{enterprise-dir}/processes/interacting-with-processes-migrating-process-designer-proc.adoc[leveloffset=+1]
+//include::{enterprise-dir}/processes/interacting-with-processes-migrating-process-designer-proc.adoc[leveloffset=+1]
 
 // Versioning info
 include::_artifacts/versioning-information.adoc[]


### PR DESCRIPTION
[Epic](https://issues.jboss.org/browse/BXMSDOC-3982)
[JIRA](https://issues.jboss.org/browse/BXMSDOC-4496)
[Interacting with process and task RHPAM 7.4 doc preview](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-4496-RHPAM-RemovedChapter9/)

As per the Ivo Bek's feedback, **Chapter 9. Migrating business processes from new to legacy process designer** is outdated. So, I have removed the content from the Interacting with processes and tasks 7.4 document. 