### PR TITLE
Upstream 7.26.x PR for BXMSDOC-5115: Added a note regarding validation of list in legacy test scenario content.

### DIFF
--- a/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/test-scenarios-legacy-EXPECT-proc.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/test-scenarios-legacy-EXPECT-proc.adoc
@@ -25,6 +25,9 @@ The list includes the following options, depending on the data in the *GIVEN* se
 image::project-data/test-scenario-field-value.png[Modify a fact field]
 +
 . Set the field values to what is expected to be valid as a result of the *GIVEN* input (such as `approved` | `equals` | `false`).
++
+NOTE: In the legacy test scenarios designer, you can use `=["value1", "value2"]` string format in the *EXPECT* field to validate the list of strings.
+
 . Continue adding any other *EXPECT* input data for the scenario and click *Save* in the test scenarios designer to save your work.
 . After you have defined and saved all *GIVEN*, *EXPECT*, and other data for the scenario, click *Run scenario* in the upper-right corner to run this `.scenario` file, or click *Run all scenarios* to run all saved `.scenario` files in the project package (if there are multiple). Although the *Run scenario* option does not require the individual `.scenario` file to be saved, the *Run all scenarios* option does require all `.scenario` files to be saved.
 +


### PR DESCRIPTION
- [Dedicated JIRA](https://issues.redhat.com/browse/BXMSDOC-5115)
- [7.5-RHPAM-Testing a decision service using test scenarios](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-5115-RHPAM-7.5-TS-CT/#test-scenarios-legacy-EXPECT-proc)
- [7.5-RHDM-Testing a decision service using test scenarios](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-5115-RHDM-7.5-TS-CT/#test-scenarios-legacy-EXPECT-proc)

Added a note regarding the validation of list in the **16.1.2. Adding EXPECT results in test scenarios (legacy)** section in **step 4**.