### PR TITLE
BXMSDOC-4828-master: Fix engine variables in Dev Studio doc.

### DIFF
--- a/doc-content/enterprise-only/integration/codeready-studio-installing-jbpm-runtime-environment-proc.adoc
+++ b/doc-content/enterprise-only/integration/codeready-studio-installing-jbpm-runtime-environment-proc.adoc
@@ -9,12 +9,12 @@ A runtime environment is a collection of JAR files that represent a specific rel
 * Red Hat CodeReady Studio is installed.
 
 .Procedure
-. Download the {ENGINE}:
+. Download the {DECISION_ENGINE}:
 .. Log in to the https://access.redhat.com[Red Hat Customer Portal].
 .. Click *DOWNLOADS* at the top of the page.
 .. On the *Product Downloads* page that opens, navigate to the JBOSS DEVELOPMENT AND MANAGEMENT section, and click *{PRODUCT}*.
 .. On the *Software Downloads* page, download *{PRODUCT} {PRODUCT_VERSION_LONG} Add-Ons* (`{PRODUCT_FILE}-add-ons.zip`).
-.. Extract `{PRODUCT_FILE}-add-ons.zip` and then extract the jBPM runtime environment JAR files located in `{PRODUCT_FILE}-add-ons/{PRODUCT_FILE}-{URL_COMPONENT_ENGINE}.zip`.
+.. Extract `{PRODUCT_FILE}-add-ons.zip` and then extract the jBPM runtime environment JAR files located in `{PRODUCT_FILE}-add-ons/{PRODUCT_FILE}-{URL_COMPONENT_DECISION_ENGINE}.zip`.
 . From the Red Hat CodeReady Studio menu, click *Window* -> *Preferences*.
 . Click *jBPM* -> *Installed jBPM Runtimes*, and then click *Add*.
 . In the name field, enter a name for the new runtime environment.

--- a/doc-content/enterprise-only/integration/codeready-studio-installing-runtime-environments-proc.adoc
+++ b/doc-content/enterprise-only/integration/codeready-studio-installing-runtime-environments-proc.adoc
@@ -9,12 +9,12 @@ A runtime environment is a collection of JAR files that represent a specific rel
 * Red Hat CodeReady Studio is installed.
 
 .Procedure
-. Download the {ENGINE}:
+. Download the {DECISION_ENGINE}:
 .. Log in to the https://access.redhat.com[Red Hat Customer Portal].
 .. Click *DOWNLOADS* at the top of the page.
 .. On the *Product Downloads* page that opens, navigate to the JBOSS DEVELOPMENT AND MANAGEMENT section, and click *{PRODUCT}*.
 .. On the *Software Downloads* page, download *{PRODUCT} {PRODUCT_VERSION_LONG} Add-Ons* (`{PRODUCT_FILE}-add-ons.zip`).
-.. Extract `{PRODUCT_FILE}-add-ons.zip` and then extract the Drools runtime environment JAR files located in `{PRODUCT_FILE}-add-ons/{PRODUCT_FILE}-{URL_COMPONENT_ENGINE}.zip`.
+.. Extract `{PRODUCT_FILE}-add-ons.zip` and then extract the Drools runtime environment JAR files located in `{PRODUCT_FILE}-add-ons/{PRODUCT_FILE}-{URL_COMPONENT_DECISION_ENGINE}.zip`.
 . From the Red Hat CodeReady Studio menu, click *Window* -> *Preferences*.
 . Click *Drools* -> *Installed Drools Runtimes*, and then click *Add*.
 . In the name field, enter a name for the new runtime environment.


### PR DESCRIPTION
@csherrar , @emmurphy1  Just FYI. I discovered this broken/unrendered doc variable since 7.3, when I changed it. I'm guessing the branch wasn't rebased or something when merged. Not sure. Anyway, just FYI. I've fixed in all.