### PR TITLE
Upstream master PR for BXMSDOC-5201: Corrected the NFS server cross reference issue.

### DIFF
--- a/doc-content/enterprise-only/installation/clustering-headless-controller-proc.adoc
+++ b/doc-content/enterprise-only/installation/clustering-headless-controller-proc.adoc
@@ -6,7 +6,13 @@ The {CONTROLLER} is integrated with {CENTRAL}. However, if you do not install {C
 .Prerequisites
 * A backed-up {EAP} installation version 7.2 or later is available. The base directory of the {EAP} installation is referred to as `__EAP_HOME__`.
 * Sufficient user permissions to complete the installation are granted.
-* An NFS server with a mounted partition is available as described in xref:nfs-server-configure-proc[].
+* An NFS server with a mounted partition is available as described in
+ifeval::["{context}" == "execution-server"]
+{URL_INSTALLING_ON_EAP_CLUSTER}#nfs-server-configure-proc[_{INSTALLING_ON_EAP_CLUSTER}_].
+endif::[]
+ifeval::["{context}" == "clustering-runtime-standalone"]
+xref:nfs-server-configure-proc[].
+endif::[]
 
 .Procedure
 . Navigate to the https://access.redhat.com/jbossnetwork/restricted/listSoftware.html[Software Downloads] page in the Red Hat Customer Portal (login required), and select the product and version from the drop-down options:


### PR DESCRIPTION
I have added the changes in the **clustering-headless-controller-proc.adoc** file to resolve the cross-reference issue in the managing and monitoring KIE Server doc. 

Following assemblies are affected: 
- assembly_clustering-eap
- assembly_managing-and-monitoring-execution-server

Following docs are affected: 
- [RHPAM 7.7 Managing and monitoring KIE Server](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-5201-RHPAM-MM-KIE-Server/)
- [RHDM 7.7 Managing and monitoring KIE Server](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-5201-RHDM-MM-KIE-Server/)
- [RHPAM 7.7 Installing and configuring Red Hat Process Manager in a Red Hat JBoss EAP clustered environment](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-5201-RHPAM-clustering-eap/)
- [RHDM 7.7 Installing and configuring Red Hat Decision Manager in a Red Hat JBoss EAP clustered environment](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-5201-RHDM-clustering-eap/)