### PR TITLE
Corrected usages of the word 'username' across all files

### DIFF
--- a/doc-content/enterprise-only/admin-and-config/managing-business-central-integrating-remote-git-repositories-proc.adoc
+++ b/doc-content/enterprise-only/admin-and-config/managing-business-central-integrating-remote-git-repositories-proc.adoc
@@ -81,7 +81,7 @@ gitlabGroup=Group/subgroup
 |The Git provider. Only two values are accepted: GIT_HUB and GIT_LAB. Required
 
 |`login`
-|The username for the Git provider. Required
+|The user name for the Git provider. Required
 
 |`password`
 |A plain text password. Not required if a `token` is provided.

--- a/doc-content/enterprise-only/openshift/apb-deploy-proc.adoc
+++ b/doc-content/enterprise-only/openshift/apb-deploy-proc.adoc
@@ -28,7 +28,7 @@ IMPORTANT: If you want to deploy an environment with immutable servers and a mon
 *** The *KIE Server Container Deployment*, *Git Repository URL*, and *Git Repository Reference* fields. These settings determine the source code that the deployment process builds and deploys on the {KIE_SERVER}.
 *** If you deployed the *Immutable Server - Monitor* option and want to connect the server to the monitoring infrastructure:
 **** Under *Router integration*, the service name of the `rhpam-immutable-mon-smartrouter` service.
-**** Under *Controller integration*, the service name of the `rhpam-immutable-mon-rhpamcentrmon` service and the admin username and password that you set in the *Immutable Server - KIE Process Server* option.
+**** Under *Controller integration*, the service name of the `rhpam-immutable-mon-rhpamcentrmon` service and the admin user name and password that you set in the *Immutable Server - KIE Process Server* option.
 +
 [IMPORTANT]
 ====

--- a/doc-content/enterprise-only/openshift/environment-immutable-monitoring-proc.adoc
+++ b/doc-content/enterprise-only/openshift/environment-immutable-monitoring-proc.adoc
@@ -30,8 +30,8 @@ In this command line:
 ** *Smart Router Keystore Secret Name* (`KIE_SERVER_ROUTER_HTTPS_SECRET`): The name of the secret for Smart Router, as created in <<secrets-smartrouter-create-proc>>.
 ** *Application Name* (`APPLICATION_NAME`): The name of the OpenShift application. It is used in the default URLs for {LOCAL_CENTRAL} and Smart Router. OpenShift also uses the application name to create a separate set of deployment configurations, services, routes, labels, and artifacts. You can deploy several applications using the same template into the same project, as long as you use different application names.
 ** *Maven repository URL* (`MAVEN_REPO_URL`): A URL for a Maven repository. You must upload all the processes (KJAR files) that are to be deployed in your environment into this repository.
-** *Maven repository username* (`MAVEN_REPO_USERNAME`): The username for the Maven repository.
-** *Maven repository password* (`MAVEN_REPO_PASSWORD`): The username for the Maven repository.
+** *Maven repository username* (`MAVEN_REPO_USERNAME`): The user name for the Maven repository.
+** *Maven repository password* (`MAVEN_REPO_PASSWORD`): The password for the Maven repository.
 ** *{CENTRAL} Server Certificate Name* (`{CENTRAL_CAPITAL_UNDER}_HTTPS_NAME`): The name of the certificate in the keystore that you created in <<secrets-central-create-proc>>.
 ** *{CENTRAL} Server Keystore Password* (`{CENTRAL_CAPITAL_UNDER}_HTTPS_PASSWORD`): The password for the keystore that you created in <<secrets-central-create-proc>>.
 ** *Smart Router Certificate Name* (`KIE_SERVER_ROUTER_HTTPS_NAME`): The name of the certificate in the keystore that you created in <<secrets-smartrouter-create-proc>>.

--- a/doc-content/enterprise-only/openshift/environment-immutable-server-kjar-proc.adoc
+++ b/doc-content/enterprise-only/openshift/environment-immutable-server-kjar-proc.adoc
@@ -64,7 +64,7 @@ endif::PAM[]
 the default value is `PRODUCTION`, which does not allow deployment of `SNAPSHOT` versions.
 ** *KIE Server Container Deployment* (`KIE_SERVER_CONTAINER_DEPLOYMENT`): The identifying information of the decision services (KJAR files) that the deployment must pull from the Maven repository. The format is: `<containerId>=<groupId>:<artifactId>:<version>`. You can provide two or more KJAR files using the `|` separator, as illustrated in the following example: `containerId=groupId:artifactId:version|c2=g2:a2:v2`.
 ** *Maven repository URL* (`MAVEN_REPO_URL`): The URL for the Maven repository.
