### PR TITLE
Upstream master PR for BXMSDOC-5933: Added limitation for consequences written in JAVA dialects

### DIFF
--- a/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/rules-attributes-ref.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/rules-attributes-ref.adoc
@@ -107,7 +107,16 @@ Example: `lock-on-active true`
 Example: `ruleflow-group "GroupName"`
 
 |`dialect`
-|A string identifying either `JAVA` or `MVEL` as the language to be used for code expressions in the rule. By default, the rule uses the dialect specified at the package level. Any dialect specified here overrides the package dialect setting for the rule.
+a|A string identifying either `JAVA` or `MVEL` as the language to be used for code expressions in the rule. By default, the rule uses the dialect specified at the package level. Any dialect specified here overrides the package dialect setting for the rule.
 
 Example: `dialect "JAVA"`
+
+NOTE: When you use {PRODUCT} without the executable model, the `dialect "JAVA"` rule consequences support only Java 5 syntax. For more information about executable models, see
+ifdef::DM,PAM[]
+{URL_PACKAGING_DEPLOYING_PROJECT}#executable-model-con_packaging-deploying[_{PACKAGING_DEPLOYING_PROJECT}_].
+endif::[]
+ifdef::DROOLS,JBPM,OP[]
+xref:executable-model-con_packaging-deploying[].
+endif::[]
+
 |===


### PR DESCRIPTION
See JIRA: https://issues.redhat.com/browse/BXMSDOC-5933

Rendered output
[Designing a decision service using DRL rules RHPAM](http://file.pnq.redhat.com/~hmanwani/BXMSDOC-5933-RHPAM/#rules-attributes-ref_drl-rules)
[Designing a decision service using DRL rules RHDM](http://file.pnq.redhat.com/~hmanwani/BXMSDOC-5933-RHDM/#rules-attributes-ref_drl-rules)