### PR TITLE
JBPM-8567 - Add support ISO8601 expressions for user task notificatio…

### DIFF
--- a/doc-content/jbpm-docs/src/main/asciidoc/TaskService/TaskEscalationsAndNotifications-section.adoc
+++ b/doc-content/jbpm-docs/src/main/asciidoc/TaskService/TaskEscalationsAndNotifications-section.adoc
@@ -140,3 +140,7 @@ For example "R2/PT6H/2019-01-01T13:00:00Z" is a trigger that first fires on Janu
 
 * *R/startDate/endDate* - First triggers at the startDate and the duration set at endDate - startDate.
 For example: "R2/2019-01-01T13:00:00Z/2019-01-01T16:00:00Z" is a trigger that fires on January 1st 2019 at 1pm and re-fires two times three and six hours from the first fire.
+
+IMPORTANT: You can use one unbounded or multiple bounded (non-ISO8601) definitions for each escalation or notification type (such as `not-completed` or `not-started`).
+You cannot mix unbounded and bounded notifications and escalations. For example, you cannot use R2/PT1S for a `not-completed` notification and R/PT2S for a `not-completed` escalation because both are of the `not-completed` type.
+However, you can use R2/PT1S for a `not-started` escalation and R/PT2S for a `not-completed` escalation. Whether a definition is an escalation or a notification is irrelevant, but the type distinction is important.


### PR DESCRIPTION
…ns - add a note about mixing of bounded and unbounded deadlines

Hi guys,

I now realized that we have in fact omitted the important note I [mentioned](https://github.com/kiegroup/kie-docs/pull/1633#issuecomment-501735694) in the original PR. This PR fixes that.

I tried to choose as clear wording as possible, but I would like to know your opinion as well.

Once this is approved, I will also create a backport for 7.26.x.