### PR TITLE
BXMSDOC-5553-master-kogito: Add Kogito glossary

### DIFF
--- a/_artifacts/document-attributes.adoc
+++ b/_artifacts/document-attributes.adoc
@@ -55,6 +55,7 @@ endif::KOGITO-COMM[]
 :DEPLOYING_ON_OPENSHIFT: Deploying {PRODUCT} services on {OPENSHIFT}
 :DECISION_SERVICES: Developing decision services with {PRODUCT}
 :PROCESS_SERVICES: Developing process services with {PRODUCT}
+:CONFIGURING_KOGITO: Configuring {PRODUCT} supporting services and runtime capabilities
 
 // URL components, for post Dev Preview
 :URL_COMPONENT_FORMAT: html-single
@@ -70,5 +71,6 @@ endif::KOGITO-COMM[]
 :URL_DEPLOYING_ON_OPENSHIFT: {URL_BASE_ENTERPRISE}/deploying_{PRODUCT-INI}_services_on_{URL_COMPONENT_OPENSHIFT}
 :URL_DECISION_SERVICES: {URL_BASE_ENTERPRISE}/developing_decision_services_with_{PRODUCT-INI}
 :URL_PROCESS_SERVICES: {URL_BASE_ENTERPRISE}/developing_process_services_with_{PRODUCT-INI}
+:URL_CONFIGURING_KOGITO: {URL_BASE_ENTERPRISE}/configuring_{PRODUCT_INIT}_supporting_services_and_runtime_capabilities
 
 :ndash: &ndash;

