### PR TITLE
BXMSDOC-4650-master: Add note about KIE session ID in KIE APIs doc.

### DIFF
--- a/doc-content/shared-kie-docs/src/main/asciidoc/Commands/runtime-commands-samples-ref.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/Commands/runtime-commands-samples-ref.adoc
@@ -73,6 +73,8 @@ Contains multiple commands to be executed together.
 
 |===
 
+NOTE: KIE session IDs are in the `kmodule.xml` file of your {PRODUCT} project. To view or add a KIE session ID in {CENTRAL} to use with the `lookup` command attribute, navigate to the relevant project in {CENTRAL} and go to project *Settings* -> *KIE bases* -> *KIE sessions*. If no KIE bases exist, click *Add KIE base* -> *KIE sessions* to define the new KIE base and KIE sessions.
+
 .Example JSON request body
 [source,json]
 ----


### PR DESCRIPTION
Details in [JIRA](https://issues.jboss.org/browse/BXMSDOC-4650).

@tarilabs, does this doc update answer that customer's [stack overflow question](https://stackoverflow.com/questions/57627740/how-to-invoke-decision-service-as-a-stateless-session-in-kie-redhat-decision-ma) about KIE session ID, and is it good with you? I know you suggested in your email to link to the managing projects doc, but I decided to just tell them what they need to know in a note instead. Reason is that even with the link, it's still a bit buried, as you noticed (would need to link very specifically to KIE sessions and then expand that bullet). Plus we try to reduce doc links where we can and just give customers the info they need where they need it as much as possible.

Let me know what you think.