### PR TITLE
Upstream 7.33.x PR for BXMSDOC-5458: Update the RH-SSO doc per changes in RHDM/RHPAM 7.7

### DIFF
--- a/doc-content/enterprise-only/integration/sso-client-adapter-proc.adoc
+++ b/doc-content/enterprise-only/integration/sso-client-adapter-proc.adoc
@@ -94,7 +94,7 @@ For more information about management CLI of {EAP}, see the https://access.redha
 ----
 <subsystem xmlns="urn:wildfly:elytron:4.0" ...>
 ......
- <policy><jacc-policy/></policy>
+ <policy name="jacc"><jacc-policy/></policy>
 </subsystem>
 ----
 

--- a/doc-content/enterprise-only/integration/sso-client-adapter-proc.adoc
+++ b/doc-content/enterprise-only/integration/sso-client-adapter-proc.adoc
@@ -72,8 +72,22 @@ In this example:
 The RH-SSO server converts the user names to lower case. Therefore, after integration with RH-SSO, your user name will appear in lower case in {PRODUCT}. If you have user names in upper case hard coded in business processes, the application might not be able to identify the upper case user.
 ====
 +
-. Navigate to the `_EAP_HOME_/standalone/configuration` directory in your {EAP} installation.
-  Locate the Elytron and undertow subsystem configurations in the `standalone.xml` and `standalone-full.xml` files and enable JACC. For example:
+. The Elytron subsystem provides a built-in policy provider based on JACC specification. To enable the JACC manually in the `standalone.xml` or in the file where Elytron is installed, do any of the following tasks:
+
+* To create the policy provider, enter the following commands in the management command-line interface (CLI) of {EAP}:
++
+--
+[source]
+----
+/subsystem=elytron/policy=jacc:add(jacc-policy={})
+/subsystem=undertow/application-security-domain=other:remove
+/subsystem=undertow/application-security-domain=other:add(http-authentication-factory=keycloak-http-authentication,enable-jacc=true)
+----
+--
++
+For more information about management CLI of {EAP}, see the https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.2/html-single/management_cli_guide/index[_Management CLI Guide_].
+
+* Navigate to the `_EAP_HOME_/standalone/configuration` directory in your {EAP} installation. Locate the Elytron and undertow subsystem configurations in the `standalone.xml` and `standalone-full.xml` files and enable JACC. For example:
 +
 --
 [source,xml,subs="attributes+"]


### PR DESCRIPTION
**JIRAs:** 
- [Epic](https://issues.redhat.com/browse/BXMSDOC-5200)
- [Dedicated JIRA](https://issues.redhat.com/browse/BXMSDOC-5458)

**7.7 doc previews**
- [RHPAM 7.7 Integrating Red Hat Process Automation Manager with Red Hat Single Sign-On](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-5458-RHPAM-SSO/#sso-client-adapter-proc)
- [RHDM 7.7 Integrating Red Hat Decision Manager with Red Hat Single Sign-On](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-5458-RHDM-SSO/#sso-client-adapter-proc)

Please check **step 9** from section 4.2. Installing the RH-SSO client adapter for Business Central.