### PR TITLE
Upstream PR BXMSDOC-5091-7.33.x to upstream 7.33.x added missing closing bracket to code snippet

### DIFF
--- a/doc-content/enterprise-only/springboot/bus-app-create_proc.adoc
+++ b/doc-content/enterprise-only/springboot/bus-app-create_proc.adoc
@@ -8,7 +8,7 @@ You can use the https://start.jbpm.org[business application] website to quickly 
 +
 [source]
 ----
-https://start.jbpm.org 
+https://start.jbpm.org
 ----
 
 . Click *Configure your business application*.
@@ -66,7 +66,7 @@ The `<business-application>.zip` file downloads, where `<business-application>` 
   </releases>
   <snapshots>
     <updatePolicy>daily</updatePolicy>
-  </snapshots
+  </snapshots>
 </pluginRepository>
 ----
 +


### PR DESCRIPTION
Upstream PR for 7.33 to cover 7.7

Original jira: https://issues.redhat.com/browse/BXMSDOC-5091
Rendered output: http://file.rdu.redhat.com/~mhaglund/BXMSDOC-5091/#bus-app-create_business-applications