### PR TITLE
BXMSDOC-4258: Tweaks to GDT content examples.

### DIFF
--- a/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/enumerations-define-proc.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/enumerations-define-proc.adoc
@@ -21,7 +21,7 @@ The new enumeration is now listed in the *Enumeration Definitions* panel of the 
 
 +
 --
-For example, the following enumeration defines the drop-down values for applicant credit rating in a mortgage decision service:
+For example, the following enumeration defines the drop-down values for applicant credit rating in a loan application decision service:
 
 .Example enumeration for applicant credit rating in {CENTRAL}
 image::Workbench/AuthoringAssets/EnumConfig.png[align="center"]

--- a/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/guided-decision-tables-columns-create-proc.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/guided-decision-tables-columns-create-proc.adoc
@@ -31,5 +31,7 @@ For descriptions of each column type and required parameters for setup, see xref
 
 After all columns are added, you can begin adding rows of rules correlating to your columns to complete the decision table. For details, see xref:guided-decision-tables-rows-create-proc[].
 
+The following is an example decision table for a loan application decision service:
+
 .Example of complete guided decision table
 image::Workbench/AuthoringAssets/guided-decision-tables-columns-add_02.png[Example of complete guided decision table]

--- a/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/guided-decision-tables-create-proc.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/guided-decision-tables-create-proc.adoc
@@ -12,9 +12,12 @@ You can use guided decision tables to define rule attributes, metadata, conditio
 . Specify whether you want the *Extended entry* or *Limited entry* table. For details, see xref:guided-decision-tables-types-con[].
 . Click *Ok* to complete the setup. If you have selected *Use Wizard*, the Guided Decision Table wizard is displayed. If you did not select the *Use Wizard* option, this prompt does not appear and you are taken directly to the table designer.
 +
+--
+For example, the following wizard setup is for a guided decision table in a loan application decision service:
+
 .Create guided decision table
 image::Workbench/AuthoringAssets/6326_1.png[]
-+
+--
 . If you are using the wizard, add any available imports, fact patterns, constraints, and actions, and select whether table columns should expand. Click *Finish* to close the wizard and view the table designer.
 +
 .Guided Decision Table wizard

--- a/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/guided-decision-tables-hit-policies-examples-ref.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/guided-decision-tables-hit-policies-examples-ref.adoc
@@ -1,10 +1,10 @@
 [id='hit-policies-examples-ref']
 = Hit policy examples: Decision table for discounts on movie tickets
 
-The following is part of a decision table for discounts on movie tickets based on customer age, student status, or military status, or all three.
+The following is part of an example decision table for discounts on movie tickets based on customer age, student status, or military status, or all three.
 
 
-.Decision table for available discounts on movie tickets
+.Example decision table for available discounts on movie tickets
 
 [cols="15%,15%,15%", frame="all", options="header"]
 |===
@@ -45,7 +45,7 @@ The following is part of a decision table for discounts on movie tickets based o
 
 |===
 
-The total discount to be applied in the end will vary depending on the hit policy specified for the table, as follows.
+In this example, the total discount to be applied in the end will vary depending on the hit policy specified for the table:
 
 * *None/Rule Order:* With both *None* and *Rule Order* hit policies, all applicable rules are incorporated, in this case allowing discounts to be stacked for each customer.
 +


### PR DESCRIPTION
@evacchi, I've gone through the guided decision tables doc per our discussion to make it clearer that the examples given are merely examples, and honestly, I only found a few areas where I clarified. The rest are all pretty clearly indicated as examples to me, and all use the same loan app example from BC. The only deviation is the hit policies section, which uses the different example that more clearly displays hit policy behavior. And there too I've tried to make it clearer that it's just an example.

I'm not sure what more can really be done, that's still within reason based on other priorities. Please let me know if you see clear and straightforward ways to improve this per your JIRA thoughts and our previous conversation.

Links:
* [JIRA](https://issues.jboss.org/browse/BXMSDOC-4258)
* [Doc preview](http://file.rdu.redhat.com/~sterobin/BXMSDOC-4258_PAM/)