### PR TITLE
BXMSDOC-4963-master: Add performance tuning sections to relevant stories

### DIFF
--- a/assemblies/assembly_configuring-central/main.adoc
+++ b/assemblies/assembly_configuring-central/main.adoc
@@ -143,5 +143,7 @@ include::{enterprise-dir}/admin-and-config/managing-business-central-using-proce
 
 include::{shared-dir}/Workbench/Installation/business-central-system-properties-ref.adoc[leveloffset=+1]
 
+include::{shared-dir}/Workbench/performance-tuning-business-central-ref.adoc[leveloffset=+1]
+
 // Versioning info
 include::_artifacts/versioning-information.adoc[]

--- a/assemblies/assembly_decision-engine/main.adoc
+++ b/assemblies/assembly_decision-engine/main.adoc
@@ -105,6 +105,7 @@ include::{drools-dir}/Examples/decision-examples-conway-ref.adoc[leveloffset=+2]
 
 include::{drools-dir}/Examples/decision-examples-doom-ref.adoc[leveloffset=+2]
 
+include::{drools-dir}/DecisionEngine/performance-tuning-decision-engine-ref.adoc[leveloffset=+1]
 
 == Additional resources
 

--- a/assemblies/assembly_drl-rules/main.adoc
+++ b/assemblies/assembly_drl-rules/main.adoc
@@ -134,6 +134,8 @@ include::{drools-dir}/Examples/decision-examples-conway-ref.adoc[leveloffset=+2]
 
 include::{drools-dir}/Examples/decision-examples-doom-ref.adoc[leveloffset=+2]
 
+include::{drools-dir}/AuthoringAssets/performance-tuning-drl-ref.adoc[leveloffset=+1]
+
 == Next steps
 * {URL_TESTING_DECISION_SERVICE}[_{TESTING_DECISION_SERVICE}_]
 * {URL_PACKAGING_DEPLOYING_PROJECT}[_{PACKAGING_DEPLOYING_PROJECT}_]

