### PR TITLE
Upstream 7.23.x PR for BXMSDOC-5517: Replaced decision engine with process engine for PAM doc

### DIFF
--- a/doc-content/enterprise-only/integration/dev-studio-installing-runtime-environments-proc.adoc
+++ b/doc-content/enterprise-only/integration/dev-studio-installing-runtime-environments-proc.adoc
@@ -9,13 +9,28 @@ A runtime environment is a collection of JAR files that represent a specific rel
 * Red Hat Developer Studio is installed.
 
 .Procedure
+ifdef::PAM[]
+. Download the {PROCESS_ENGINE}:
+endif::[]
+
+ifdef::DM[]
 . Download the {DECISION_ENGINE}:
+endif::[]
+
 .. Log in to the https://access.redhat.com[Red Hat Customer Portal].
 .. Click *DOWNLOADS* at the top of the page.
 .. On the *Product Downloads* page that opens, navigate to the JBOSS DEVELOPMENT AND MANAGEMENT section, and click *{PRODUCT}*.
 .. On the *Software Downloads* page, download *{PRODUCT} {PRODUCT_VERSION_LONG} Add-Ons* (`{PRODUCT_FILE}-add-ons.zip`).
-.. Extract `{PRODUCT_FILE}-add-ons.zip` and then extract the Drools runtime environment JAR files located in `{PRODUCT_FILE}-add-ons/{PRODUCT_FILE}-{URL_COMPONENT_DECISION_ENGINE}.zip`.
-. From the Red Hat Developer Studio menu, click *Window* -> *Preferences*.
+
+ifdef::PAM[]
+.. Extract `{PRODUCT_FILE}-add-ons.zip` and then extract the Drools runtime environment JAR files located in `{PRODUCT_FILE}-add-ons/{PRODUCT_FILE}-{URL_COMPONENT_PROCESS_ENGINE}.zip`
+endif::PAM[]
+
+ifdef::DM[]
+.. Extract `{PRODUCT_FILE}-add-ons.zip` and then extract the Drools runtime environment JAR files located in `{PRODUCT_FILE}-add-ons/{PRODUCT_FILE}-{URL_COMPONENT_DECISION_ENGINE}.zip`
+endif::DM[]
+
+. From the {CODEREADY_STUDIO} menu, click *Window* -> *Preferences*.
 . Click *Drools* -> *Installed Drools Runtimes*, and then click *Add*.
 . In the name field, enter a name for the new runtime environment.
 . Click *Browse* and navigate to the directory where you extracted the runtime environment files.


### PR DESCRIPTION
See JIRA: https://issues.redhat.com/browse/BXMSDOC-5517

[RHPAM 7.4](http://file.pnq.redhat.com/~hmanwani/BXMSDOC-5517-RHPAM7.4/#dev-studio-installing-runtime-environments-proc)
[RHDM 7.4](http://file.pnq.redhat.com/~hmanwani/BXMSDOC-5517-RHDM7.4/#dev-studio-installing-runtime-environments-proc)