### PR TITLE
BXMSDOC-4721-master: Add EJB API section to APIs content.

### DIFF
--- a/_artifacts/document-attributes.adoc
+++ b/_artifacts/document-attributes.adoc
@@ -1,5 +1,5 @@
 
-:REBUILT: Tuesday, October 29, 2019
+:REBUILT: Thursday, October 31, 2019
 
 :ENTERPRISE_VERSION: 7.5
 :COMMUNITY_VERSION: 7.26
@@ -39,8 +39,8 @@ endif::OP[]
 :YEAR: 2019
 
 // Maven info, from https://mvnrepository.com (public repo) or https://repository.jboss.org/nexus/index.html#welcome (Nexus repo)
-:MAVEN_ARTIFACT_VERSION: 7.26.0.Final-redhat-00004
-:BOM_VERSION: 7.5.0.redhat-00003
+:MAVEN_ARTIFACT_VERSION: 7.26.0.Final-redhat-00005
+:BOM_VERSION: 7.5.0.redhat-00004
 
 // Product names
 :PRODUCT_PAM: Red Hat Process Automation Manager

--- a/assemblies/assembly_kie-apis/main.adoc
+++ b/assemblies/assembly_kie-apis/main.adoc
@@ -91,6 +91,13 @@ include::{shared-dir}/Workbench/RemoteAPI/knowledge-store-rest-api-projects-ref.
 
 include::{shared-dir}/Workbench/RemoteAPI/knowledge-store-rest-api-jobs-ref.adoc[leveloffset=+3]
 
+ifdef::PAM[]
+include::{shared-dir}/KieServer/ejb-api-con.adoc[leveloffset=+1]
+
+include::{shared-dir}/KieServer/ejb-api-services-ref.adoc[leveloffset=+2]
+
+include::{shared-dir}/KieServer/ejb-api-war-proc.adoc[leveloffset=+2]
+endif::[]
 
 == Additional resources
 * {URL_MANAGING_KIE_SERVER}[_{MANAGING_KIE_SERVER}_]

--- a/doc-content/shared-kie-docs/src/main/asciidoc/KieServer/KieServer-chapter.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/KieServer/KieServer-chapter.adoc
@@ -28,6 +28,11 @@ include::controller-java-api-con.adoc[leveloffset=+1]
 include::controller-java-api-requests-proc.adoc[leveloffset=+2]
 include::controller-java-clients-ref.adoc[leveloffset=+2]
 include::controller-java-api-examples-ref.adoc[leveloffset=+2]
+ifdef::JBPM[]
+include::ejb-api-con.adoc[leveloffset=+1]
+include::ejb-api-services-ref.adoc[leveloffset=+2]
+include::ejb-api-war-proc.adoc[leveloffset=+2]
+endif::[]
 
 include::SecuringPasswords.adoc[leveloffset=+1]
 

--- a/doc-content/shared-kie-docs/src/main/asciidoc/KieServer/ejb-api-con.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/KieServer/ejb-api-con.adoc
@@ -1,0 +1,15 @@
+[id='ejb-api-con_{context}']
+
+= EJB API for KIE sessions and task services
+
+{PRODUCT} provides an Enterprise JavaBeans (EJB) API that you can use for embedded use cases to access `KieSession` and `TaskService` objects remotely from an application. The EJB API enables close transaction integration between the {PROCESS_ENGINE} in {PRODUCT} and remote customer applications.
+
+Although {KIE_SERVER} does not support EJB, you can use EJB as a remote protocol for the {PROCESS_ENGINE} similar to remote REST or JMS operations with {KIE_SERVER}.
+
+The implementation of the EJB interface is a single framework-independent and container-agnostic API that you can use with framework-specific code. The EJB services are exposed through the `org.jbpm.services.api` and `org.jbpm.services.ejb` packages in {PRODUCT}. The implementation does not support the `RuleService` class, but the `ProcessService` class exposes an `execute` method that enables you to use various rule-related commands, such as `InsertCommand` and `FireAllRulesCommand`.
+
+NOTE: Contexts and Dependency Injection (CDI) is also supported through the `org.jbpm.services.cdi` package in {PRODUCT}. However, to avoid conflicts in your EJB integration, do not use EJB and CDI together.
+
+ifdef::JBPM[]
+For more information about {PRODUCT} integration with EJB, see <<_ejb>>.
+endif::[]

