### PR TITLE
BXMSDOC-4559-master: Add section on custom Prometheus metrics.

### DIFF
--- a/assemblies/assembly_managing-and-monitoring-execution-server/main.adoc
+++ b/assemblies/assembly_managing-and-monitoring-execution-server/main.adoc
@@ -81,6 +81,8 @@ endif::PAM[]
 include::{shared-dir}/KieServer/prometheus-monitoring-con.adoc[leveloffset=+1]
 include::{shared-dir}/KieServer/prometheus-monitoring-proc.adoc[leveloffset=+2]
 include::{shared-dir}/KieServer/prometheus-monitoring-ocp-proc.adoc[leveloffset=+2]
+include::{shared-dir}/KieServer/prometheus-monitoring-custom-proc.adoc[leveloffset=+2]
+
 
 include::{enterprise-dir}/admin-and-config/configuring-openshift-connection-timeout-proc.adoc[leveloffset=+1]
 
@@ -122,5 +124,6 @@ ifdef::DM[]
 endif::[]
 * {URL_DEPLOYING_OPENSHIFT_AUTOMATION_BROKER}[_{DEPLOYING_OPENSHIFT_AUTOMATION_BROKER}_]
 * {URL_DEPLOYING_OPENSHIFT_OPERATOR}[_{DEPLOYING_OPENSHIFT_OPERATOR}_]
+
 //Versioning info
 include::_artifacts/versioning-information.adoc[]

--- a/doc-content/shared-kie-docs/src/main/asciidoc/KieServer/KieServer-chapter.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/KieServer/KieServer-chapter.adoc
@@ -35,3 +35,4 @@ include::prometheus-monitoring-con.adoc[leveloffset=+1]
 include::prometheus-monitoring-proc.adoc[leveloffset=+2]
 //Excluded until confirmed that Drools/jBPM have verified support on OpenShift. Some conditioning will be required at that point. (Stetson, 22 May 2019)
 //include::prometheus-monitoring-ocp-proc.adoc[leveloffset=+2]
+include::{shared-dir}/KieServer/prometheus-monitoring-custom-proc.adoc[leveloffset=+2]

--- a/doc-content/shared-kie-docs/src/main/asciidoc/KieServer/prometheus-monitoring-con.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/KieServer/prometheus-monitoring-con.adoc
@@ -13,3 +13,7 @@ endif::[]
 ifdef::DROOLS,JBPM,OP[]
 see the https://github.com/kiegroup/droolsjbpm-integration/tree/master/kie-server-parent/kie-server-services/kie-server-services-prometheus[{KIE_SERVER} Prometheus Extension] page on GitHub.
 endif::[]
+
+ifdef::DM,PAM[]
+IMPORTANT: Red Hat support for Prometheus is limited to the setup and configuration recommendations provided in Red Hat product documentation.
+endif::[]

