### PR TITLE
Upstream 7.26.x PR for BXMSDOC-5123: LocalDate data type supported in legacy test scenario.

### DIFF
--- a/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/test-scenarios-legacy-create-proc.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/test-scenarios-legacy-create-proc.adoc
@@ -7,6 +7,8 @@ You can create test scenarios in {CENTRAL} to test the functionality of business
 * *GIVEN* facts
 * *EXPECT* results
 
+NOTE: The legacy test scenarios designer supports the `LocalDate` java built-in data type. You can use the `LocalDate` java built-in data type in the `dd-mmm-yyyy` date format. For example, you can set this in the `17-Oct-2020` date format.
+
 With this data, the test scenario can validate the expected and actual results for that rule instance based on the defined facts. You can also add a *CALL METHOD* and any available *globals* to a test scenario, but these scenario settings are optional.
 
 .Procedure


### PR DESCRIPTION
- [Dedicated JIRA](https://issues.redhat.com/browse/BXMSDOC-5123)
- [7.5-RHPAM-Testing a decision service using test scenarios](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-5123-RHPAM-7.5-TS-CT/#test-scenarios-legacy-create-proc)
- [7.5-RHDM-Testing a decision service using test scenarios](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-5123-RHDM-7.5-TS-CT/#test-scenarios-legacy-create-proc)

Added a note regarding the LocalDate in section 16.1.