### PR TITLE
BXMSDOC-4971-master: Update build and deploy steps with mention of verification link.

### DIFF
--- a/doc-content/drools-docs/src/main/asciidoc/Examples/decision-examples-central-proc.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/Examples/decision-examples-central-proc.adoc
@@ -32,5 +32,5 @@ You can also select the *Build & Install* option to build the project and publis
 To configure the {KIE_SERVER} environment mode, set the `org.kie.server.mode` system property to `org.kie.server.mode=development` or `org.kie.server.mode=production`. To configure the deployment behavior for a corresponding project in {CENTRAL}, go to project *Settings* -> *General Settings* -> *Version* and toggle the *Development Mode* option. By default, {KIE_SERVER} and all new projects in {CENTRAL} are in development mode. You cannot deploy a project with *Development Mode* turned on or with a manually added `SNAPSHOT` version suffix to a {KIE_SERVER} that is in production mode.
 ====
 
-To review project deployment details (if applicable), go to *Menu* -> *Deploy* -> *Execution Servers*.
+To review project deployment details, click *View deployment details* in the deployment banner at the top of the screen or in the *Deploy* drop-down menu. This option directs you to the *Menu* -> *Deploy* -> *Execution Servers* page.
 --

--- a/doc-content/enterprise-only/getting-started/deploying-application-proc.adoc
+++ b/doc-content/enterprise-only/getting-started/deploying-application-proc.adoc
@@ -20,5 +20,6 @@ You can also select the *Build & Install* option to build the project and publis
 To configure the {KIE_SERVER} environment mode, set the `org.kie.server.mode` system property to `org.kie.server.mode=development` or `org.kie.server.mode=production`. To configure the deployment behavior for a corresponding project in {CENTRAL}, go to project *Settings* -> *General Settings* -> *Version* and toggle the *Development Mode* option. By default, {KIE_SERVER} and all new projects in {CENTRAL} are in development mode. You cannot deploy a project with *Development Mode* turned on or with a manually added `SNAPSHOT` version suffix to a {KIE_SERVER} that is in production mode.
 ====
 
-. To verify the deployment, click *Menu* -> *Manage* -> *Process Definitions*, and click image:getting-started/btn_refresh.png[].
+. To review project deployment details, click *View deployment details* in the deployment banner at the top of the screen or in the *Deploy* drop-down menu. This option directs you to the *Menu* -> *Deploy* -> *Execution Servers* page.
+. To verify process definitions, click *Menu* -> *Manage* -> *Process Definitions*, and click image:getting-started/btn_refresh.png[].
 . Click the three vertical dots in the *Actions* column and select *Start* to start a new instance of the process.

--- a/doc-content/enterprise-only/processes/deploy-proc.adoc
+++ b/doc-content/enterprise-only/processes/deploy-proc.adoc
@@ -12,9 +12,13 @@ The following chapter instructs you how to build and deploy a new instance of th
 . Click the project you want to deploy, for example *pizzaPlace*.
 . Click *Deploy*.
 +
+--
 [NOTE]
 ====
 You can also select the *Build & Install* option to build the project and publish the KJAR file to the configured Maven repository without deploying to a {KIE_SERVER}. In a development environment, you can click *Deploy* to deploy the built KJAR file to a {KIE_SERVER} without stopping any running instances (if applicable), or click *Redeploy* to deploy the built KJAR file and replace all instances. The next time you deploy or redeploy the built KJAR, the previous deployment unit (KIE container) is automatically updated in the same target {KIE_SERVER}. In a production environment, the *Redeploy* option is disabled and you can click *Deploy* only to deploy the built KJAR file to a new deployment unit (KIE container) on a {KIE_SERVER}.
 
 To configure the {KIE_SERVER} environment mode, set the `org.kie.server.mode` system property to `org.kie.server.mode=development` or `org.kie.server.mode=production`. To configure the deployment behavior for a corresponding project in {CENTRAL}, go to project *Settings* -> *General Settings* -> *Version* and toggle the *Development Mode* option. By default, {KIE_SERVER} and all new projects in {CENTRAL} are in development mode. You cannot deploy a project with *Development Mode* turned on or with a manually added `SNAPSHOT` version suffix to a {KIE_SERVER} that is in production mode.
 ====
