### PR TITLE
Upstream 7.33.x PR for BXMSDOC-5953: Corrected the cross reference links in the documents.

### DIFF
--- a/doc-content/enterprise-only/admin-and-config/kie-server-smart-router-enable-endpoint-authentication-proc.adoc
+++ b/doc-content/enterprise-only/admin-and-config/kie-server-smart-router-enable-endpoint-authentication-proc.adoc
@@ -5,7 +5,13 @@ You can configure Smart Router (KIE Server Router) for endpoint authentication.
 
 .Prerequisites
 * {KIE_SERVER} is installed on each node of a {EAP} {EAP_VERSION} cluster.
-* Smart Router is installed and configured. For more information, see xref:clustering-smart-router-install-proc[].
+* Smart Router is installed and configured. For more information, see
+ifeval::["{context}" == "execution-server"]
+{URL_INSTALLING_ON_EAP_CLUSTER}#clustering-smart-router-install-proc[{INSTALLING_ON_EAP_CLUSTER}].
+endif::[]
+ifeval::["{context}" == "clustering-runtime-standalone"]
+xref:clustering-smart-router-install-proc[].
+endif::[]
 
 .Procedure
 * To start Smart Router with endpoint authentication enabled, configure the management credentials:

--- a/doc-content/enterprise-only/admin-and-config/kie-server-smart-router-enable-tls-support-proc.adoc
+++ b/doc-content/enterprise-only/admin-and-config/kie-server-smart-router-enable-tls-support-proc.adoc
@@ -5,7 +5,13 @@ You can configure Smart Router (KIE Server Router) for TLS support to allow HTTP
 
 .Prerequisites
 * {KIE_SERVER} is installed on each node of a {EAP} {EAP_VERSION} cluster.
-* Smart Router is installed and configured. For more information, see xref:clustering-smart-router-install-proc[].
+* Smart Router is installed and configured. For more information, see
+ifeval::["{context}" == "execution-server"]
+{URL_INSTALLING_ON_EAP_CLUSTER}#clustering-smart-router-install-proc[{INSTALLING_ON_EAP_CLUSTER}].
+endif::[]
+ifeval::["{context}" == "clustering-runtime-standalone"]
+xref:clustering-smart-router-install-proc[].
+endif::[]
 
 .Procedure
 * To start Smart Router with TLS support and HTTPS enabled, use the TLS keystore properties, for example:


### PR DESCRIPTION
**Affected documents:** 
- RHPAM and RHDM Managing and monitoring KIE Server
- Installing and configuring RHPAM/RHDM in a Red Hat JBoss EAP clustered environment

Managing and monitoring KIE Server book was not building properly due to cross-reference links issue. Updated the links. 