-** *Maven repository username* (`MAVEN_REPO_USERNAME`): The username for the Maven repository.
+** *Maven repository username* (`MAVEN_REPO_USERNAME`): The user name for the Maven repository.
 ** *Maven repository password* (`MAVEN_REPO_PASSWORD`): The password for the Maven repository.
 ** *Disable KIE server management* (`KIE_SERVER_MGMT_DISABLED`): You must set this parameter to `true` for an immutable deployment.
 ** *KIE Server Startup Strategy* (`KIE_SERVER_STARTUP_STRATEGY`): You must set this parameter to `LocalContainersStartupStrategy` for an immutable deployment.

--- a/doc-content/enterprise-only/openshift/environment-immutable-server-proc.adoc
+++ b/doc-content/enterprise-only/openshift/environment-immutable-server-proc.adoc
@@ -53,7 +53,7 @@ endif::PAM[]
 +
 . If your build includes dependencies that are not available on the public Maven tree and require a separate repository, set the parameters to provide this repository:
 ** *Maven repository URL* (`MAVEN_REPO_URL`): The URL for the Maven repository.
-** *Maven repository username* (`MAVEN_REPO_USERNAME`): The username for the Maven repository.
+** *Maven repository username* (`MAVEN_REPO_USERNAME`): The user name for the Maven repository.
 ** *Maven repository password* (`MAVEN_REPO_PASSWORD`): The password for the Maven repository.
 +
 include::offline-params.adoc[]

--- a/doc-content/enterprise-only/openshift/environment-managed-deploy-proc.adoc
+++ b/doc-content/enterprise-only/openshift/environment-managed-deploy-proc.adoc
@@ -33,8 +33,8 @@ In this command line:
 ** *Smart Router Keystore Secret Name* (`KIE_SERVER_ROUTER_HTTPS_SECRET`): The name of the secret for Smart Router, as created in <<secrets-smartrouter-create-proc>>.
 ** *Application Name* (`APPLICATION_NAME`): The name of the OpenShift application. It is used in the default URLs for {CENTRAL} and {KIE_SERVER}. OpenShift uses the application name to create a separate set of deployment configurations, services, routes, labels, and artifacts. You can deploy several applications using the same template into the same project, as long as you use different application names.
 ** *Maven repository URL* (`MAVEN_REPO_URL`): A URL for a Maven repository. You must upload all the processes (KJAR files) that are to be deployed in your environment into this repository.
-** *Maven repository username* (`MAVEN_REPO_USERNAME`): The username for the Maven repository.
-** *Maven repository password* (`MAVEN_REPO_PASSWORD`): The username for the Maven repository.
+** *Maven repository username* (`MAVEN_REPO_USERNAME`): The user name for the Maven repository.
+** *Maven repository password* (`MAVEN_REPO_PASSWORD`): The password for the Maven repository.
 ** *{CENTRAL} Server Certificate Name* (`{CENTRAL_CAPITAL_UNDER}_HTTPS_NAME`): The name of the certificate in the keystore that you created in <<secrets-central-create-proc>>.
 ** *{CENTRAL} Server Keystore Password* (`{CENTRAL_CAPITAL_UNDER}_HTTPS_PASSWORD`): The password for the keystore that you created in <<secrets-central-create-proc>>.
 ** *Smart Router Certificate Name* (`KIE_SERVER_ROUTER_HTTPS_NAME`): The name of the certificate in the keystore that you created in <<secrets-smartrouter-create-proc>>.

--- a/doc-content/enterprise-only/openshift/template-deploy-centralmavenpwd-proc.adoc
+++ b/doc-content/enterprise-only/openshift/template-deploy-centralmavenpwd-proc.adoc
@@ -3,7 +3,7 @@
 
 When configuring the template to deploy {what_deploying}, if you want to use the Maven repository that is built into {CENTRAL} and to connect additional {KIE_SERVERS} to the {CENTRAL}, you must configure credentials for accessing this Maven repository. You can then use these credentials to configure the {KIE_SERVERS}.
 