+
+To review project deployment details, click *View deployment details* in the deployment banner at the top of the screen or in the *Deploy* drop-down menu. This option directs you to the *Menu* -> *Deploy* -> *Execution Servers* page.
+--

--- a/doc-content/enterprise-only/project-data/build-deploy-branches-proc.adoc
+++ b/doc-content/enterprise-only/project-data/build-deploy-branches-proc.adoc
@@ -5,11 +5,19 @@ After your project is developed, you can build the project from the specified br
 
 .Procedure
 . In {CENTRAL}, go to *Menu* -> *Design* -> *Projects* and click the project name.
-. In the upper-right corner, click *Deploy* to build the project and deploy it to {KIE_SERVER}. If the build fails, address any problems described in the *Alerts* panel at the bottom of the screen. For more information about project deployment options, see {URL_PACKAGING_DEPLOYING_PROJECT}[_{PACKAGING_DEPLOYING_PROJECT}_].
+. In the upper-right corner, click *Deploy* to build the project and deploy it to {KIE_SERVER}.
 +
+--
 [NOTE]
 ====
 You can also select the *Build & Install* option to build the project and publish the KJAR file to the configured Maven repository without deploying to a {KIE_SERVER}. In a development environment, you can click *Deploy* to deploy the built KJAR file to a {KIE_SERVER} without stopping any running instances (if applicable), or click *Redeploy* to deploy the built KJAR file and replace all instances. The next time you deploy or redeploy the built KJAR, the previous deployment unit (KIE container) is automatically updated in the same target {KIE_SERVER}. In a production environment, the *Redeploy* option is disabled and you can click *Deploy* only to deploy the built KJAR file to a new deployment unit (KIE container) on a {KIE_SERVER}.
 
 To configure the {KIE_SERVER} environment mode, set the `org.kie.server.mode` system property to `org.kie.server.mode=development` or `org.kie.server.mode=production`. To configure the deployment behavior for a corresponding project in {CENTRAL}, go to project *Settings* -> *General Settings* -> *Version* and toggle the *Development Mode* option. By default, {KIE_SERVER} and all new projects in {CENTRAL} are in development mode. You cannot deploy a project with *Development Mode* turned on or with a manually added `SNAPSHOT` version suffix to a {KIE_SERVER} that is in production mode.
 ====
+
+If the build fails, address any problems described in the *Alerts* panel at the bottom of the screen.
+
+To review project deployment details, click *View deployment details* in the deployment banner at the top of the screen or in the *Deploy* drop-down menu. This option directs you to the *Menu* -> *Deploy* -> *Execution Servers* page.
+
+For more information about project deployment options, see {URL_PACKAGING_DEPLOYING_PROJECT}[_{PACKAGING_DEPLOYING_PROJECT}_].
+--

--- a/doc-content/enterprise-only/project-data/project-build-deploy-central-proc.adoc
+++ b/doc-content/enterprise-only/project-data/project-build-deploy-central-proc.adoc
@@ -7,18 +7,22 @@ After your project is developed, you can build the project in {CENTRAL} and depl
 . In {CENTRAL}, go to *Menu* -> *Design* -> *Projects* and click the project name.
 . In the upper-right corner, click *Deploy* to build the project and deploy it to a {KIE_SERVER}. To compile the project without deploying it to {KIE_SERVER}, click *Build*.
 +