--- a/doc-content/shared-kie-docs/src/main/asciidoc/KieServer/prometheus-monitoring-custom-proc.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/KieServer/prometheus-monitoring-custom-proc.adoc
@@ -1,0 +1,222 @@
+[id='prometheus-monitoring-custom-proc_{context}']
+
+= Extending Prometheus metrics monitoring in {KIE_SERVER} with custom metrics
+
+After you configure your {KIE_SERVER} instance to use Prometheus metrics monitoring, you can extend the Prometheus functionality in {KIE_SERVER} to use custom metrics according to your business needs. Prometheus then collects and stores your custom metrics along with the default metrics that {KIE_SERVER} exposes with Prometheus.
+
+As an example, this procedure defines custom Decision Model and Notation (DMN) metrics to be collected and stored by Prometheus.
+
+.Prerequisites
+* Prometheus metrics monitoring is configured for your {KIE_SERVER} instance. For information about Prometheus configuration with {KIE_SERVER} on-premise, see
+ifdef::DM,PAM[]
+<<prometheus-monitoring-proc_execution-server>>. For information about Prometheus configuration with {KIE_SERVER} on {OPENSHIFT}, see <<prometheus-monitoring-ocp-proc_execution-server>>.
+endif::[]
+ifdef::DROOLS,JBPM,OP[]
+<<prometheus-monitoring-proc_kie-apis>>.
+endif::[]
+
+.Procedure
+. Create an empty Maven project and define the following packaging type and dependencies in the `pom.xml` file for the project:
++
+.Example pom.xml file in the sample project
+[source,xml,subs="attributes+"]
+----
+<packaging>jar</packaging>
+
+<properties>
+  <version.org.kie>{MAVEN_ARTIFACT_VERSION}</version.org.kie>
+</properties>
+
+<dependencies>
+  <dependency>
+    <groupId>org.kie</groupId>
+    <artifactId>kie-api</artifactId>
+    <version>${version.org.kie}</version>
+  </dependency>
+  <dependency>
+    <groupId>org.kie.server</groupId>
+    <artifactId>kie-server-api</artifactId>
+    <version>${version.org.kie}</version>
+  </dependency>
+  <dependency>
+    <groupId>org.kie.server</groupId>
+    <artifactId>kie-server-services-common</artifactId>
+    <version>${version.org.kie}</version>
+  </dependency>
+  <dependency>
+    <groupId>org.kie.server</groupId>
+    <artifactId>kie-server-services-drools</artifactId>
+    <version>${version.org.kie}</version>
+  </dependency>
+  <dependency>
+    <groupId>org.kie.server</groupId>
+    <artifactId>kie-server-services-prometheus</artifactId>
+    <version>${version.org.kie}</version>
+  </dependency>
+  <dependency>
+    <groupId>org.kie</groupId>
+    <artifactId>kie-dmn-api</artifactId>
+    <version>${version.org.kie}</version>
+  </dependency>
+  <dependency>
+    <groupId>org.kie</groupId>
+    <artifactId>kie-dmn-core</artifactId>
+    <version>${version.org.kie}</version>
+  </dependency>
+  <dependency>
+    <groupId>org.jbpm</groupId>
+    <artifactId>jbpm-services-api</artifactId>
+    <version>${version.org.kie}</version>
+  </dependency>
+  <dependency>
+    <groupId>org.jbpm</groupId>
+    <artifactId>jbpm-executor</artifactId>
+    <version>${version.org.kie}</version>
+  </dependency>
+  <dependency>
+    <groupId>org.optaplanner</groupId>
+    <artifactId>optaplanner-core</artifactId>
+    <version>${version.org.kie}</version>
+  </dependency>
+  <dependency>
+    <groupId>io.prometheus</groupId>
+    <artifactId>simpleclient</artifactId>
+    <version>0.5.0</version>
+  </dependency>
+</dependencies>
+----
+. Implement the relevant listener from the `org.kie.server.services.prometheus.PrometheusMetricsProvider` interface as part of the custom listener class that defines your custom Prometheus metrics, as shown in the following example:
++
+--
+.Sample implementation of the `DMNRuntimeEventListener` listener in a custom listener class
+[source,java]
+----
+package org.kie.server.ext.prometheus;
+
+import io.prometheus.client.Gauge;
+import org.kie.dmn.api.core.ast.DecisionNode;
+import org.kie.dmn.api.core.event.AfterEvaluateBKMEvent;
+import org.kie.dmn.api.core.event.AfterEvaluateContextEntryEvent;
+import org.kie.dmn.api.core.event.AfterEvaluateDecisionEvent;
+import org.kie.dmn.api.core.event.AfterEvaluateDecisionServiceEvent;
+import org.kie.dmn.api.core.event.AfterEvaluateDecisionTableEvent;
+import org.kie.dmn.api.core.event.BeforeEvaluateBKMEvent;
+import org.kie.dmn.api.core.event.BeforeEvaluateContextEntryEvent;
+import org.kie.dmn.api.core.event.BeforeEvaluateDecisionEvent;
+import org.kie.dmn.api.core.event.BeforeEvaluateDecisionServiceEvent;
+import org.kie.dmn.api.core.event.BeforeEvaluateDecisionTableEvent;
+import org.kie.dmn.api.core.event.DMNRuntimeEventListener;
+import org.kie.server.api.model.ReleaseId;
+import org.kie.server.services.api.KieContainerInstance;
+
+public class ExampleCustomPrometheusMetricListener implements DMNRuntimeEventListener {
+
+    private final KieContainerInstance kieContainer;
+
+    private final Gauge randomGauge = Gauge.build()
+            .name("random_gauge_nanosecond")
+            .help("Random gauge as an example of custom KIE Prometheus metric")
+            .labelNames("container_id", "group_id", "artifact_id", "version", "decision_namespace", "decision_name")
+            .register();
+
+    public ExampleCustomPrometheusMetricListener(KieContainerInstance containerInstance) {
+        kieContainer = containerInstance;
+    }
+
+    public void beforeEvaluateDecision(BeforeEvaluateDecisionEvent e) {
+    }
+
+    public void afterEvaluateDecision(AfterEvaluateDecisionEvent e) {
+        DecisionNode decisionNode = e.getDecision();
+        ReleaseId releaseId = kieContainer.getResource().getReleaseId();
+        randomGauge.labels(kieContainer.getContainerId(), releaseId.getGroupId(),
+                           releaseId.getArtifactId(), releaseId.getVersion(),
+                           decisionNode.getModelName(), decisionNode.getModelNamespace())
+                .set((int) (Math.random() * 100));
+    }
+
+    public void beforeEvaluateBKM(BeforeEvaluateBKMEvent event) {
+    }
+
+    public void afterEvaluateBKM(AfterEvaluateBKMEvent event) {
+    }
+
+    public void beforeEvaluateContextEntry(BeforeEvaluateContextEntryEvent event) {
+    }
+
+    public void afterEvaluateContextEntry(AfterEvaluateContextEntryEvent event) {
+    }
+
+    public void beforeEvaluateDecisionTable(BeforeEvaluateDecisionTableEvent event) {
+    }
+
+    public void afterEvaluateDecisionTable(AfterEvaluateDecisionTableEvent event) {
+    }
+
+    public void beforeEvaluateDecisionService(BeforeEvaluateDecisionServiceEvent event) {
+    }
+
+    public void afterEvaluateDecisionService(AfterEvaluateDecisionServiceEvent event) {
+    }
+}
+----
+
+The `PrometheusMetricsProvider` interface contains the required listeners for collecting Prometheus metrics. The interface is incorporated by the `kie-server-services-prometheus` dependency that you declared in your project `pom.xml` file.
+
+In this example, the `ExampleCustomPrometheusMetricListener` class implements the `DMNRuntimeEventListener` listener (from the `PrometheusMetricsProvider` interface) and defines the custom DMN metrics to be collected and stored by Prometheus.
+--
+. Implement the `PrometheusMetricsProvider` interface as part of a custom metrics provider class that associates your custom listener with the `PrometheusMetricsProvider` interface, as shown in the following example:
++
+--
+.Sample implementation of the `PrometheusMetricsProvider` interface in a custom metrics provider class
+[source,java]
+----
+package org.kie.server.ext.prometheus;
+
+import org.jbpm.executor.AsynchronousJobListener;
+import org.jbpm.services.api.DeploymentEventListener;
+import org.kie.api.event.rule.AgendaEventListener;
+import org.kie.api.event.rule.DefaultAgendaEventListener;
+import org.kie.dmn.api.core.event.DMNRuntimeEventListener;
+import org.kie.server.services.api.KieContainerInstance;
+import org.kie.server.services.prometheus.PrometheusMetricsProvider;
+import org.optaplanner.core.impl.phase.event.PhaseLifecycleListener;
+import org.optaplanner.core.impl.phase.event.PhaseLifecycleListenerAdapter;
+
+public class MyPrometheusMetricsProvider implements PrometheusMetricsProvider {
+
+    public DMNRuntimeEventListener createDMNRuntimeEventListener(KieContainerInstance kContainer) {
+        return new ExampleCustomPrometheusMetricListener(kContainer);
+    }
+
+    public AgendaEventListener createAgendaEventListener(String kieSessionId, KieContainerInstance kContainer) {
+        return new DefaultAgendaEventListener();
+    }
+
+    public PhaseLifecycleListener createPhaseLifecycleListener(String solverId) {
+        return new PhaseLifecycleListenerAdapter() {
+        };
+    }
+
+    public AsynchronousJobListener createAsynchronousJobListener() {
+        return null;
+    }
+
+    public DeploymentEventListener createDeploymentEventListener() {
+        return null;
+    }
+}
+----
+
+In this example, the `MyPrometheusMetricsProvider` class implements the `PrometheusMetricsProvider` interface and includes your custom `ExampleCustomPrometheusMetricListener` listener class.
+--
+. To make the new metrics provider discoverable for {KIE_SERVER}, create a `META-INF/services/org.kie.server.services.prometheus.PrometheusMetricsProvider` file in your Maven project and add the fully qualified class name of the `PrometheusMetricsProvider` implementation class within the file. For this example, the file contains the single line `org.kie.server.ext.prometheus.MyPrometheusMetricsProvider`.
+. Build your project and copy the resulting JAR file into the `~/kie-server.war/WEB-INF/lib` directory of your project.
+ifdef::DM,PAM[]
+For example, on {EAP}, the path to this directory is `_EAP_HOME_/standalone/deployments/kie-server.war/WEB-INF/lib`.
+endif::[]
+. Start the {KIE_SERVER} and deploy the built project to the running {KIE_SERVER}. You can deploy the project using the {CENTRAL} interface or the {KIE_SERVER} REST API (a `PUT` request to `\http://SERVER:PORT/kie-server/services/rest/server/containers/{containerId}`).
++
+--
+After your project is deployed on a running {KIE_SERVER}, Prometheus begins collecting metrics and {KIE_SERVER} publishes the metrics to the REST API endpoint `\http://HOST:PORT/SERVER/services/rest/metrics` (or on Spring Boot, to `\http://HOST:PORT/rest/metrics`).
+--