-Also, if you are configuring RH-SSO or LDAP authentication, you must set the credentials for the built-in Maven repository to a username and password configured in RH-SSO or LDAP. This setting is required so that the {KIE_SERVER} can access the Maven repository.
+Also, if you are configuring RH-SSO or LDAP authentication, you must set the credentials for the built-in Maven repository to a user name and password configured in RH-SSO or LDAP. This setting is required so that the {KIE_SERVER} can access the Maven repository.
 
 .Prerequisites
 

--- a/doc-content/enterprise-only/openshift/template-deploy-connectcentral-proc.adoc
+++ b/doc-content/enterprise-only/openshift/template-deploy-connectcentral-proc.adoc
@@ -35,13 +35,13 @@ ifeval::["{context}"=="additional-server-managed"]
 ** If you configured the {LOCAL_CENTRAL} to use an external Maven repository, set the following parameters:
 *** *Maven repository URL* (`MAVEN_REPO_URL`): A URL for the external Maven repository that {LOCAL_CENTRAL} uses.
 *** *Maven repository ID* (`MAVEN_REPO_ID`): An identifier for the Maven repository. The default value is `repo-custom`.
-*** *Maven repository username* (`MAVEN_REPO_USERNAME`): The username for the Maven repository.
+*** *Maven repository username* (`MAVEN_REPO_USERNAME`): The user name for the Maven repository.
 *** *Maven repository password* (`MAVEN_REPO_PASSWORD`): The password for the Maven repository.
 endif::[]
 ifdef::central_monitor_maven[]
 . Ensure that the following settings are set to the same value as the same settings for the {LOCAL_CENTRAL}:
-*** *Maven repository URL* (`MAVEN_REPO_URL`): A URL for the external Maven repository froh which services must be deployed.
-*** *Maven repository username* (`MAVEN_REPO_USERNAME`): The username for the Maven repository.
+*** *Maven repository URL* (`MAVEN_REPO_URL`): A URL for the external Maven repository from which services must be deployed.
+*** *Maven repository username* (`MAVEN_REPO_USERNAME`): The user name for the Maven repository.
 *** *Maven repository password* (`MAVEN_REPO_PASSWORD`): The password for the Maven repository.
 endif::central_monitor_maven[]
 

--- a/doc-content/enterprise-only/openshift/template-deploy-mandatory-proc.adoc
+++ b/doc-content/enterprise-only/openshift/template-deploy-mandatory-proc.adoc
@@ -142,7 +142,7 @@ on the {KIE_SERVER}
 endif::maven_single_server[]
 into this repository.
 ** *Maven repository ID* (`MAVEN_REPO_ID`): An identifier for the Maven repository. The default value is `repo-custom`.
-** *Maven repository username* (`MAVEN_REPO_USERNAME`): The username for the Maven repository.
+** *Maven repository username* (`MAVEN_REPO_USERNAME`): The user name for the Maven repository.
 ** *Maven repository password* (`MAVEN_REPO_PASSWORD`): The password for the Maven repository.
 endif::params_mandatory_maven[]
 ifdef::params_kieserver_container_deployment[]

--- a/doc-content/enterprise-only/openshift/template-deploy-optionalmaven-proc.adoc
+++ b/doc-content/enterprise-only/openshift/template-deploy-optionalmaven-proc.adoc
@@ -20,7 +20,7 @@ To configure access to a custom Maven repository, set the following parameters:
 
 * *Maven repository URL* (`MAVEN_REPO_URL`): The URL for the Maven repository.
 * *Maven repository ID* (`MAVEN_REPO_ID`): An identifier for the Maven repository. The default value is `repo-custom`.
-* *Maven repository username* (`MAVEN_REPO_USERNAME`): The username for the Maven repository.
+* *Maven repository username* (`MAVEN_REPO_USERNAME`): The user name for the Maven repository.
 * *Maven repository password* (`MAVEN_REPO_PASSWORD`): The password for the Maven repository.
 
 .Next steps

--- a/doc-content/jbpm-docs/src/main/asciidoc/BusinessApplications/Tutorials/AppWithCases-section.adoc
+++ b/doc-content/jbpm-docs/src/main/asciidoc/BusinessApplications/Tutorials/AppWithCases-section.adoc
@@ -117,7 +117,7 @@ HTTP headers can be set to change the format of data returned
 
 {casedefid} needs to be replaced with actual case definition id that is returned from the endpoint http://localhost:8090/rest/server/containers/business-application-kjar/cases/definitions
 
