### PR TITLE
BXMSDOC-4540 7.23.x RN 7.4.1 Known Issues Guided Rules exposes parenthesis outside of expression

### DIFF
--- a/doc-content/enterprise-only/release-notes/rn-known-issues-ref.adoc
+++ b/doc-content/enterprise-only/release-notes/rn-known-issues-ref.adoc
@@ -5,6 +5,45 @@ This section lists known issues with {PRODUCT} {PRODUCT_VERSION}.
 
 
 == {CENTRAL}
+
+.Guided rules expose parentheses outside of an expression [https://issues.jboss.org/browse/RHDM-1046[RHDM-1046]]
+
+Issue: When you create a guided rule, if you select the field for multiple values and each value is enclosed in
+parenthesis, for example `(red), (blue)`,  an invalid rule is generated.
+
+
+Steps to reproduce:
+
+. Open {CENTRAL}.
+. Open any project.
+. Create the data object `Car` with the field `color:String`.
+. Create a new guided decision table.
+. Define a new *Condition* column:
++
+*Pattern:* `$c : Car`
++
+*Calculation Type*: `Literal value`
++
+*Field*: `color`
++
+*Operator*: `is contained in the (comma separated) list`
++
+*Header*: `Car color is`
+. Select the *Model* tab and enter `(red), (blue)` in the corresponding cell.
+
+Expected result: The `$c : Car(color in ("(red)", "(blue)"))` rule is generated.
+
+Actual result: The `$c : Car( color in ("red)", "(blue") )` rule is generated.
+
+Workaround: In the *Model* tab, enter the values as shown in the following example:
+
+[source]
+----
+((red), (blue))
+----
+
+
+
 .A guided scorecard cannot be tested with the Test Scenario (Legacy) asset [https://issues.jboss.org/browse/RHPAM-2307[RHPAM-2307]]
 
 Issue: If a guided scorecard name begins with a lowercase letter, you cannot test the scorecard with the Test Scenario (Legacy) asset.


### PR DESCRIPTION
Details in jira
[BXMSDOC-4540](https://issues.jboss.org/browse/BXMSDOC-4540)