--- a/assemblies/assembly_managing-and-monitoring-execution-server/main.adoc
+++ b/assemblies/assembly_managing-and-monitoring-execution-server/main.adoc
@@ -113,6 +113,9 @@ include::{shared-dir}/KieServer/kie-server-extensions-endpoint-proc.adoc[levelof
 include::{shared-dir}/KieServer/kie-server-extensions-transport-proc.adoc[leveloffset=+2]
 include::{shared-dir}/KieServer/kie-server-extensions-client-proc.adoc[leveloffset=+2]
 
+include::{shared-dir}/KieServer/performance-tuning-kie-server-ref.adoc[leveloffset=+1]
+
+
 
 == Additional resources
 * {URL_INSTALLING_ON_EAP}[_{INSTALLING_ON_EAP}_]

--- a/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/guided-decision-tables-validation-disable-proc.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/guided-decision-tables-validation-disable-proc.adoc
@@ -1,12 +1,16 @@
 [id='guided-decision-tables-validation-disable-proc']
 = Disabling verification and validation of guided decision tables
 
-The decision table verification and validation feature of {CENTRAL} is enabled by default. You can disable it by setting the `org.kie.verification.disable-dtable-realtime-verification` system property value to `true` in your {EAP} directory.
+The decision table verification and validation feature of {CENTRAL} is enabled by default. This feature helps you validate your guided decision tables, but with complex guided decision tables, this feature can hinder {DECISION_ENGINE} performance. You can disable this feature by setting the `org.kie.verification.disable-dtable-realtime-verification` system property value to `true` in your {PRODUCT} distribution.
 
 .Procedure
-Navigate to `$EAP_HOME/standalone/configuration/standalone-full.xml` and add the following system property:
+Navigate to `~/standalone-full.xml` and add the following system property:
 
 [source]
 ----
 <property name="org.kie.verification.disable-dtable-realtime-verification" value="true"/>
 ----
+
+ifdef::DM,PAM[]
+For example, on {EAP}, you add this system property in `$EAP_HOME/standalone/configuration/standalone-full.xml`.
+endif::[]

--- a/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/performance-tuning-drl-ref.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/performance-tuning-drl-ref.adoc
@@ -1,0 +1,7 @@
+[id='performance-tuning-drl-ref_{context}']
+
+= Performance tuning considerations with DRL
+
+The following key concepts or suggested practices can help you optimize {DECISION_ENGINE} performance. These concepts are summarized in this section as a convenience and are explained in more detail in the cross-referenced documentation, where applicable. This section will expand or change as needed with new releases of {PRODUCT}.
+
+Use

--- a/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/performance-tuning-drl-ref.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/performance-tuning-drl-ref.adoc
@@ -2,6 +2,78 @@
 
 = Performance tuning considerations with DRL
 
-The following key concepts or suggested practices can help you optimize {DECISION_ENGINE} performance. These concepts are summarized in this section as a convenience and are explained in more detail in the cross-referenced documentation, where applicable. This section will expand or change as needed with new releases of {PRODUCT}.
+The following key concepts or suggested practices can help you optimize DRL rules and {DECISION_ENGINE} performance. These concepts are summarized in this section as a convenience and are explained in more detail in the cross-referenced documentation, where applicable. This section will expand or change as needed with new releases of {PRODUCT}.
 
-Use
+Define the property and value of pattern constraints from left to right::
+In DRL pattern constraints, ensure that the fact property name is on the left side of the operator and that the value (constant or a variable) is on the right side. The property name must always be the key in the index and not the value. For example, write `Person( firstName == "John" )` instead of `Person( "John" == firstName )`. Defining the constraint property and value from right to left can hinder {DECISION_ENGINE} performance.
++
+--
+For more information about DRL patterns and constraints, see xref:drl-rules-WHEN-con_drl-rules[].
+--
+
+List the most restrictive rule conditions first::
+For rules with multiple conditions, list the conditions from most to least restrictive so that the {DECISION_ENGINE} can avoid assessing the entire set of conditions if the more restrictive conditions are not met.
++
+--
+For example, the following conditions are part of a travel-booking rule that applies a discount to travelers who book both a flight and a hotel together. In this scenario, customers rarely book hotels with flights to receive this discount, so the hotel condition is rarely met and the rule is rarely executed. Therefore, the first condition ordering is more efficient because it prevents the {DECISION_ENGINE} from evaluating the flight condition frequently and unnecessarily when the hotel condition is not met.
+
+.Preferred condition order: hotel and flight
+[source]
+----
+when
+  $h:hotel() // Rarely booked
+  $f:flight()
+----
+
+.Inefficient condition order: flight and hotel
+[source]
+----
+when
+  $f:flight()
+  $h:hotel() // Rarely booked
+----
+
+For more information about DRL patterns and constraints, see xref:drl-rules-WHEN-con_drl-rules[].
+--
+
+Avoid iterating over large collections of objects with excessive `from` clauses::
+Avoid using the `from` condition element in DRL rules to iterate over large collections of objects, as shown in the following example:
++
+--
+.Example conditions with `from` clause
+[source]
+----
+when
+  $c: Company()
+  $e : Employee ( salary > 100000.00) from $c.employees
+----
+
+In such cases, the {DECISION_ENGINE} iterates over the large graph every time the rule condition is evaluated and impedes  rule evaluation.
+
+Alternatively, instead of adding an object with a large graph that the {DECISION_ENGINE} must iterate over frequently, add the collection directly to the KIE session and then join the collection in the condition, as shown in the following example:
+
+.Example conditions without `from` clause
+[source]
+----
+when
+  $c: Company();
+  Employee (salary > 100000.00, company == $c)
+----
+
+In this example, the {DECISION_ENGINE} iterates over the list only one time and can evaluate rules more efficiently.
+
+For more information about the `from` element or other DRL condition elements, see xref:drl-rules-WHEN-elements-ref_drl-rules[].
+--
+
+Use {DECISION_ENGINE} event listeners instead of `System.out.println` statements in rules for debug logging::
+You can use `System.out.println` statements in your rule actions for debug logging and console output, but doing this for many rules can impede rule evaluation. As a more efficient alternative, use the built-in {DECISION_ENGINE} event listeners when possible. If these listeners do not meet your requirements, use a system logging utility supported by the {DECISION_ENGINE}, such as Logback, Apache Commons Logging, or Apache Log4j.
++
+--
+For more information about supported {DECISION_ENGINE} event listeners and logging utilities, see
+ifdef::DM,PAM[]
+{URL_DECISION_ENGINE_DOC}#engine-event-listeners-con_decision-engine[_{DECISION_ENGINE_DOC}_].
+endif::[]
+ifdef::DROOLS,JBPM,OP[]
+xref:engine-event-listeners-con_decision-engine[].
+endif::[]
+--

--- a/doc-content/drools-docs/src/main/asciidoc/DecisionEngine-chapter.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/DecisionEngine-chapter.adoc
@@ -70,3 +70,5 @@ include::DecisionEngine/engine-queries-con.adoc[leveloffset=+1]
 include::DecisionEngine/engine-event-listeners-con.adoc[leveloffset=+1]
 
 include::DecisionEngine/logging-proc.adoc[leveloffset=+2]
+
+include::DecisionEngine/performance-tuning-decision-engine-ref.adoc[leveloffset=+1]

--- a/doc-content/drools-docs/src/main/asciidoc/DecisionEngine/performance-tuning-decision-engine-ref.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/DecisionEngine/performance-tuning-decision-engine-ref.adoc
@@ -1,0 +1,38 @@
+[id='performance-tuning-decision-engine-ref_{context}']
+
+= Performance tuning considerations with the {DECISION_ENGINE}
+
+The following key concepts or suggested practices can help you optimize {DECISION_ENGINE} performance. These concepts are summarized in this section as a convenience and are explained in more detail in the cross-referenced documentation, where applicable. This section will expand or change as needed with new releases of {PRODUCT}.
+
+Use sequential mode for stateless KIE sessions whenever applicable::
+Sequential mode is an advanced rule base configuration in the {DECISION_ENGINE} that enables the {DECISION_ENGINE} to evaluate rules one time in the order that they are listed in the {DECISION_ENGINE} agenda without regard to changes in the working memory. As a result, rule execution may be faster in sequential mode, but important updates may not be applied to your rules. Sequential mode applies to stateless KIE sessions only.
++
+--
+To enable sequential mode, set the system property `drools.sequential` to `true`.
+
+For more information about sequential mode or other options for enabling it, see xref:phreak-sequential-mode-con_decision-engine[].
+--
+
+Use simple operations with event listeners::
+Limit the number of event listeners and the type of operations they perform. Use event listeners for simple operations, such as debug logging and setting properties. Complicated operations, such as network calls, in listeners can impede rule execution. After you finish working with a KIE session, remove the attached event listeners so that the session can be cleaned, as shown in the following example:
++
+--
+.Example event listener removed after use
+[source,java]
+----
+Listener listener = ...;
+StatelessKnowledgeSession ksession = createSession();
+try {
+    ksession.insert(fact);
+    ksession.fireAllRules();
+    ...
+} finally {
+    if (session != null) {
+        ksession.detachListener(listener);
+        ksession.dispose();
+    }
+}
+----
+
+For information about {DECISION_ENGINE} event listeners and debug logging, see xref:engine-event-listeners-con_decision-engine[].
+--

--- a/doc-content/drools-docs/src/main/asciidoc/DecisionEngine/performance-tuning-decision-engine-ref.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/DecisionEngine/performance-tuning-decision-engine-ref.adoc
@@ -4,7 +4,7 @@
 
 The following key concepts or suggested practices can help you optimize {DECISION_ENGINE} performance. These concepts are summarized in this section as a convenience and are explained in more detail in the cross-referenced documentation, where applicable. This section will expand or change as needed with new releases of {PRODUCT}.
 
-Use sequential mode for stateless KIE sessions whenever applicable::
+Use sequential mode for stateless KIE sessions that do not require important {DECISION_ENGINE} updates::
 Sequential mode is an advanced rule base configuration in the {DECISION_ENGINE} that enables the {DECISION_ENGINE} to evaluate rules one time in the order that they are listed in the {DECISION_ENGINE} agenda without regard to changes in the working memory. As a result, rule execution may be faster in sequential mode, but important updates may not be applied to your rules. Sequential mode applies to stateless KIE sessions only.
 +
 --
@@ -34,5 +34,5 @@ try {
 }
 ----
 
-For information about {DECISION_ENGINE} event listeners and debug logging, see xref:engine-event-listeners-con_decision-engine[].
+For information about built-in event listeners and debug logging in the {DECISION_ENGINE}, see xref:engine-event-listeners-con_decision-engine[].
 --

--- a/doc-content/drools-docs/src/main/asciidoc/LanguageReference-chapter.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/LanguageReference-chapter.adoc
@@ -62,6 +62,8 @@ include::LanguageReference/drl-rules-errors-ref.adoc[leveloffset=+2]
 
 include::LanguageReference/drl-rule-units-con.adoc[leveloffset=+2]
 
+include::AuthoringAssets/performance-tuning-drl-ref.adoc[leveloffset=+2]
+
 ifdef::DROOLS,JBPM,OP[]
 include::LanguageReference/DSL-section.adoc[leveloffset=+1]
 endif::[]

--- a/doc-content/drools-docs/src/main/asciidoc/LanguageReference/drl-rules-WHEN-con.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/LanguageReference/drl-rules-WHEN-con.adoc
@@ -254,9 +254,9 @@ For example, the following DRL rule uses the variable `$p` for a pattern with th
 [source]
 ----
 rule "simple rule"
-when
+  when
     $p : Person()
-then
+  then
     System.out.println( "Person " + $p );
 end
 ----

--- a/doc-content/drools-docs/src/main/asciidoc/LanguageReference/drl-rules-WHEN-elements-ref.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/LanguageReference/drl-rules-WHEN-elements-ref.adoc
@@ -141,7 +141,7 @@ endif::[]
 ----
 rule "All full-time employees have red ID badges"
   when
-    forall( $emp : Employee( type == "fulltime")
+    forall( $emp : Employee( type == "fulltime" )
                    Employee( this == $emp, badgeColor = "red" ) )
   then
     // True, all full-time employees have red ID badges.
@@ -211,8 +211,8 @@ endif::[]
 ----
 rule "Validate zipcode"
   when
-    Person($personAddress : address)
-    Address(zipcode == "23920W") from $personAddress
+    Person( $personAddress : address )
+    Address( zipcode == "23920W" ) from $personAddress
   then
     // Zip code is okay.
 end
@@ -224,7 +224,7 @@ end
 rule "Validate zipcode"
   when
     $p : Person()
-    $a : Address(zipcode == "23920W") from $p.address
+    $a : Address( zipcode == "23920W" ) from $p.address
   then
     // Zip code is okay.
 end
@@ -236,11 +236,23 @@ end
 rule "Apply 10% discount to all items over US$ 100 in an order"
   when
     $order : Order()
-    $item  : OrderItem( value > 100) from $order.items
+    $item  : OrderItem( value > 100 ) from $order.items
   then
     // Apply discount to `$item`.
 end
 ----
+
+[NOTE]
+====
+For large collections of objects, instead of adding an object with a large graph that the {DECISION_ENGINE} must iterate over frequently, add the collection directly to the KIE session and then join the collection in the condition, as shown in the following example:
+
+[source]
+----
+when
+  $order : Order()
+  OrderItem( value > 100, order == $order )
+----
+====
 
 .Example rule with `from` and `lock-on-active` rule attribute
 [source]
@@ -250,7 +262,7 @@ rule "Assign people in North Carolina (NC) to sales region 1"
   lock-on-active true
   when
     $p : Person()
-    $a : Address( state == "NC") from $p.address
+    $a : Address( state == "NC" ) from $p.address
   then
     modify ($p) {} // Assign the person to sales region 1.
 end
@@ -260,7 +272,7 @@ rule "Apply a discount to people in the city of Raleigh"
   lock-on-active true
   when
     $p : Person()
-    $a : Address( city == "Raleigh") from $p.address
+    $a : Address( city == "Raleigh" ) from $p.address
   then
     modify ($p) {} // Apply discount to the person.
 end
@@ -311,8 +323,8 @@ Use this to define an entry point, or _event stream_, corresponding to a data so
 ----
 rule "Authorize withdrawal"
   when
-    WithdrawRequest($ai : accountId, $am : amount) from entry-point "ATM Stream"
-    CheckingAccount(accountId == $ai, balance > $am)
+    WithdrawRequest( $ai : accountId, $am : amount ) from entry-point "ATM Stream"
+    CheckingAccount( accountId == $ai, balance > $am )
   then
     // Authorize withdrawal.
 end

--- a/doc-content/enterprise-only/admin-and-config/configuring-environment-mode-proc.adoc
+++ b/doc-content/enterprise-only/admin-and-config/configuring-environment-mode-proc.adoc
@@ -1,4 +1,4 @@
-[id='configuring-environment-mode-proc']
+[id='configuring-environment-mode-proc_{context}']
 = Configuring the environment mode in {KIE_SERVER} and {CENTRAL}
 
 You can set {KIE_SERVER} to run in `production` mode or in `development` mode. Development mode provides a flexible deployment policy that enables you to update existing deployment units (KIE containers) while maintaining active process instances for small changes. It also enables you to reset the deployment unit state before updating active process instances for larger changes. Production mode is optimal for production environments, where each deployment creates a new deployment unit.

--- a/doc-content/shared-kie-docs/src/main/asciidoc/KieServer/KieServer-chapter.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/KieServer/KieServer-chapter.adoc
@@ -40,4 +40,6 @@ include::prometheus-monitoring-con.adoc[leveloffset=+1]
 include::prometheus-monitoring-proc.adoc[leveloffset=+2]
 //Excluded until confirmed that Drools/jBPM have verified support on OpenShift. Some conditioning will be required at that point. (Stetson, 22 May 2019)
 //include::prometheus-monitoring-ocp-proc.adoc[leveloffset=+2]
-include::{shared-dir}/KieServer/prometheus-monitoring-custom-proc.adoc[leveloffset=+2]
+include::prometheus-monitoring-custom-proc.adoc[leveloffset=+2]
+
+include::performance-tuning-kie-server-ref.adoc[leveloffset=+1]

--- a/doc-content/shared-kie-docs/src/main/asciidoc/KieServer/performance-tuning-kie-server-ref.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/KieServer/performance-tuning-kie-server-ref.adoc
@@ -1,0 +1,36 @@
+[id='performance-tuning-kie-server-ref_{context}']
+
+= Performance tuning considerations with {KIE_SERVER}
+
+The following key concepts or suggested practices can help you optimize {KIE_SERVER} performance. These concepts are summarized in this section as a convenience and are explained in more detail in the cross-referenced documentation, where applicable. This section will expand or change as needed with new releases of {PRODUCT}.
+
+Ensure that development mode is enabled during development::
+You can set {KIE_SERVER} or specific projects in {CENTRAL} to use `production` mode or `development` mode. By default, {KIE_SERVER} and all new projects in {CENTRAL} are in development mode. This mode provides features that facilitate your development experience, such as flexible project deployment policies, and features that optimize {KIE_SERVER} performance during development, such as disabled duplicate GAV detection. Use development mode until your {PRODUCT} environment is established and completely ready for production mode.
++
+--
+For more information about configuring the environment mode or duplicate GAV detection, see the following resources:
+
+ifdef::DM,PAM[]
+* xref:configuring-environment-mode-proc_execution-server[]
+* {URL_PACKAGING_DEPLOYING_PROJECT}#project-duplicate-GAV-con_packaging-deploying[_{PACKAGING_DEPLOYING_PROJECT}_]
+endif::[]
+ifdef::DROOLS,JBPM,OP[]
+* <<_development_streamline_lifecycle>>
+* <<_duplicate_gav_detection>>
+endif::[]
+--
+
+Adapt {KIE_SERVER} capabilities and extensions to your specific needs::
+The capabilities in {KIE_SERVER} are determined by plug-in extensions that you can enable, disable, or further extend to meet your business needs. By default, {KIE_SERVER} extensions are exposed through REST or JMS data transports and use predefined client APIs. You can extend existing {KIE_SERVER} capabilities with additional REST endpoints, extend supported transport methods beyond REST or JMS, or extend functionality in the {KIE_SERVER} client.
++
+--
+This flexibility in {KIE_SERVER} functionality enables you to adapt your {KIE_SERVER} instances to your business needs, instead of adapting your business needs to the default {KIE_SERVER} capabilities.
+
+For information about enabling, disabling, or extending {KIE_SERVER} capabilities, see
+ifdef::DM,PAM[]
+xref:kie-server-extensions-con_execution-server[].
+endif::[]
+ifdef::DROOLS,JBPM,OP[]
+xref:kie-server-extensions-con_kie-apis[].
+endif::[]
+--

--- a/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/Workbench-chapter.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/Workbench-chapter.adoc
@@ -13,3 +13,5 @@ include::Embedding/Embedding-section.adoc[leveloffset=+1]
 include::ExecServer/ExecServer-section.adoc[leveloffset=+1]
 include::ExperimentalFeatures/ExperimentalFeatures-section.adoc[leveloffset=+1]
 include::WorkbenchProfiles/WorkbenchProfiles-section.adoc[leveloffset=+1]
+
+include::performance-tuning-business-central-ref.adoc[leveloffset=+1]

--- a/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/performance-tuning-business-central-ref.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/performance-tuning-business-central-ref.adoc
@@ -1,0 +1,41 @@
+[id='performance-tuning-business-central-ref_{context}']
+
+= Performance tuning considerations with {CENTRAL}
+
+The following key concepts or suggested practices can help you optimize {CENTRAL} configuration and {PRODUCT} performance. These concepts are summarized in this section as a convenience and are explained in more detail in the cross-referenced documentation, where applicable. This section will expand or change as needed with new releases of {PRODUCT}.
+
+Ensure that development mode is enabled during development::
+You can set {KIE_SERVER} or specific projects in {CENTRAL} to use `production` mode or `development` mode. By default, {KIE_SERVER} and all new projects in {CENTRAL} are in development mode. This mode provides features that facilitate your development experience, such as flexible project deployment policies, and features that optimize {KIE_SERVER} performance during development, such as disabled duplicate GAV detection. Use development mode until your {PRODUCT} environment is established and completely ready for production mode.
++
+--
+For more information about configuring the environment mode or duplicate GAV detection, see the following resources:
+
+ifdef::DM,PAM[]
+* xref:configuring-environment-mode-proc_configuring-central[]
+* {URL_PACKAGING_DEPLOYING_PROJECT}#project-duplicate-GAV-con_packaging-deploying[_{PACKAGING_DEPLOYING_PROJECT}_]
+endif::[]
+ifdef::DROOLS,JBPM,OP[]
+* <<_development_streamline_lifecycle>>
+* <<_duplicate_gav_detection>>
+endif::[]
+--
+
+Disable verification and validation of complex guided decision tables::
+The decision table verification and validation feature of {CENTRAL} is enabled by default. This feature helps you validate your guided decision tables, but with complex guided decision tables, this feature can hinder {DECISION_ENGINE} performance. You can disable this feature by setting the `org.kie.verification.disable-dtable-realtime-verification` system property value to `true`.
++
+--
+For more information about guided decision table validation, see
+ifdef::DM,PAM[]
+{URL_GUIDED_DECISION_TABLES}#guided-decision-tables-validation-disable-proc[_{GUIDED_DECISION_TABLES}_].
+endif::[]
+ifdef::DROOLS,JBPM,OP[]
+<<guided-decision-tables-validation-disable-proc>>
+endif::[]
+--
+
+Disable automatic builds if you have many large projects::
+In {CENTRAL}, when you navigate between projects in the *Project Explorer* side panel, the selected project is built automatically so that the *Alerts* window is updated to show any build errors for the project. If you have large projects or frequently switch between many projects that are under active development, this feature can hinder {CENTRAL} and {DECISION_ENGINE} performance.
++
+--
+To disable automatic project builds, set the `org.kie.build.disable-project-explorer` system property to `true`.
+--


### PR DESCRIPTION
Starting 7.6, we have been asked to add performance tuning sections to relevant stories, according to [BAPL-1467](https://issues.jboss.org/browse/BAPL-1467) as outlined in the [Performance tuning content google doc](https://docs.google.com/document/d/1Y0IrlbBTnTG2la3HZl6hwjyPjxEWIfQEPRjl5q3Ppzc/edit?usp=sharing). These sections merely highlight what is typically already documented in context. **This is just a start to this effort and is for 7.6.** The sections will be expanded and changed over coming releases.

To be QE verified:

@baldimir , can you QE verify the following sections:
* [Performance tuning considerations with the decision engine](http://file.rdu.redhat.com/~sterobin/BXMSDOC-4963_ENG/#performance-tuning-decision-engine-ref_decision-engine)
* [Performance tuning considerations with DRL](http://file.rdu.redhat.com/~sterobin/BXMSDOC-4963_DRL/#performance-tuning-drl-ref_drl-rules)
* [Community version](http://file.rdu.redhat.com/~sterobin/BXMSDOC-4963_DROOLS/#performance-tuning-decision-engine-ref_decision-engine) - Just fyi, same, but for community

@MarianMacik , can you QE verify the following section:
* [Performance tuning considerations with KIE Server](http://file.rdu.redhat.com/~sterobin/BXMSDOC-4963_KIE/#performance-tuning-kie-server-ref_execution-server)
* [Community version](http://file.rdu.redhat.com/~sterobin/BXMSDOC-4963_DROOLS/#performance-tuning-kie-server-ref_kie-apis) - Just fyi, same, but for community

@tomasdavidorg , can you QE verify the following section:
* [Performance tuning considerations with Business Central](http://file.rdu.redhat.com/~sterobin/BXMSDOC-4963_BC/#performance-tuning-business-central-ref_configuring-central)
* [Community version](http://file.rdu.redhat.com/~sterobin/BXMSDOC-4963_DROOLS/#performance-tuning-business-central-ref_kie-apis) - Just fyi, same, but for community

@jstastny-cz, just FYI ^^