### PR DESCRIPTION
@vblagoje @sutaakar , can you SME and QE review this? Valdimir said they merged it for 7.25 / 7.5 last minute and ideally would like for the new doc section to be included with the cutoff. Links below. **Please see also my questions below.**

@mramendi, can you also have a glance from the OCP perspective at the same time? So that anything you voice can be in the live conversation during SME/QE review.

Links:
* [DM doc preview](http://file.rdu.redhat.com/~sterobin/BXMSDOC-4559_DM/#prometheus-monitoring-custom-proc_execution-server)
* [PAM doc preview](http://file.rdu.redhat.com/~sterobin/BXMSDOC-4559_PAM/#prometheus-monitoring-custom-proc_execution-server) - Same, but for PAM
* [Drools doc preview](http://file.rdu.redhat.com/~sterobin/BXMSDOC-4559_DROOLS/#prometheus-monitoring-custom-proc_kie-apis) - Same, but for Drools.
* [jBPM doc preview](http://file.rdu.redhat.com/~sterobin/BXMSDOC-4559_JBPM/#prometheus-monitoring-custom-proc_kie-apis) - Same, but for jBPM.

**Questions/comments:**
* In step 1, creating the maven project and setting packaging to `jar`, doesn't the user also need to add a bunch of dependencies? I'm coincidentally also documenting a series of similar procedures for extending KIE Server capabilities based on Maciej's blogs, such as [extending KIE Server transports](http://mswiderski.blogspot.com/2015/12/kie-server-extend-kie-server-with.html), and in each case, the maven project also needs several dependencies to work properly. How about in this procedure with Prometheus?
* This procedure assumes the user has already configured Prometheus (prerequisite) either on-premise or on OCP, so the current procedure as it stands applies to OCP and on-premise alike, correct? Or is anything different for OCP in this procedure?
* The format and even section title is intentionally consistent with the other similar sections on extending KIE Server extensions that I'm currently working on. Suggestions are certainly welcome, but just FYI, if you're wondering.