--- a/doc-content/shared-kie-docs/src/main/asciidoc/KieServer/ejb-api-services-ref.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/KieServer/ejb-api-services-ref.adoc
@@ -1,0 +1,36 @@
+[id='ejb-api-services-ref_{context}']
+
+// Workaround until we address the EAP/Wildfly variable issue properly and globally. (Stetson, 22 Oct 2019)
+ifdef::JBPM[]
+:EAP: Wildfly
+endif::[]
+
+= Supported EJB services
+
+For the full list of available Enterprise JavaBeans (EJB) services in {PRODUCT},
+ifdef::PAM[]
+download the *{PRODUCT} {PRODUCT_VERSION_LONG} Maven Repository* from the https://access.redhat.com/jbossnetwork/restricted/listSoftware.html[Red Hat Customer Portal] and navigate to `~/jboss-{PRODUCT_FILE_BA}.GA-maven-repository/maven-repository/org/jbpm/jbpm-services-ejb-*`.
+endif::[]
+ifdef::JBPM[]
+see the EJB services source in https://github.com/kiegroup/jbpm/tree/master/jbpm-services/jbpm-services-ejb[GitHub].
+endif::[]
+
+The artifacts that provide the EJB interface to the {PRODUCT_JBPM} services are in the following packages:
+
+* `org.jbpm.services.ejb.api`: Contains extensions of the {PRODUCT_JBPM} services API for the EJB interface
+* `org.jbpm.services.ejb.impl`: Contains EJB wrappers on top of the core service implementation
+* `org.jbpm.services.ejb.client`: Contains the EJB remote client implementation, supported on {EAP} only
+
+The `org.jbpm.services.ejb.api` package contains the following service interfaces that you can use with remote EJB clients:
+
+* `DefinitionServiceEJBRemote`: Use this interface to gather information about processes (ID, name, and version), process variables (name and type), defined reusable subprocesses, domain-specific services, user tasks, and user task inputs and outputs.
+* `DeploymentServiceEJBRemote`: Use this interface to initiate deployments and undeployments. The interface includes the methods `deploy`, `undeploy`, `getRuntimeManager`, `getDeployedUnits`, `isDeployed`, `activate`, `deactivate`, and `getDeployedUnit`. Calling the `deploy` method with an instance of `DeploymentUnit` deploys the unit into the runtime engine by building a `RuntimeManager` instance. After a successful deployment, an instance of `DeployedUnit` is created and cached for further use. (To use these methods, you must install the artifacts of the project in a Maven repository.)
+* `ProcessServiceEJBRemote`: Use this interface to control the life cycle of one or more processes and work items.
+* `RuntimeDataServiceEJBRemote`: Use this interface to retrieve data related to the run time, such as process instances, process definitions, node instance information, and variable information. The interface includes several convenience methods for gathering task information based on owner, status, and time.
+* `UserTaskServiceEJBRemote`: Use this interface to control the life cycle of a user task. The interface includes several convenience methods for interacting with user tasks, such as `activate`, `start`, `stop`, and `execute`.
+* `QueryServiceEJBRemote`: Use this interface for advanced queries.
+* `ProcessInstanceMigrationServiceEJBRemote`: Use this interface to migrate process instances when a new version of a process definition is deployed.
+
+If you run EJB applications and {CENTRAL} on the same {KIE_SERVER} instance, you can synchronize the information between EJB and {CENTRAL} at a specified interval by setting the `org.jbpm.deploy.sync.int` system property. After the service finishes the synchronization, you can access the updated information using REST operations.
+
+NOTE: EJB services in {PRODUCT} are intended for embedded use cases. If you run EJB applications and {CENTRAL} on the same {KIE_SERVER} instance, you must also add the `kie-services` package on the class path of your EJB application.