-NOTE: Remember that endpoints are protected so make sure you provide username and password when making the request.
+NOTE: Remember that endpoints are protected so make sure you provide user name and password when making the request.
 
 In response to this request, a case instance id should be returned.
 

--- a/doc-content/jbpm-docs/src/main/asciidoc/BusinessApplications/Tutorials/AppWithHanldersAndListeners-section.adoc
+++ b/doc-content/jbpm-docs/src/main/asciidoc/BusinessApplications/Tutorials/AppWithHanldersAndListeners-section.adoc
@@ -267,7 +267,7 @@ Optionally HTTP headers can be set to change the format of data returned
 
 {processid} needs to be replaced with actual process id that is returned from the endpoint http://localhost:8090/rest/server/containers/business-application-kjar/processes
 
-NOTE: Remember that endpoints are protected so make sure you provide username and password when making the request.
+NOTE: Remember that endpoints are protected so make sure you provide user name and password when making the request.
 
 In response to this request, a process instance id should be returned.
 

--- a/doc-content/jbpm-docs/src/main/asciidoc/BusinessApplications/Tutorials/AppWithJPA-section.adoc
+++ b/doc-content/jbpm-docs/src/main/asciidoc/BusinessApplications/Tutorials/AppWithJPA-section.adoc
@@ -233,7 +233,7 @@ Body:
 
 {processid} needs to be replaced with actual process id that is returned from the endpoint http://localhost:8090/rest/server/containers/business-application-kjar/processes
 
-NOTE: Remember that endpoints are protected so make sure you provide username and password when making the request.
+NOTE: Remember that endpoints are protected so make sure you provide user name and password when making the request.
 
 In response to this request, a process instance id should be returned.
 

--- a/doc-content/jbpm-docs/src/main/asciidoc/BusinessApplications/Tutorials/AppWithProcesses-section.adoc
+++ b/doc-content/jbpm-docs/src/main/asciidoc/BusinessApplications/Tutorials/AppWithProcesses-section.adoc
@@ -93,7 +93,7 @@ Optionally HTTP headers can be set to change the format of data returned
 
 {processid} needs to be replaced with actual process id that is returned from the endpoint http://localhost:8090/rest/server/containers/business-application-kjar/processes
 
-NOTE: Remember that endpoints are protected so make sure you provide username and password when making the request.
+NOTE: Remember that endpoints are protected so make sure you provide user name and password when making the request.
 
 In response to this request, a process instance id should be returned.
 

--- a/doc-content/jbpm-docs/src/main/asciidoc/BusinessApplications/Tutorials/ElasticSearchBusinessApp-section.adoc
+++ b/doc-content/jbpm-docs/src/main/asciidoc/BusinessApplications/Tutorials/ElasticSearchBusinessApp-section.adoc
@@ -57,7 +57,7 @@ you browser at http://localhost:9200[http://localhost:9200] and you should see s
 }
 ----
 
-NOTE: when prompted for username and password use elastic/changeme
+NOTE: when prompted for user name and password use elastic/changeme
 
 === Build business application
 
@@ -199,7 +199,7 @@ Body:
 
 {processid} needs to be replaced with actual process id that is returned from the endpoint http://localhost:8090/rest/server/containers/business-application-kjar/processes
 
-NOTE: Remember that endpoints are protected so make sure you provide username and password when making the request.
+NOTE: Remember that endpoints are protected so make sure you provide user name and password when making the request.
 
 Once executed you can verify the integration with ElasticSearch simply by pointing your browser to
 http://localhost:9200/processes/_search?pretty=true[http://localhost:9200/processes/_search?pretty=true]

--- a/doc-content/jbpm-docs/src/main/asciidoc/BusinessApplications/Tutorials/JMSBusinessApp-section.adoc
+++ b/doc-content/jbpm-docs/src/main/asciidoc/BusinessApplications/Tutorials/JMSBusinessApp-section.adoc
@@ -57,7 +57,7 @@ Next, start the broker instance, go to business-app-broker/bin and issue followi
 ----
 
 Open your browser at http://localhost:8161/console[http://localhost:8161/console] to logon to
-management console of Apache Artemis with username and password provided at the time you created the broker.
+management console of Apache Artemis with user name and password provided at the time you created the broker.
 
 NOTE: For more detailed instruction on how to configure Apache Artemis https://activemq.apache.org/artemis/docs/latest/using-server.html[visit its website]
 