+--
 [NOTE]
 ====
 You can also select the *Build & Install* option to build the project and publish the KJAR file to the configured Maven repository without deploying to a {KIE_SERVER}. In a development environment, you can click *Deploy* to deploy the built KJAR file to a {KIE_SERVER} without stopping any running instances (if applicable), or click *Redeploy* to deploy the built KJAR file and replace all instances. The next time you deploy or redeploy the built KJAR, the previous deployment unit (KIE container) is automatically updated in the same target {KIE_SERVER}. In a production environment, the *Redeploy* option is disabled and you can click *Deploy* only to deploy the built KJAR file to a new deployment unit (KIE container) on a {KIE_SERVER}.
 
 To configure the {KIE_SERVER} environment mode, set the `org.kie.server.mode` system property to `org.kie.server.mode=development` or `org.kie.server.mode=production`. To configure the deployment behavior for a corresponding project in {CENTRAL}, go to project *Settings* -> *General Settings* -> *Version* and toggle the *Development Mode* option. By default, {KIE_SERVER} and all new projects in {CENTRAL} are in development mode. You cannot deploy a project with *Development Mode* turned on or with a manually added `SNAPSHOT` version suffix to a {KIE_SERVER} that is in production mode.
 ====
-+
+
 If only one {KIE_SERVER} is connected to {CENTRAL}, or if all connected {KIE_SERVERS} are in the same server configuration, the services in the project are started automatically in a deployment unit (KIE container).
-+
+
 If multiple server configurations are available, a deployment dialog is displayed in {CENTRAL}, prompting you to specify server and deployment details.
-+
+--
 . If the deployment dialog appears, verify or set the following values:
 * *Deployment Unit Id / Deployment Unit Alias:* Verify the name and alias of the deployment unit (KIE container) running the service within the {KIE_SERVER}. You normally do not need to change these settings.
 * *Server Configuration:* Select the server configuration for deploying this project. You can later deploy it to other configured servers without rebuilding the project.
 * *Start Deployment Unit?:* Verify that this box is selected to start the deployment unit (KIE container). If you clear this box, the service is deployed onto the server but not started.
+
++
+To review project deployment details, click *View deployment details* in the deployment banner at the top of the screen or in the *Deploy* drop-down menu. This option directs you to the *Menu* -> *Deploy* -> *Execution Servers* page.

--- a/doc-content/enterprise-only/project-data/revise-project-version-proc.adoc
+++ b/doc-content/enterprise-only/project-data/revise-project-version-proc.adoc
@@ -22,5 +22,6 @@ You can also select the *Build & Install* option to build the project and publis
 To configure the {KIE_SERVER} environment mode, set the `org.kie.server.mode` system property to `org.kie.server.mode=development` or `org.kie.server.mode=production`. To configure the deployment behavior for a corresponding project in {CENTRAL}, go to project *Settings* -> *General Settings* -> *Version* and toggle the *Development Mode* option. By default, {KIE_SERVER} and all new projects in {CENTRAL} are in development mode. You cannot deploy a project with *Development Mode* turned on or with a manually added `SNAPSHOT` version suffix to a {KIE_SERVER} that is in production mode.
 ====
 
-. To verify the deployment, click *Menu* -> *Manage* -> *Process Definitions*, and click image:getting-started/btn_refresh.png[].
+. To review project deployment details, click *View deployment details* in the deployment banner at the top of the screen or in the *Deploy* drop-down menu. This option directs you to the *Menu* -> *Deploy* -> *Execution Servers* page.
+. To verify process definitions, click *Menu* -> *Manage* -> *Process Definitions*, and click image:getting-started/btn_refresh.png[].
 . Click image:project-data/dots.png[] in the *Actions* column and select *Start* to start a new instance of the process.

