### PR TITLE
Upstream master PR for BXMSDOC-5240: Updated the Managing & monitoring KIE Server doc as per RHPAM/RHDM 7.7

### DIFF
--- a/assemblies/assembly_managing-and-monitoring-execution-server/main.adoc
+++ b/assemblies/assembly_managing-and-monitoring-execution-server/main.adoc
@@ -51,7 +51,9 @@ include::{enterprise-dir}/admin-and-config/kie-server-configure-central-proc.ado
 include::{enterprise-dir}/admin-and-config/configuring-environment-mode-proc.adoc[leveloffset=+1]
 
 include::{enterprise-dir}/admin-and-config/kie-server-configure-server-managed-by-workbench-proc.adoc[leveloffset=+1]
-include::{enterprise-dir}/admin-and-config/kie-server-smart-router-enable-tls-support-proc.adoc[leveloffset=+2]
+ifdef::PAM[]
+include::{enterprise-dir}/admin-and-config/kie-server-smart-router-enable-tls-support-proc.adoc[leveloffset=+1]
+endif::PAM[]
 
 include::{enterprise-dir}/admin-and-config/kie-server-managed-kie-server-con.adoc[leveloffset=+1]
 

--- a/doc-content/enterprise-only/admin-and-config/deployment-descriptors-con.adoc
+++ b/doc-content/enterprise-only/admin-and-config/deployment-descriptors-con.adoc
@@ -3,7 +3,7 @@
 
 Processes and rules are stored in Apache Maven based packaging and are known as knowledge archives, or KJAR. The rules, processes, assets, and other project artifacts are part of a JAR file built and managed by Maven. A file kept inside the `META-INF` directory of the KJAR called `kmodule.xml` can be used to define the KIE bases and sessions. This `kmodule.xml` file, by default, is empty.
 
-Whenever a runtime component such as {CENTRAL} is about to process the KJAR, it looks up `kmodule.xml` to build the runtime representation.
+Whenever a runtime component such as {KIE_SERVER} is about to process the KJAR, it looks up `kmodule.xml` to build the runtime representation.
 
 Deployment descriptors supplement the `kmodule.xml` file and provide granular control over your deployment. The presence of these descriptors is optional and your deployment will proceed successfully without them. You can set purely technical properties using these descriptors, including meta values such as persistence, auditing, and runtime strategy.
 

--- a/doc-content/enterprise-only/installation/patches-applying-proc.adoc
+++ b/doc-content/enterprise-only/installation/patches-applying-proc.adoc
@@ -13,14 +13,7 @@ NOTE: Only updates for {PRODUCT} are included in {PRODUCT} update tools. Updates
 
 .Procedure
 . Navigate to the https://access.redhat.com/jbossnetwork/restricted/listSoftware.html[Software Downloads] page in the Red Hat Customer Portal (login required), and select the product and version from the drop-down options.
-+
---
-Example:
 
-* *Product:* {PRODUCT_SHORT}
-* *Version:* {PRODUCT_VERSION}.1
---
-+
 If you are upgrading to a new minor release of {PRODUCT}, such as an upgrade from version 7.6.x to 7.7, first apply the latest patch update to your current version of {PRODUCT} and then follow this procedure again to upgrade to the new minor release.
 +
 . Click *Patches*, download the *{PRODUCT} [VERSION] Update Tool*, and extract the downloaded `{PRODUCT_INIT}-$VERSION-update.zip` file to a temporary directory.

--- a/doc-content/enterprise-only/migration/migration-configure-kie-server-proc.adoc
+++ b/doc-content/enterprise-only/migration/migration-configure-kie-server-proc.adoc
@@ -18,6 +18,7 @@ endif::[]
 .Procedure
 Navigate to the {PRODUCT} {PRODUCT_VERSION} `bin` directory and start the new {KIE_SERVER} with the following properties. Adjust the specific properties according to your environment.
 
+ifdef::PAM[]
 [source,subs="attributes+"]
 ----
 $ ~/EAP_HOME/bin/standalone.sh --server-config=standalone-full.xml <1>
@@ -31,6 +32,21 @@ $ ~/EAP_HOME/bin/standalone.sh --server-config=standalone-full.xml <1>
 -Dorg.kie.server.persistence.dialect=org.hibernate.dialect.PostgreSQLDialect <9>
 -Dorg.kie.server.persistence.ds=java:jboss/datasources/psjbpmDS <10>
 ----
+endif::PAM[]
+
+ifdef::DM[]
+[source,subs="attributes+"]
+----
+$ ~/EAP_HOME/bin/standalone.sh --server-config=standalone-full.xml <1>
+-Dorg.kie.server.id=myserver <2>
+-Dorg.kie.server.user={URL_COMPONENT_KIE_SERVER_UNDER}_username <3>
+-Dorg.kie.server.pwd={URL_COMPONENT_KIE_SERVER_UNDER}_password <4>
+-Dorg.kie.server.controller=http://localhost:8080/{URL_COMPONENT_CENTRAL}/rest/controller <5>
+-Dorg.kie.server.controller.user=controller_username <6>
+-Dorg.kie.server.controller.pwd=controller_password <7>
+-Dorg.kie.server.location=http://localhost:8080/kie-server/services/rest/server <8>
+----
+endif::DM[]
 <1> Start command with `standalone-full.xml` server profile
 <2> Server ID that must match the server configuration name defined in {CENTRAL}
 <3> User name to connect with {KIE_SERVER} from the {CONTROLLER}
@@ -39,8 +55,10 @@ $ ~/EAP_HOME/bin/standalone.sh --server-config=standalone-full.xml <1>
 <6> User name to connect to the {CONTROLLER} REST API
 <7> Password to connect to the {CONTROLLER} REST API
 <8> {KIE_SERVER} location (on the same instance as {CENTRAL} in this example)
+ifdef::PAM[]
 <9> Hibernate dialect to be used
 <10> JNDI name of the data source used for your previous {PRODUCT_OLD} database
+endif::PAM[]
 
 [NOTE]
 ====


### PR DESCRIPTION
**JIRAs:**
- [Epic](https://issues.redhat.com/browse/BXMSDOC-5201)
- [Dedicated JIRA](https://issues.redhat.com/browse/BXMSDOC-5240)

**Doc previews:**
- [7.7 RHPAM Managing and Monitoring KIE Server](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-5240-RHPAM-MMES/#migration-configure-kie-server-proc)
- [7.7 RHDM Managing and Monitoring KIE Server](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-5240-RHDM-MMES/#migration-configure-kie-server-proc)

**Following changes are incorporated in the doc:**

- Properties *org.kie.server.persistence.dialect* and *org.kie.server.persistence.ds* they are only present in RHPAM and removed from RHDM.
- This chapter *Configuring Smart Router for TLS support* is only present in RHPAM doc as Smart Router is applicable to RHPAM only.
- Business central doesn't process KJARs any more so I have replaced Business central by KIE server.
- Chapter 9. Configuring KIE Server Managed by Business Central and 9.1. Configuring Smart Router for TLS support are now separated.
- references from version 7.5.x to 7.6 are now updated to *7.6.x to 7.7*.