@@ -340,7 +340,7 @@ Body:
 }
 ----
 
-NOTE: Remember that endpoints are protected so make sure you provide username and password when making the request.
+NOTE: Remember that endpoints are protected so make sure you provide user name and password when making the request.
 
 Verify that there is a user task assigned to `wbadmin` user with information coming from second process instance - `hello`
 

--- a/doc-content/jbpm-docs/src/main/asciidoc/Designer/Customization-section.adoc
+++ b/doc-content/jbpm-docs/src/main/asciidoc/Designer/Customization-section.adoc
@@ -105,7 +105,7 @@ nicely in {CENTRAL} it is recommended not to set these unless in a development e
 |String defining the repository subdomain if one exists
 
 |*designer.repository.usr*
-|In the case custom repository needs authentication this one defines the username for it.
+|In the case custom repository needs authentication this one defines the user name for it.
 |String defining the user name for authentication
 
 |*designer.repository.pwd*

--- a/doc-content/jbpm-docs/src/main/asciidoc/Installer/10MinWorkbench-section.adoc
+++ b/doc-content/jbpm-docs/src/main/asciidoc/Installer/10MinWorkbench-section.adoc
@@ -13,7 +13,7 @@ You can always take a look at the server log {jbpm-installer-folder}/wildfly-{ve
 ====
 
 
-Log in, using krisv / krisv as username / password.
+Log in, using krisv / krisv as user name / password.
 
 Using a prebuilt Evaluation example, the http://download.jboss.org/jbpm/videos/7.0.0.Final_workbench_getting_started.swf[following screencast] gives an overview of how to manage your process instances.
 It shows you:

--- a/doc-content/jbpm-docs/src/main/asciidoc/ReleaseNotes/Release.7.10.0.Final-section.adoc
+++ b/doc-content/jbpm-docs/src/main/asciidoc/ReleaseNotes/Release.7.10.0.Final-section.adoc
@@ -17,7 +17,7 @@ If you already have https://docs.docker.com/install/[Docker] installed on your l
 docker run -p 8080:8080 -p 8001:8001 -d --name jbpm-server-full jboss/jbpm-server-full:latest
 ----
 
-Once container and web applications started, you can navigate to it and login using the username `wbadmin` and password `wbadmin`
+Once container and web applications started, you can navigate to it and login using the user name `wbadmin` and password `wbadmin`
 or any of the users available in the http://jbpm.org/learn/gettingStarted.html[getting started] document.
 
     http://localhost:8080/jbpm-console

--- a/doc-content/shared-kie-docs/src/main/asciidoc/KieServer/Install-section.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/KieServer/Install-section.adoc
@@ -14,7 +14,7 @@ To install the KIE Execution Server and verify it is running, complete the follo
 . Deploy the WAR file into your web container.
 . Create a user with the role of `kie-server` on the container.
 . Test that you can access the {KIE_SERVER} by navigating to the endpoint in a browser window: ``http://SERVER:PORT/CONTEXT/services/rest/server/``.
-. When prompted for username/password, type in the username and password that you created in step 2.
+. When prompted for user name/password, type in the user name and password that you created in step 2.
 . Once authenticated, you will see an XML response in the form of {KIE_SERVER} status, similar to this:
 +
 
@@ -36,10 +36,10 @@ To install the KIE Execution Server and verify it is running, complete the follo
 
 . Download and unzip the Tomcat distribution. Let's call the root of the distribution ``TOMCAT_HOME``. This directory is named after the Tomcat version, so for example ``apache-tomcat-7.0.55``.
 . Download _kie-server- -webc.war_ and place it into ``TOMCAT_HOME/webapps``.
-. Configure user(s) and role(s). Make sure that file `TOMCAT_HOME/conf/tomcat-users.xml` contains the following username and role definition. You can of course choose different username and password, just make sure that the user has role ``kie-server``:
+. Configure user(s) and role(s). Make sure that file `TOMCAT_HOME/conf/tomcat-users.xml` contains the following user name and role definition. You can of course choose different user name and password, just make sure that the user has role ``kie-server``:
 +
 
-.Username and role definition for Tomcat
+.User name and role definition for Tomcat
 ====
 [source,xml]
 ----
@@ -54,7 +54,7 @@ To install the KIE Execution Server and verify it is running, complete the follo
 ./startup.sh -Dorg.kie.server.id=first-kie-server
              -Dorg.kie.server.location=http://localhost:8080/kie-server/services/rest/server
 ----
-. Verify the server is running. Go to `http://SERVER:PORT/CONTEXT/services/rest/server/` and type the specified username and password. You should see simple XML message with basic information about the server.
+. Verify the server is running. Go to `http://SERVER:PORT/CONTEXT/services/rest/server/` and type the specified user name and password. You should see simple XML message with basic information about the server.
 
 
 [IMPORTANT]
@@ -69,7 +69,7 @@ container. The Web container version of the WAR contains only the REST interface
 
 . Download and unzip the WildFly distribution. Let's call the root of the distribution ``WILDFLY_HOME``. This directory is named after the WildFly version, so for example ``wildfly-14.0.1.Final``.
 . Download _kie-server- -ee7.war_ and place it into ``WILDFLY_HOME/standalone/deployments``.
-. Configure user(s) and role(s). Execute the following command `` WILDFLY_HOME/bin/add-user.[sh|bat] -a -u 'kieserver' -p 'kieserver1!' -ro 'kie-server'``. You can of course choose different username and password, just make sure that the user has role ``kie-server``.
+. Configure user(s) and role(s). Execute the following command `` WILDFLY_HOME/bin/add-user.[sh|bat] -a -u 'kieserver' -p 'kieserver1!' -ro 'kie-server'``. You can of course choose different user name and password, just make sure that the user has role ``kie-server``.
 . Start the server by running ``WILDFLY_HOME/bin/standalone.[sh|bat] -c standalone-full.xml <bootstrap_switches>``. You can check out the standard output or WildFly logs in `WILDFLY_HOME/standalone/logs` to see if the application deployed successfully. Please read the table above for the bootstrap switches that can be used to properly configure the instance. For instance:
 +
 [source]
@@ -79,7 +79,7 @@ container. The Web container version of the WAR contains only the REST interface
                  -Dorg.kie.server.id=first-kie-server
                  -Dorg.kie.server.location=http://localhost:8230/kie-server/services/rest/server
 ----
-. Verify the server is running. Go to `http://SERVER:PORT/CONTEXT/services/rest/server/` and type the specified username and password. You should see simple XML message with basic information about the server.
+. Verify the server is running. Go to `http://SERVER:PORT/CONTEXT/services/rest/server/` and type the specified user name and password. You should see simple XML message with basic information about the server.
 +
 image::KieServer/kie-server-info.png[]
 

--- a/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/General/Introduction-section.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/General/Introduction-section.adoc
@@ -7,7 +7,7 @@
 
 Create a user with the role `admin` and log in with those credentials.
 
-After successfully logging in, the account username is displayed at the top right.
+After successfully logging in, the account user name is displayed at the top right.
 Click it to review the roles of the current account.
 
 [[_wb.homescreen]]

--- a/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/SecurityManagement/SecurityManagement-section.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/SecurityManagement/SecurityManagement-section.adoc
@@ -251,7 +251,7 @@ Next is the type of information handled in the user's details screen:
 * The assigned roles
 * The permissions granted or denied
 
-In order to **update or delete an existing user**, click the _Edit_ button present near to the username in the user editor screen:
+In order to **update or delete an existing user**, click the _Edit_ button present near to the user name in the user editor screen:
 
 image::Workbench/SecurityManagement/SecurityManagementEditUser.png[]
 
@@ -333,7 +333,7 @@ kieserver=16c6511893651c9b4b57e0c027a96075
 ----
 
 Notice that it's based on key-value pairs where the key is the __username__, and the value is the hashed value for the user's __password__.
-So a user is just represented by a key and its username, it does not have a name nor an address or any other meta information.
+So a user is just represented by a key and its user name, it does not have a name nor an address or any other meta information.
 
 On the other hand, consider the use of a realm provided by a Keycloak server.
 The user information is composed by more meta-data, such as the surname, address, etc, as in the following image:


### PR DESCRIPTION
Hello people,

This pull request is an attempt to correct the invalid usages of the word `username` so that the documentation conforms with the style guide in this matter (as mentioned [here](https://github.com/kiegroup/kie-docs/pull/2075#pullrequestreview-325333622) by @sterobin).

Please note that I have intentionally not touched `rhpam7*.adoc` and `rhdm7*.adoc` files per [this comment](https://github.com/kiegroup/kie-docs/pull/2075#issuecomment-561268085).

Please let me know if I have made any mistake.

Thanks,
Jafer