--- a/assemblies/assembly_kogito-creating-running/main.adoc
+++ b/assemblies/assembly_kogito-creating-running/main.adoc
@@ -32,6 +32,7 @@ include::{kogito-dir}/creating-running/proc_kogito-designing-app.adoc[leveloffse
 include::{kogito-dir}/creating-running/proc_kogito-designing-app-rule-units.adoc[leveloffset=+2]
 include::{kogito-dir}/creating-running/proc_kogito-running-app.adoc[leveloffset=+1]
 include::{kogito-dir}/creating-running/proc_kogito-interacting-app.adoc[leveloffset=+1]
+include::{kogito-dir}/creating-running/ref_kogito-glossary.adoc[leveloffset=+1]
 
 == Additional resources
 * {URL_DEPLOYING_ON_OPENSHIFT}[_{DEPLOYING_ON_OPENSHIFT}_]

--- a/doc-content/kogito-docs/src/main/asciidoc/creating-running/proc_kogito-running-app.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/creating-running/proc_kogito-running-app.adoc
@@ -1,4 +1,4 @@
-[id='proc_kogito-running-app']
+[id='proc_kogito-running-app_{context}']
 
 = Running a {PRODUCT} service
 

--- a/doc-content/kogito-docs/src/main/asciidoc/creating-running/ref_kogito-glossary.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/creating-running/ref_kogito-glossary.adoc
@@ -1,0 +1,275 @@
+[id='ref_kogito-glossary_{context}']
+
+= {PRODUCT} glossary of terms
+
+This glossary defines terms, concepts, or components that are referenced frequently in {PRODUCT} documentation or that have a unique meaning or function in {PRODUCT}.
+
+BPMN model::
+A definition of a business process workflow based on the https://www.omg.org/spec/BPMN/2.0/About-BPMN[Business Process Model and Notation (BPMN) specification]. BPMN is a standard established by the Object Management Group (OMG) for describing and modeling business processes. BPMN defines an XML schema that enables BPMN models to be shared between BPMN-compliant platforms and across organizations so that business analysts and business process developers can collaborate in designing and implementing BPMN process services. The BPMN standard is similar to and can be used together with the Decision Model and Notation (DMN) standard for designing and modeling business decisions.
++
+.Additional resources:
+ifdef::KOGITO[]
+* {URL_PROCESS_SERVICES}[_{PROCESS_SERVICES}_]
+endif::[]
+ifdef::KOGITO-COMM[]
+* xref:chap_kogito-developing-process-services[]
+endif::[]
+
+business domain API::
+An API that your business develops and implements within business applications that contain {PRODUCT} services.
+
+business models::
+The collection of BPMN process models, DMN decision models, DRL rules, XLS decision tables, and any other assets that define the business logic for a {PRODUCT} service.
+
+CloudEvents format::
+A specification for describing event data in a common way. {PRODUCT} runtime events for messages, processes, tasks, and other application activities are published in https://cloudevents.io/[CloudEvents] format so that they can be consumed efficiently by other entities, such as the {PRODUCT} Data Index Service.
++
+.Additional resources:
+ifdef::KOGITO[]
+* {URL_CONFIGURING_KOGITO}#con_kogito-runtime-events_kogito-configuring[_{PRODUCT} runtime events_]
+* {URL_CONFIGURING_KOGITO}#con_data-index-service_kogito-configuring[_{PRODUCT} Data Index Service_]
+endif::[]
+ifdef::KOGITO-COMM[]
+* xref:con_kogito-runtime-events_kogito-configuring[]
+* xref:con_data-index-service_kogito-configuring[]
+endif::[]
+
+decision table::
+A set of business rules defined in a tabular format. Each row in a decision table is a rule, and each column is a condition, an action, or another rule attribute.
++
+.Additional resources:
+ifdef::KOGITO[]
+* {URL_DECISION_SERVICES}#con_decision-tables_decision-tables[_Designing a decision service using spreadsheet decision tables_]
+endif::[]
+ifdef::KOGITO-COMM[]
+* xref:con_decision-tables_decision-tables[]
+endif::[]
+
+development mode::
+A project build option that provides a fast feedback loop from code changes to a running system using hot reload. Development mode also enables debugging tools such as Swagger in {PRODUCT} runtime services.
++
+.Additional resources:
+ifdef::KOGITO[]
+* {URL_CREATING_RUNNING}#proc_kogito-running-app_creating-running[_Running a {PRODUCT} service_]
+endif::[]
+ifdef::KOGITO-COMM[]
+* xref:proc_kogito-running-app_creating-running[]
+endif::[]
+* https://quarkus.io/guides/maven-tooling[_Quarkus - Building applications with Maven_]
+
+DRL rule::
+A definition of a business rule in Drools Rule Language (DRL) format. DRL is a notation established by the https://www.drools.org/[Drools] open source business automation project for defining and describing business rules.
++
+.Additional resources:
+ifdef::KOGITO[]
+* {URL_DECISION_SERVICES}#con_drl_drl-rules[_Designing a decision service using DRL rules_]
+endif::[]
+ifdef::KOGITO-COMM[]
+* xref:con_drl_drl-rules[]
+endif::[]
+
+DRL rule unit::
+A group of data sources, global variables, and DRL rules that function together for a specific purpose. You can use DRL rule units to partition a rule set into smaller units, bind different data sources to those units, and then execute the individual unit. Rule units are an enhanced alternative to rule-grouping DRL attributes such as rule agenda groups or activation groups for execution control.
++
+.Additional resources:
+ifdef::KOGITO[]
+* {URL_DECISION_SERVICES}#con_drl-rule-units_drl-rules[_Rule units in DRL_]
+endif::[]
+ifdef::KOGITO-COMM[]
+* xref:con_drl-rule-units_drl-rules[]
+endif::[]
+
+DMN model::
+A definition of a business decision flow based on the https://www.omg.org/spec/DMN[Decision Model and Notation (DMN) specification]. DMN is a standard established by the Object Management Group (OMG) for describing and modeling operational decisions. DMN defines an XML schema that enables DMN models to be shared between DMN-compliant platforms and across organizations so that business analysts and business rules developers can collaborate in designing and implementing DMN decision services. The DMN standard is similar to and can be used together with the Business Process Model and Notation (BPMN) standard for designing and modeling business processes.
++
+.Additional resources:
+ifdef::KOGITO[]
+* {URL_DECISION_SERVICES}#con_dmn_dmn-models[_Designing a decision service using DMN models_]
+endif::[]
+ifdef::KOGITO-COMM[]
+* xref:con_dmn_dmn-models[]
+endif::[]
+
+event listener::
+A procedure or function in a program that reacts to a specified event, such as a completed node in a process or an executed decision.
++
+.Additional resources:
+ifdef::KOGITO[]
+* {URL_CONFIGURING_KOGITO}#proc_event-listeners-registering_kogito-configuring[_Registering event listeners_]
+endif::[]
+ifdef::KOGITO-COMM[]
+* xref:proc_event-listeners-registering_kogito-configuring[]
+endif::[]
+
+intelligent application::
+An optimized, integrated solution that uses {PRODUCT} services to implement business-domain knowledge.
+
+{PRODUCT} CLI::
+A command-line interface (CLI) that enables you to interact with the {PRODUCT} Operator for deployment tasks. The {PRODUCT} CLI also enables you to deploy {PRODUCT} services from source instead of relying on custom resources and YAML files.
++
+.Additional resources:
+ifdef::KOGITO[]
+* {URL_DEPLOYING_ON_OPENSHIFT}#proc_kogito-deploying-on-ocp-kogito-cli_kogito-deploying-on-openshift[_Deploying {PRODUCT} on {OPENSHIFT} using the {PRODUCT} CLI_]
+endif::[]
+ifdef::KOGITO-COMM[]
+* xref:proc_kogito-deploying-on-ocp-kogito-cli_kogito-deploying-on-openshift[]
+endif::[]
+
+////
+//@comment: Excluding for now due to current build issues with the extension and we aren't using it at this point. (Stetson, 2 Apr 2020)
+{PRODUCT} Quarkus extension::
+An extension required to generate and build a Maven project for {PRODUCT} runtime services on the Quarkus Java framework. You can add the {PRODUCT} extension during project creation using the Quarkus Maven plugin or using the https://code.quarkus.io/[Code with Quarkus] extension manager.
+
+//@comment: Also excluding until we document and promote it. (Stetson 2 Apr 2020)
+{PRODUCT} Management Console::
+A user interface that enables administrators to manage {PRODUCT} process instances, tasks, jobs, and other process-related assets in a {PRODUCT} service.
+////
+
+{PRODUCT} Data Index Service::
+A dedicated service in {PRODUCT} that stores all {PRODUCT} events related to processes, tasks, and domain data. The Data Index Service uses Apache Kafka messaging to consume CloudEvents messages from {PRODUCT} services, and then indexes the returned data for future GraphQL queries and stores the data in the Infinispan persistence store. The Data Index Service is at the core of all {PRODUCT} search, insight, and management capabilities.
++
+.Additional resources:
+ifdef::KOGITO[]
+* {URL_CONFIGURING_KOGITO}#con_data-index-service_kogito-configuring[_{PRODUCT} Data Index Service_]
+endif::[]
+ifdef::KOGITO-COMM[]
+* xref:con_data-index-service_kogito-configuring[]
+endif::[]
+
+{PRODUCT} domain-specific service::
+A business automation service for your business domain that you create using {PRODUCT}. You define the logic of this service using BPMN process models, DMN decision models, or other business models, and any other supported runtime configurations. In {PRODUCT} documentation, the general term for _{PRODUCT} services_ that you create refers to this type of service.
+
+{PRODUCT} Jobs Service::
+A dedicated service in {PRODUCT} for scheduling BPMN process events that are configured to be executed at a given time. These time-based events in a process model are known as _jobs_. The Jobs Service does not execute a job, but triggers a callback that might be an HTTP request on a given endpoint specified for the job request or any other configured callback. The Jobs Service receives requests for job scheduling and then sends a request at the time specified on the job request.
++
+.Additional resources:
+ifdef::KOGITO[]
+* {URL_CONFIGURING_KOGITO}#con_jobs-service_kogito-configuring[_{PRODUCT} Jobs Service_]
+endif::[]
+ifdef::KOGITO-COMM[]
+* xref:con_jobs-service_kogito-configuring[]
+endif::[]
+
+{PRODUCT} Operator::
+An operator that deploys {PRODUCT} services and manages the required {PRODUCT} infrastructure services. The {PRODUCT} Operator uses the https://github.com/operator-framework[Operator Framework] and automates many of the deployment steps for you.
++
+.Additional resources:
+ifdef::KOGITO[]
+* {URL_DEPLOYING_ON_OPENSHIFT}#con_kogito-on-ocp_kogito-deploying-on-openshift[_{PRODUCT} on {OPENSHIFT}_]
+endif::[]
+ifdef::KOGITO-COMM[]
+* xref:con_kogito-on-ocp_kogito-deploying-on-openshift[]
+endif::[]
+
+{PRODUCT} runtime event::
+A record of a significant change of state in the application domain at a point in time. {PRODUCT} emits a runtime event as a result of an executed asset, such as a process instance or a task instance in a process, and can then use the event to notify third parties about changes to the BPMN process instance and its data.
++
+.Additional resources:
+ifdef::KOGITO[]
+* {URL_CONFIGURING_KOGITO}#con_kogito-runtime-events_kogito-configuring[_{PRODUCT} runtime events_]
+endif::[]
+ifdef::KOGITO-COMM[]
+* xref:con_kogito-runtime-events_kogito-configuring[]
+endif::[]
+
+{PRODUCT} runtime persistence::
+An optional capability for preserving {PRODUCT} process data in your services across application restarts. {PRODUCT} persistence is based on https://infinispan.org/[Infinispan] and enables you to configure key-value storage definitions to persist data, such as active process nodes and process instance variables.
++
+.Additional resources:
+ifdef::KOGITO[]
+* {URL_CONFIGURING_KOGITO}#con_persistence_kogito-configuring[_Persistence in {PRODUCT}_]
+endif::[]
+ifdef::KOGITO-COMM[]
+* xref:con_persistence_kogito-configuring[]
+endif::[]
+
+{PRODUCT} supporting services::
+The collection of middleware infrastructure services and other dedicated services that help you build additional functionality in the {PRODUCT} domain-specific services that you create. Key middleware infrastructure services in {PRODUCT} include Infinispan persistence and Apache Kafka reactive messaging. Dedicated services provided by {PRODUCT} include the {PRODUCT} Data Index Service and the {PRODUCT} Jobs Service.
++
+.Additional resources:
+ifdef::KOGITO[]
+* {URL_CONFIGURING_KOGITO}#con_data-index-service_kogito-configuring[_{PRODUCT} Data Index Service_]
+* {URL_CONFIGURING_KOGITO}#con_jobs-service_kogito-configuring[_{PRODUCT} Jobs Service_]
+* {URL_CONFIGURING_KOGITO}#proc_persistence-enabling_kogito-configuring[_Enabling persistence for {PRODUCT} services_]
+* {URL_CONFIGURING_KOGITO}#proc_messaging-enabling_kogito-configuring[_Enabling messaging for {PRODUCT} services_]
+endif::[]
+ifdef::KOGITO-COMM[]
+* xref:con_data-index-service_kogito-configuring[]
+* xref:con_jobs-service_kogito-configuring[]
+* xref:proc_persistence-enabling_kogito-configuring[]
+* xref:proc_messaging-enabling_kogito-configuring[]
+endif::[]
+
+message event::
+A specified point in a business process where a defined message is used as the input (received) or output (sent) as a result of the process execution. For example, a message event might be an email sent to a specified user after a task is complete.
++
+.Additional resources:
+ifdef::KOGITO[]
+* {URL_CONFIGURING_KOGITO}#con_kogito-runtime-events_kogito-configuring[_{PRODUCT} runtime events_]
+* {URL_CONFIGURING_KOGITO}#proc_messaging-enabling_kogito-configuring[_Enabling messaging for {PRODUCT} services_]
+endif::[]
+ifdef::KOGITO-COMM[]
+* xref:con_kogito-runtime-events_kogito-configuring[]
+* xref:proc_messaging-enabling_kogito-configuring[]
+endif::[]
+
+MicroProfile Reactive Messaging::
+A specification for sending and receiving messages within and between microservices using message brokers. {PRODUCT} supports https://github.com/eclipse/microprofile-reactive-messaging[MicroProfile Reactive Messaging] for messaging in {PRODUCT} services, such as message events used as either input or output of business process execution.
++
+.Additional resources:
+ifdef::KOGITO[]
+* {URL_CONFIGURING_KOGITO}#proc_messaging-enabling_kogito-configuring[_Enabling messaging for {PRODUCT} services_]
+endif::[]
+ifdef::KOGITO-COMM[]
+* xref:proc_messaging-enabling_kogito-configuring[]
+endif::[]
+
+middleware infrastructure services::
+The collection of supplemental services in {PRODUCT} that provide capabilities such as persistence, messaging, and security. Key middleware infrastructure services in {PRODUCT} include Infinispan persistence and Apache Kafka reactive messaging.
++
+.Additional resources:
+ifdef::KOGITO[]
+* {URL_CONFIGURING_KOGITO}#proc_persistence-enabling_kogito-configuring[_Enabling persistence for {PRODUCT} services_]
+* {URL_CONFIGURING_KOGITO}#proc_messaging-enabling_kogito-configuring[_Enabling messaging for {PRODUCT} services_]
+endif::[]
+ifdef::KOGITO-COMM[]
+* xref:proc_persistence-enabling_kogito-configuring[]
+* xref:proc_messaging-enabling_kogito-configuring[]
+endif::[]
+
+process definition::
+A model that defines the components, workflow, and functionality for a business process, such as a BPMN model.
+
+process instance::
+An occurrence of a pending, running, or completed business process, based on the process definition.
+
+PROTO file (`.proto`)::
+A data library used for marshalling Java objects in protobuf (https://developers.google.com/protocol-buffers/[protocol buffers]) format. {PRODUCT} runtime persistence and communication with Infinispan are handled through a protobuf schema and generated marshallers.
++
+.Additional resources:
+ifdef::KOGITO[]
+* {URL_CONFIGURING_KOGITO}#con_persistence_kogito-configuring[_Persistence in {PRODUCT}_]
+endif::[]
+ifdef::KOGITO-COMM[]
+* xref:con_persistence_kogito-configuring[]
+endif::[]
+
+task life cycle::
+A mechanism that moves a user task or custom task (work item) across various phases, such as *Active* -> *Claim* -> *Complete*. {PRODUCT} provides standard life cycle phases for user tasks and also supports custom life cycles or life cycle phases.
++
+.Additional resources:
+ifdef::KOGITO[]
+* {URL_PROCESS_SERVICES}#con_task-life-cycle_kogito-developing-process-services[_Task life cycle in {PRODUCT} processes_]
+endif::[]
+ifdef::KOGITO-COMM[]
+* xref:con_task-life-cycle_kogito-developing-process-services[]
+endif::[]
+
+////
+//@comment: Excluding for now due to current lack of support in Kogito. Will add once settled. (Stetson 2 Apr 2020)
+Work item::
+A custom task, typically a custom service task, that you can reuse across multiple business processes.
+
+Work item handler::
+A Java object that contains the implementation logic for a custom task (work item).
+////

--- a/doc-content/kogito-docs/src/main/asciidoc/index.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/index.adoc
@@ -44,6 +44,10 @@ include::chap_kogito-developing-decision-services.adoc[leveloffset=+1]
 //Developing process services
 include::chap_kogito-developing-process-services.adoc[leveloffset=+1]
 
+
+//Glossary
+include::creating-running/ref_kogito-glossary.adoc[leveloffset=+1]
+
 [discrete]
 = {PRODUCT} Release Notes
 

--- a/doc-content/kogito-docs/src/main/asciidoc/openshift/con_kogito-on-ocp.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/openshift/con_kogito-on-ocp.adoc
@@ -1,4 +1,4 @@
-[id='con_kogito-on-ocp']
+[id='con_kogito-on-ocp_{context}']
 
 = {PRODUCT} on {OPENSHIFT}
 


### PR DESCRIPTION
@krisv , @porcelli , @ricardozanini , @ibek , I've added a Kogito glossary based on our [google doc](https://docs.google.com/document/d/1khJCEWc5zTok3YTygt6vqKc2BPcgh9C01nC17BvV9rE/edit#heading=h.9xf9elwpgzg4) and discussion, with tweaks and clarifications to tie in to the other documentation and links for more info.

Can you all review and let me know if you're good with this? Doc links below. After your feedback and approval, will move it forward.

Many of the links refer to a new "Configuring Kogito supporting services and runtime capabilities" doc/content that is pending merge and thus are broken. Once that PR is merged, those links will render for community. For enterprise, those links might never render until GA, unless we can figure a way to do so for the dynamic FTP that will be used.

Links:
* [JIRA](https://issues.redhat.com/browse/BXMSDOC-5553)
* [Enterprise doc preview](http://file.rdu.redhat.com/~sterobin/BXMSDOC-5553/#ref_kogito-glossary_kogito-creating-running)
* [Community doc preview](http://file.rdu.redhat.com/~sterobin/BXMSDOC-5553_COMM/#ref_kogito-glossary_kogito-developing-process-services) - Same, but conditioned