### PR TITLE
DROOLS-4485: [DMN Designer] Data Types visual indication - Release notes

### DIFF
--- a/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes-chapter.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes-chapter.adoc
@@ -6,6 +6,8 @@
 //include::ReleaseNotes/ReleaseNotesDrools.7.24.0.Final/ReleaseNotesDrools.7.24.0.Final-section.adoc[leveloffset=+1]
 //include::{shared-dir}/Workbench/ReleaseNotes/ReleaseNotesWorkbench.7.24.0.Final/ReleaseNotesWorkbench.7.24.0.Final-section.adoc[leveloffset=+1]
 
+include::ReleaseNotes/ReleaseNotesDrools.7.33.0.Final/ReleaseNotesDrools.7.33.0.Final-section.adoc[leveloffset=+1]
+
 include::ReleaseNotes/ReleaseNotesDrools.7.32.0.Final/ReleaseNotesDrools.7.32.0.Final-section.adoc[leveloffset=+1]
 
 include::ReleaseNotes/ReleaseNotesDrools.7.30.0.Final/ReleaseNotesDrools.7.30.0.Final-section.adoc[leveloffset=+1]

--- a/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.7.33.0.Final/ReleaseNotesDrools.7.33.0.Final-section.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.7.33.0.Final/ReleaseNotesDrools.7.33.0.Final-section.adoc
@@ -1,0 +1,5 @@
+[id='drools.releasenotesdrools.7.33.0']
+
+= New and Noteworthy in Drools 7.33.0
+
+include::dmn-data-types-ux-7-33-enhancements.adoc[leveloffset=+1]

--- a/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.7.33.0.Final/dmn-data-types-ux-7-33-enhancements.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.7.33.0.Final/dmn-data-types-ux-7-33-enhancements.adoc
@@ -1,0 +1,5 @@
+[id='dmn-data-types-ux-7-33-enhancements']
+
+= DMN data types UX enhancements
+
+The DMN designer in {CENTRAL} has been updated with a visual level indicator for data type rows in the *Data Types* tab. Data types now have a blue line that shows the hierarchical value of the highlighted Data Type.


### PR DESCRIPTION
See https://issues.redhat.com/browse/DROOLS-4485

![2020-01-08 08 53 41](https://user-images.githubusercontent.com/1079279/71976288-b368ea00-31f4-11ea-90e1-0a1e926e08cd.gif)

----

This PR must be merged after the https://github.com/kiegroup/kie-wb-common/pull/3102, but this is ready for review.