--- a/doc-content/enterprise-only/springboot/bus-app-import_proc.adoc
+++ b/doc-content/enterprise-only/springboot/bus-app-import_proc.adoc
@@ -43,7 +43,7 @@ You can also select the *Build & Install* option to build the project and publis
 To configure the {KIE_SERVER} environment mode, set the `org.kie.server.mode` system property to `org.kie.server.mode=development` or `org.kie.server.mode=production`. To configure the deployment behavior for a corresponding project in {CENTRAL}, go to project *Settings* -> *General Settings* -> *Version* and toggle the *Development Mode* option. By default, {KIE_SERVER} and all new projects in {CENTRAL} are in development mode. You cannot deploy a project with *Development Mode* turned on or with a manually added `SNAPSHOT` version suffix to a {KIE_SERVER} that is in production mode.
 ====
 
-. To verify the deployment, go to *Menu* -> *Deploy* -> *Execution Servers*.
+. To review project deployment details, click *View deployment details* in the deployment banner at the top of the screen or in the *Deploy* drop-down menu. This option directs you to the *Menu* -> *Deploy* -> *Execution Servers* page.
 ifdef::PAM,JBPM[]
 . To interact with your newly deployed business assets, go to *Menu* -> *Manage* -> *Process Definitions* and *Process Instances*.
 endif::[]

--- a/doc-content/jbpm-docs/src/main/asciidoc/BPMN2/deploy-business-process-proc.adoc
+++ b/doc-content/jbpm-docs/src/main/asciidoc/BPMN2/deploy-business-process-proc.adoc
@@ -14,9 +14,13 @@ endif::[]
 . Click the project that you want to deploy.
 . Click *Deploy*.
 +
+--
 [NOTE]
 ====
 You can also select the *Build & Install* option to build the project and publish the KJAR file to the configured Maven repository without deploying to a {KIE_SERVER}. In a development environment, you can click *Deploy* to deploy the built KJAR file to a {KIE_SERVER} without stopping any running instances (if applicable), or click *Redeploy* to deploy the built KJAR file and replace all instances. The next time you deploy or redeploy the built KJAR, the previous deployment unit (KIE container) is automatically updated in the same target {KIE_SERVER}. In a production environment, the *Redeploy* option is disabled and you can click *Deploy* only to deploy the built KJAR file to a new deployment unit (KIE container) on a {KIE_SERVER}.
 
 To configure the {KIE_SERVER} environment mode, set the `org.kie.server.mode` system property to `org.kie.server.mode=development` or `org.kie.server.mode=production`. To configure the deployment behavior for a corresponding project in {CENTRAL}, go to project *Settings* -> *General Settings* -> *Version* and toggle the *Development Mode* option. By default, {KIE_SERVER} and all new projects in {CENTRAL} are in development mode. You cannot deploy a project with *Development Mode* turned on or with a manually added `SNAPSHOT` version suffix to a {KIE_SERVER} that is in production mode.
 ====
+
+To review project deployment details, click *View deployment details* in the deployment banner at the top of the screen or in the *Deploy* drop-down menu. This option directs you to the *Menu* -> *Deploy* -> *Execution Servers* page.
+--


### PR DESCRIPTION
@ederign  (SME) and @barboras7 (QE) , can you verify this minor doc update from [BAPL-893](https://issues.jboss.org/browse/BAPL-893) (deployment verification link)? I basically added the following mention in several related docs:

>To review project deployment details, click **View deployment details** in the deployment banner at the top of the screen or in the **Deploy** drop-down menu. This option directs you to the **Menu** -> **Deploy** -> **Execution Servers** page.

It touches several documents, but this is specifically to resolve the "Packaging and deploying a project" doc for 7.6, linked below. I confirmed with all squad members for this doc that this was the only relevant 7.6 change for the doc.

Links:
* [Doc epic](https://issues.jboss.org/browse/BXMSDOC-4795)
* [BAPL-893](https://issues.jboss.org/browse/BAPL-893)
* [Doc preview](http://file.rdu.redhat.com/~sterobin/BXMSDOC-4971_PAM/#project-build-deploy-central-proc_packaging-deploying) - See the end of the "Building and deploying a project" section, for example. Similar addition in other docs, listed in the PR.