--- a/doc-content/shared-kie-docs/src/main/asciidoc/KieServer/ejb-api-war-proc.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/KieServer/ejb-api-war-proc.adoc
@@ -1,0 +1,55 @@
+[id='ejb-api-war-proc_{context}']
+
+// Workaround until we address the EAP/Wildfly variable issue properly and globally. (Stetson, 22 Oct 2019)
+ifdef::JBPM[]
+:EAP: Wildfly
+endif::[]
+
+= Deploying an EJB services WAR file
+
+You can use the Enterprise JavaBeans (EJB) interface to create and deploy an EJB services WAR file that you want to use as part of your {PRODUCT} distribution.
+
+.Procedure
+
+. Register a human task callback using a startup Java class, such as the following example:
++
+[source]
+----
+@Singleton
+@Startup
+public class StartupBean {
+
+  @PostConstruct
+  public void init()
+  { System.setProperty("org.jbpm.ht.callback", "jaas"); }
+
+}
+----
+
+. Build your EJB project to generate the WAR file according to your project configuration.
+. Deploy the generated file on the {EAP} instance where {PRODUCT} is running.
++
+--
+Avoid using the `Singleton` strategy for your runtime sessions. The `Singleton` strategy can cause applications to load the same `ksession` instance multiple times from the underlying file system and cause optimistic lock exceptions.
+
+If you want to deploy the EJB WAR file on a {EAP} instance separate from the one where {PRODUCT} is running, configure your application or the application server to invoke a remote EJB and to propagate the security context.
+
+If you are using Hibernate to create a database schema for {PRODUCT}, update the `persistence.xml` file in {CENTRAL} and set the value of the `hibernate.hbm2ddl.auto` property to `update` instead of `create`.
+--
+. Test the deployment locally by creating a basic web application and injecting the EJB services, as shown in the following example:
++
+[source]
+----
+@EJB(lookup = "ejb:/sample-war-ejb-app/ProcessServiceEJBImpl!org.jbpm.services.ejb.api.ProcessServiceEJBRemote")
+private ProcessServiceEJBRemote processService;
+
+@EJB(lookup = "ejb:/sample-war-ejb-app/UserTaskServiceEJBImpl!org.jbpm.services.ejb.api.UserTaskServiceEJBRemote")
+private UserTaskServiceEJBRemote userTaskService;
+
+@EJB(lookup = "ejb:/sample-war-ejb-app/RuntimeDataServiceEJBImpl!org.jbpm.services.ejb.api.RuntimeDataServiceEJBRemote")
+private RuntimeDataServiceEJBRemote runtimeDataService;
+----
+
+ifdef::PAM[]
+For more information about developing and deploying EJB applications with {EAP}, see https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/{EAP_VERSION}/html-single/developing_ejb_applications/index[_Developing EJB Applications_].
+endif::[]


### PR DESCRIPTION
@mswiderski @MarianMacik, can you SME/QE verify this new chapter on the EJB API for 7.x? It comes from the 6.4 Dev Guide, but with updates, tweaks, and cleanup. Doc previews below.

**IMPORTANT**: I will cherry-pick this as is to 7.1+. Let me know if you see any issues with that.

Links:
* [JIRA](https://issues.jboss.org/browse/BXMSDOC-4721)
* [PAM doc preview](http://file.rdu.redhat.com/~sterobin/BXMSDOC-4721_PAM/#ejb-api-con_kie-apis)
* [jBPM doc  preview](http://file.rdu.redhat.com/~sterobin/BXMSDOC-4721_JBPM/#ejb-api-con_kie-apis) - Same, but with community conditions

@cristianonicolai You're welcome to have a look as well.