### PR TITLE
PLANNER-1839: Have Asciidoctor managed by kie-parent

### DIFF
--- a/doc-content/pom.xml
+++ b/doc-content/pom.xml
@@ -43,19 +43,6 @@
         <plugin>
           <groupId>org.asciidoctor</groupId>
           <artifactId>asciidoctor-maven-plugin</artifactId>
-          <version>1.5.7.1</version>
-          <dependencies>
-            <dependency>
-              <groupId>org.asciidoctor</groupId>
-              <artifactId>asciidoctorj</artifactId>
-              <version>1.5.7</version>
-            </dependency>
-            <dependency>
-              <groupId>org.asciidoctor</groupId>
-              <artifactId>asciidoctorj-pdf</artifactId>
-              <version>1.5.0-alpha.16</version>
-            </dependency>
-          </dependencies>
           <configuration>
             <imagesDir>.</imagesDir>
             <resources>


### PR DESCRIPTION
https://issues.redhat.com/browse/PLANNER-1839

## PR group
- kiegroup/droolsjbpm-build-bootstrap/pull/1192
- kiegroup/kie-docs/pull/2200 (optional)
- kiegroup/optaplanner/pull/696
- kiegroup/optaweb-employee-rostering/pull/395
- kiegroup/optaweb-vehicle-routing/pull/268

@sterobin This PR is **optional**. I noticed slight changes in the HTML output after the upgrade, for example:
- darker background of some code blocks, improving their visibility,
- change in ruby code syntax highlighting.

Nothing serious. But please review carefully before merging. Feel free to reject if you don't want to have the maven plugin ant its dependencies' versions managed by `kie-parent`. Notice that after accepting this change it will still be easy to override the dependencies' version by setting:
```xml
  <properties>
    <version.org.asciidoctor.asciidoctorj>2.1.0</version.org.asciidoctor.asciidoctorj>
    <version.org.asciidoctor.asciidoctorj-pdf>1.5.0-rc.3</version.org.asciidoctor.asciidoctorj-pdf>
  </properties>
```