### PR TITLE
Upstream 7.11.x PR for BXMSDOC-4380: user with process-admin role can't see task in Tasks page

### DIFF
--- a/doc-content/enterprise-only/admin-and-config/manage-tasks-proc.adoc
+++ b/doc-content/enterprise-only/admin-and-config/manage-tasks-proc.adoc
@@ -1,13 +1,20 @@
 [id='manage-tasks-proc-{context}']
 = Managing tasks
 
-The *Task Inbox* can be accessed in {CENTRAL} by clicking *Menu* -> *Track* -> *Task Inbox*. Tasks that are assigned to the current user appear in the *Task Inbox*. You can click on a task to open and begin working on it. 
+The *Task Inbox* can be accessed in {CENTRAL} by clicking *Menu* -> *Track* -> *Task Inbox*. Tasks that are assigned to the current user appear in the *Task Inbox*. You can click on a task to open and begin working on it.
 
 A user task can be assigned to a particular user, multiple users, or to a group. If assigned to multiple users or a group it appears in the task Lists of all assigned users and any of the possible actors can claim the task. When a task is assigned to another user it no longer appears in your the *Task Inbox*.
 
 image::admin-and-config/task-inbox.png[Task inbox]
 
-Users with the `process-admin` role can view and manage all user tasks from the *Tasks* page in {CENTRAL}, located under *Menu* -> *Manage* -> *Tasks*. Users with the `admin` role can access the *Tasks* page but do not have access rights to view and manage tasks by default. 
+Business administrators can view and manage all user tasks from the *Tasks* page in {CENTRAL}, located under *Menu* -> *Manage* -> *Tasks*. Users with the `admin` or `process-admin` role can access the *Tasks* page but do not have access rights to view and manage tasks by default.
+
+To manage all the tasks, a user must be specified as a process administrator by defining any of the following conditions:
+
+* User is specified as `task admin user`. The default value is `Administrator`.
+* User belongs to the task administrators group. The default value is `Administrators`.
+
+You can configure the user and user group assignment with the `org.jbpm.ht.admin.user` and `org.jbpm.ht.admin.group` system properties. 
 
 You can open view and modify the details of a task, such as the due date, the priority or the task description, by clicking on a task in the list. The following tabs are available in the task page:
 


### PR DESCRIPTION
- [Associated JIRA](https://issues.jboss.org/browse/BXMSDOC-4380)
- [Managing & monitoring business processes in RHPAM 7.1 doc preview](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-4380-MMBP-7.1-preview/#manage-tasks-proc-managing-and-monitoring-processes)

Please check and verify the small paragraph I have added in **5.5. Managing tasks** section.