### PR TITLE
Upstream 7.26.x PR for BXMSDOC-4451: Update installing and configuring process/decision server on WAS doc per changes in 7.5

### DIFF
--- a/_artifacts/document-attributes.adoc
+++ b/_artifacts/document-attributes.adoc
@@ -39,8 +39,8 @@ endif::OP[]
 :YEAR: 2019
 
 // Maven info, from https://mvnrepository.com (public repo) or https://repository.jboss.org/nexus/index.html#welcome (Nexus repo)
-:MAVEN_ARTIFACT_VERSION: 7.26.0.Final-redhat-00002
-:BOM_VERSION: 7.5.0.GA-redhat-00002
+:MAVEN_ARTIFACT_VERSION: 7.26.0.Final-redhat-00003
+:BOM_VERSION: 7.5.0.redhat-00003
 
 // Product names
 :PRODUCT_PAM: Red Hat Process Automation Manager

--- a/assemblies/assembly_installing-dsps-on-was/main.adoc
+++ b/assemblies/assembly_installing-dsps-on-was/main.adoc
@@ -24,55 +24,31 @@ include::{enterprise-dir}/websphere/was-con.adoc[leveloffset=+1]
 include::{enterprise-dir}/websphere/was-install-start-proc.adoc[leveloffset=+1]
 
 include::{enterprise-dir}/websphere/was-configure-proc.adoc[leveloffset=+1]
-
 include::{enterprise-dir}/websphere/was-security-set-proc.adoc[leveloffset=+2]
-
 ifdef::PAM[]
 include::{enterprise-dir}/websphere/was-data-source-create-proc.adoc[leveloffset=+2]
 endif::PAM[]
-
 include::{enterprise-dir}/weblogic/wls-was-jms-configure-con.adoc[leveloffset=+2]
-
 include::{enterprise-dir}/websphere/was-jms-bus-proc.adoc[leveloffset=+3]
-
 include::{enterprise-dir}/websphere/was-jms-factory-create-proc.adoc[leveloffset=+3]
-
 include::{enterprise-dir}/installation/jms-factories-ref.adoc[leveloffset=+4]
-
 include::{enterprise-dir}/websphere/was-jms-queues-create-proc.adoc[leveloffset=+3]
-
 include::{enterprise-dir}/installation/jms-queues-ref.adoc[leveloffset=+4]
-
 include::{enterprise-dir}/websphere/was-jms-activation-proc.adoc[leveloffset=+3]
-
 include::{enterprise-dir}/installation/jms-activation-ref.adoc[leveloffset=+4]
-
 include::{enterprise-dir}/websphere/kie-server-was-environment-set-proc.adoc[leveloffset=+2]
-
 include::{enterprise-dir}/websphere/was-stop-start-proc.adoc[leveloffset=+2]
 
 include::{enterprise-dir}/websphere/kie-server-was-install-proc.adoc[leveloffset=+1]
-
 include::{enterprise-dir}/websphere/kie-server-was-group-proc.adoc[leveloffset=+2]
-
 include::{enterprise-dir}/websphere/kie-server-was-mapping-proc.adoc[leveloffset=+2]
-
 include::{enterprise-dir}/websphere/was-ks-classloader-proc.adoc[leveloffset=+2]
-
 include::{enterprise-dir}/websphere/kie-server-was-verify-proc.adoc[leveloffset=+2]
 
 include::{enterprise-dir}/websphere/controller-was-install-proc.adoc[leveloffset=+1]
-
 include::{enterprise-dir}/websphere/was-controller-classloader-proc.adoc[leveloffset=+2]
-
-
 include::{enterprise-dir}/weblogic/controller-wls-was-environment-set-proc.adoc[leveloffset=+2]
-
-//:context: controller-was-install
-//include::{enterprise-dir}/websphere/controller-was-group-proc.adoc[leveloffset=+2]
-
 include::{enterprise-dir}/websphere/controller-was-mapping-proc.adoc[leveloffset=+2]
-
 include::{enterprise-dir}/websphere/controller-wls-was-verify-proc.adoc[leveloffset=+2]
 
 include::{enterprise-dir}/websphere/was-configure-embedded-engine-proc.adoc[leveloffset=+1]

--- a/doc-content/enterprise-only/installation/securing-passwords-was-proc.adoc
+++ b/doc-content/enterprise-only/installation/securing-passwords-was-proc.adoc
@@ -51,7 +51,7 @@ If {KIE_SERVER} is not configured with JCEKS, {KIE_SERVER} passwords are stored 
 | `<KEY_CONTROL_ALIAS>`
 | Alias of the key for default REST Process Automation Controller where the password is stored
 
-| `kie.keystore.key.ctrl.key.ctrl.pwd`
+| `kie.keystore.key.ctrl.pwd`
 | `<KEY_CONTROL_PWD>`
 | Password of the alias for default REST  Process Automation Controller with the stored password
 

