### PR TITLE
BXMSDOC-3863 7.5.x Clarification regarding .niogit folder in RHDM when following migration document from BRMS 6.4

### DIFF
--- a/docs/product-assembly_migrating-from-BRMS-6.4-to-DM-7.0/src/main/asciidoc/main.adoc
+++ b/docs/product-assembly_migrating-from-BRMS-6.4-to-DM-7.0/src/main/asciidoc/main.adoc
@@ -11,8 +11,9 @@ include::product-shared-docs/author-group.adoc[]
 // Purpose statement for the assembly
 If you have Red Hat BRMS 6.4 projects that you want to use in {PRODUCT} {PRODUCT_VERSION}, you must first migrate the projects.
 
-.Prerequisite
-You have a Red Hat BRMS 6.4 installation that contains artifacts that you want to migrate to {PRODUCT} {PRODUCT_VERSION}.
+.Prerequisites
+* You have a Red Hat BRMS 6.4 installation that contains artifacts that you want to migrate to {PRODUCT} {PRODUCT_VERSION}.
+* A clean {PRODUCT} {PRODUCT_VERSION} installation exists that does not contain a `.niogit` folder. If the {PRODUCT} {PRODUCT_VERSION} installation contains a `.niogit` folder, the migration will fail. 
 
 include::migration-overview-con.adoc[leveloffset=+1]
 include::projects-central-migrating-proc.adoc[leveloffset=+1]


### PR DESCRIPTION
Details in jira:
[BXMSDOC-3863](https://issues.jboss.org/browse/BXMSDOC-3863)