### PR TITLE
JBPM-8763: System property to activate keycloak authentication on bus…

### DIFF
--- a/doc-content/enterprise-only/integration/sso-kie-server-client-adapter-proc.adoc
+++ b/doc-content/enterprise-only/integration/sso-kie-server-client-adapter-proc.adoc
@@ -61,12 +61,13 @@ In this example:
 --
 +
 
+. If you are using {CENTRAL} as {KIE_SERVER} controller you must set the system property `org.jbpm.workbench.kie_server.keycloak` as `true`.
 . Save your configuration changes.
 . Use the following command to restart the {EAP} server and run {KIE_SERVER}.
 +
 [source,subs="attributes+"]
 ----
-EXEC_SERVER_HOME/bin/standalone.sh -Dorg.kie.server.id=<ID> -Dorg.kie.server.user=<USER> -Dorg.kie.server.pwd=<PWD> -Dorg.kie.server.location=<LOCATION_URL> -Dorg.kie.server.controller=<CONTROLLER_URL> -Dorg.kie.server.controller.user=<CONTROLLER_USER> -Dorg.kie.server.controller.pwd=<CONTOLLER_PASSWORD>
+EXEC_SERVER_HOME/bin/standalone.sh -Dorg.kie.server.id=<ID> -Dorg.kie.server.user=<USER> -Dorg.kie.server.pwd=<PWD> -Dorg.kie.server.location=<LOCATION_URL> -Dorg.kie.server.controller=<CONTROLLER_URL> -Dorg.kie.server.controller.user=<CONTROLLER_USER> -Dorg.kie.server.controller.pwd=<CONTOLLER_PASSWORD> -Dorg.jbpm.workbench.kie_server.keycloak=true
 ----
 +
 For example:

--- a/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/KeycloakSSOIntegration/KC_SSO_integ-section.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/KeycloakSSOIntegration/KC_SSO_integ-section.adoc
@@ -381,8 +381,7 @@ Consider your concrete environment settings if different from this example:
 * Enable basic auth -> Up to you. You can enable Basic auth for third party service consumers
 * Credential -> Use the secret key for the _kie-execution-server_ client. You can find it in the __Credentials__tab of the KC admin console
 
-CAUTION: If you are using {CENTRAL} as {KIE_SERVER} controller you must set the system property `org.jbpm.workbench.kie_server.keycloak` as `true` in the server where {CENTRAL} is running.
-
+CAUTION: If you are using {CENTRAL} as a {KIE_SERVER} controller, you must set the value of the `org.jbpm.workbench.kie_server.keycloak` system property to true in the server where {CENTRAL} is running.
 
 === Deploy and run the execution server
 

--- a/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/KeycloakSSOIntegration/KC_SSO_integ-section.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/KeycloakSSOIntegration/KC_SSO_integ-section.adoc
@@ -381,6 +381,8 @@ Consider your concrete environment settings if different from this example:
 * Enable basic auth -> Up to you. You can enable Basic auth for third party service consumers
 * Credential -> Use the secret key for the _kie-execution-server_ client. You can find it in the __Credentials__tab of the KC admin console
 
+CAUTION: If you are using {CENTRAL} as {KIE_SERVER} controller you must set the system property `org.jbpm.workbench.kie_server.keycloak` as `true` in the server where {CENTRAL} is running.
+
 
 === Deploy and run the execution server
 


### PR DESCRIPTION
This is only for 7.26.Final community and for RHPAM 7.5.

The new system property was an immediate solution for 7.5 and 7.26 to disable keycloak due a classloading issue.

In master this change does not apply due the following change made by Cristiano:
https://github.com/kiegroup/jbpm-wb/pull/1388