--- a/doc-content/enterprise-only/websphere/kie-server-was-environment-set-proc.adoc
+++ b/doc-content/enterprise-only/websphere/kie-server-was-environment-set-proc.adoc
@@ -30,7 +30,7 @@ This opens the configuration properties for the JVM that is used to start {WEBSP
 |Description
 
 |`kie.server.jms.queues.response`
-|`jms/queue/KIE.SERVER.RESPONSE`
+|`jms/KIE.SERVER.RESPONSE`
 |The JNDI name of JMS queue for responses used by {KIE_SERVER}.
 
 |`org.kie.server.domain`
@@ -65,7 +65,7 @@ ifdef::PAM[]
 |Specifies the Hibernate dialect to be used. Set according to data source.
 
 |`org.kie.executor.jms.queue`
-|`jms/queue/KIE.SERVER.EXECUTOR`
+|`jms/KIE.SERVER.EXECUTOR`
 |Job executor JMS queue for {KIE_SERVER}.
 
 |`org.kie.executor.jms.cf`

--- a/doc-content/enterprise-only/websphere/was-data-source-create-proc.adoc
+++ b/doc-content/enterprise-only/websphere/was-data-source-create-proc.adoc
@@ -12,7 +12,7 @@ A data source is an object that enables a Java Database Connectivity (JDBC) clie
 * *Version:* {PRODUCT_VERSION}
 . Download *{PRODUCT} {PRODUCT_VERSION}.x Add-Ons*, where *x* is the current patch version.
 . Complete the following steps to prepare your database:
-.. Extract `{PRODUCT_INIT}-{PRODUCT_VERSION}.x-add-ons.zip` in a temporary directory, for example `TEMP_DIR`.
+.. Extract `{PRODUCT_FILE}-add-ons.zip` in a temporary directory, for example `TEMP_DIR`.
 .. Extract `TEMP_DIR/{PRODUCT_INIT}-{PRODUCT_VERSION}-migration-tool.zip`.
 .. Change your current directory to the `TEMP_DIR/{PRODUCT_INIT}-{PRODUCT_VERSION}-migration-tool/ddl-scripts` directory. This directory contains DDL scripts for several database types.
 .. Import the DDL script for your database type into the database that you want to use, for example:

--- a/doc-content/enterprise-only/websphere/was-jms-activation-proc.adoc
+++ b/doc-content/enterprise-only/websphere/was-jms-activation-proc.adoc
@@ -12,5 +12,5 @@ A JMS activation specification is required in order to bridge the queue and the 
 . Select the correct scope and click *New*.
 . Select the *Default Messaging Provider* option and click *OK*.
 . For each of the following required activation specifications, enter the name of the activation specification (for example, `KIE.SERVER.REQUEST`) and the JNDI name (for example, `jms/activation/KIE.SERVER.REQUEST`), and then select the service bus from the *Bus Name* drop-down list.
-. From the *Destination Type* drop-down list, select *Queue* and enter the name of the corresponding queue as a *Destination lookup* (for example, `jms/queue/KIE.SERVER.REQUEST`).
+. From the *Destination Type* drop-down list, select *Queue* and enter the name of the corresponding queue as a *Destination lookup* (for example, `jms/KIE.SERVER.REQUEST`).
 . Click *Apply* and *Save* to save the changes to the master configuration, and repeat for each required activation specification.

--- a/doc-content/enterprise-only/websphere/was-jms-queues-create-proc.adoc
+++ b/doc-content/enterprise-only/websphere/was-jms-queues-create-proc.adoc
@@ -10,6 +10,6 @@ JMS queues are the destination end points for point-to-point messaging. You must
 . In the WebSphere Integrated Solutions Console, navigate to *Resources* -> *JMS* -> *Queues*.
 . Select the correct scope and click *New*.
 . Select the *Default Messaging Provider* option and click *OK*.
-. For each of the following required queues, enter the name of the queue (for example, `KIE.SERVER.REQUEST`) and the JNDI name (for example, `jms/queue/KIE.SERVER.REQUEST`), and then select the service bus from the *Bus Name* drop-down list.
+. For each of the following required queues, enter the name of the queue (for example, `KIE.SERVER.REQUEST`) and the JNDI name (for example, `jms/KIE.SERVER.REQUEST`), and then select the service bus from the *Bus Name* drop-down list.
 . From the *Queue Name* drop-down list, select the *Create Service Integration Bus Destination*, enter a unique identifier, and select the bus member that you created previously.
 . Click *Apply* and *Save* to save the changes to the master configuration, and repeat for each required queue.


### PR DESCRIPTION
[Epic](https://issues.jboss.org/browse/BXMSDOC-4451)
[JIRA](https://issues.jboss.org/browse/BXMSDOC-4623)
[Installing and configuring process server on WAS](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-4451-WAS-PAM-FP/#was-configure-embedded-engine-proc)
[Installing and configuring process server on WAS](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-4451-WAS-DM-FP/#was-configure-embedded-engine-proc)