### PR TITLE
Upstream 7.30.x PR for BXMSDOC-4985: [DDF] kie server controller parameter is incorrect.

### DIFF
--- a/doc-content/enterprise-only/admin-and-config/kie-server-configure-central-proc.adoc
+++ b/doc-content/enterprise-only/admin-and-config/kie-server-configure-central-proc.adoc
@@ -31,7 +31,7 @@ Example:
 [source,xml,subs="attributes+"]
 ----
 <property name="org.kie.server.controller.user" value="central_user"/>
-<property name="org.kie.server.controller.password" value="central_password"/>
+<property name="org.kie.server.controller.pwd" value="central_password"/>
 <property name="org.kie.server.controller" value="http://central.example.com:8080/{URL_COMPONENT_CENTRAL}/rest/controller"/>
 <property name="org.kie.server.location" value="http://kieserver.example.com:8080/kie-server/services/rest/server"/>
 <property name="org.kie.server.id" value="production-servers"/>


### PR DESCRIPTION
- [DDF JIRA](https://issues.jboss.org/browse/BXMSDOC-4985)
- [v7.6-Managing and monitoring Process Server](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-4985-MMPS-RHPAM-DDF/#kie-server-configure-central-proc_execution-server)
- [v7.6-Managing and monitoring Decision Server](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-4985-MMPS-RHDM-DDF/#kie-server-configure-central-proc_execution-server)

Updated the property name from **org.kie.server.controller.password** to **org.kie.server.controller.pwd** in the codeblock example. 

Please check the **Chapter. 8** in the RHPAM and **Chapter. 7** in RHDM doc previews.