### PR TITLE
Upstream 7.30.x PR for BXMSDOC-5831: replaced ] with ) in DMN doc

### DIFF
--- a/doc-content/drools-docs/src/main/asciidoc/DMN/dmn-data-types-ref.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/DMN/dmn-data-types-ref.adoc
@@ -188,7 +188,7 @@ For example, the following literal expression defines an interval between `1` an
 The following literal expression defines an interval between 1 hour and 12 hours, including the lower boundary (a closed interval), but excluding the upper boundary (an open interval):
 
 ----
-[ duration("PT1H") .. duration("PT12H") ]
+[ duration("PT1H") .. duration("PT12H") )
 ----
 
 You can use ranges in decision tables to test for ranges of values, or use ranges in simple literal expressions. For example, the following literal expression returns `true` if the value of a variable `x` is between `0` and `100`:


### PR DESCRIPTION
Replaced ] with ) for a literal expression excluding the upper boundary (an open interval).

See JIRA: https://issues.redhat.com/browse/BXMSDOC-5831

RHPAM - [Designing a decision service using DMN models](http://file.pnq.redhat.com/~hmanwani/BXMSDOC-5831-RHPAM-7.6/#dmn-data-types-ref_dmn-models)
RHDM - [Designing a decision service using DMN models](http://file.pnq.redhat.com/~hmanwani/BXMSDOC-5831-RHDM-7.6/#dmn-data-types-ref_dmn-models)