### PR TITLE
Fix spelling of `Node.js` (platform) and `.NET` (framework)

### DIFF
--- a/doc-content/drools-docs/src/main/asciidoc/DMN/dmn-execution-rest-proc.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/DMN/dmn-execution-rest-proc.adoc
@@ -1,7 +1,7 @@
 [id='dmn-execution-rest-proc']
 = Executing a DMN service using the {KIE_SERVER} REST API
 
-Directly interacting with the REST endpoints of {KIE_SERVER} provides the most separation between the calling code and the decision logic definition. The calling code is completely free of direct dependencies, and you can implement it in an entirely different development platform such as `node.js` or `.net`. The examples in this section demonstrate Nix-style curl commands but provide relevant information to adapt to any REST client.
+Directly interacting with the REST endpoints of {KIE_SERVER} provides the most separation between the calling code and the decision logic definition. The calling code is completely free of direct dependencies, and you can implement it in an entirely different development platform such as `Node.js` or `.NET`. The examples in this section demonstrate Nix-style curl commands but provide relevant information to adapt to any REST client.
 
 For more information about the {KIE_SERVER} REST API, see
 ifdef::DM,PAM[]


### PR DESCRIPTION
See: https://en.wikipedia.org/wiki/Node.js

And:

> ".NET" redirects here.

https://en.wikipedia.org/wiki/.NET_Framework 

