### PR TITLE
Fix typo for DMN custom data type name

### DIFF
--- a/doc-content/drools-docs/src/main/asciidoc/DMN/dmn-gs-creating-custom-datatypes-proc.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/DMN/dmn-gs-creating-custom-datatypes-proc.adoc
@@ -13,7 +13,7 @@ image::dmn/dmn-custom-datatypes-tab.png[]
 
 The following tables list the `tDriver`, `tViolation`, and `tFine` custom data types that you will create for this project.
 
-.Driver custom data types
+.`tDriver` custom data type
 [cols="1,1", options="header"]
 |===
 |Name |Type
@@ -26,7 +26,7 @@ The following tables list the `tDriver`, `tViolation`, and `tFine` custom data t
 |Points |number
 |===
 
-.Violation custom data types
+.`tViolation` custom data type
 [cols="1,1", options="header"]
 |===
 |Name |Type
@@ -39,7 +39,7 @@ The following tables list the `tDriver`, `tViolation`, and `tFine` custom data t
 |Actual Speed |number
 |===
 
-.Fine custom data types
+.`tFine` custom data type
 [cols="1,1", options="header"]
 |===
 |Name |Type

--- a/doc-content/drools-docs/src/main/asciidoc/DMN/dmn-gs-creating-custom-datatypes-proc.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/DMN/dmn-gs-creating-custom-datatypes-proc.adoc
@@ -11,7 +11,7 @@ image::dmn/dmn-custom-datatypes-tab.png[]
 //.Diagram properties tab
 //image::dmn/dmn-diagram-properties-tab.png[]
 
-The following tables list the `Driver`, `Violation`, and `Fine` custom data types that you will create for this project.
+The following tables list the `tDriver`, `tViolation`, and `tFine` custom data types that you will create for this project.
 
 .Driver custom data types
 [cols="1,1", options="header"]


### PR DESCRIPTION
@sterobin I believe throughout the tutorial/doc they are referred with the `t` prefix