### PR TITLE
BXMSDOC-6024: Update doc content with new VSCode support

### DIFF
--- a/doc-content/kogito-docs/src/main/asciidoc/bpmn/proc-bpmn-model-creating.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/bpmn/proc-bpmn-model-creating.adoc
@@ -8,29 +8,14 @@ You can use the {PRODUCT} BPMN modeler in VSCode to design BPMN process models a
 For more information about BPMN2 support in {PRODUCT}, see xref:ref-bpmn-support_kogito-developing-process-services[].
 
 .Prerequisites
-* https://code.visualstudio.com/[VSCode] 1.44.0 or later is installed.
-* The {PRODUCT} https://github.com/kiegroup/kogito-tooling/releases[VSCode extension] is installed and enabled in your VSCode IDE. For information about enabling the VSCode extension, see
+* https://code.visualstudio.com/[VSCode] 1.46.0 or later is installed.
+* The *{PRODUCT} Bundle* VSCode extension is installed and enabled in your VSCode IDE. For information about enabling the VSCode extension, see
 ifdef::KOGITO[]
 {URL_CREATING_RUNNING}#proc-kogito-vscode-extension_kogito-creating-running[_{CREATING_RUNNING}_].
 endif::[]
 ifdef::KOGITO-COMM[]
 xref:proc-kogito-vscode-extension_kogito-creating-running[].
 endif::[]
-* You have launched VSCode from a command terminal with the following command and parameters. These parameters are required to enable {PRODUCT} modelers in VSCode for DMN, BPMN, and test scenario files.
-+
---
-.On Linux or Windows
-[source]
-----
-$ code --enable-proposed-api kiegroup.vscode-extension-pack-kogito-kie-editors
-----
-
-.On Mac
-[source]
-----
-$ code --args --enable-proposed-api kiegroup.vscode-extension-pack-kogito-kie-editors
-----
---
 * You have created a {PRODUCT} project and have included any Java objects required for your {PRODUCT} service. For information about creating a project, see
 ifdef::KOGITO[]
 {URL_CREATING_RUNNING}[_{CREATING_RUNNING}_].
@@ -42,7 +27,7 @@ endif::[]
 .Procedure
 . In your VSCode IDE, create or import a BPMN file in the relevant folder of your {PRODUCT} project, typically in `src/main/resources`.
 +
-NOTE: For a new BPMN file, you can also enter `bpmn.new` in a web browser to design your business process in the {PRODUCT} online BPMN modeler. When you finish creating your process, you can click *Download* in the online modeler page to import your BPMN file into your {PRODUCT} project.
+NOTE: For a new BPMN file, you can also enter `bpmn.new` in a web browser to design your business process in the {PRODUCT} online BPMN modeler. When you finish creating your process model, you can click *Download* in the online modeler page to import your BPMN file into your {PRODUCT} project.
 
 . Open the new or imported BPMN file to view the process diagram in the {PRODUCT} BPMN modeler.
 +

--- a/doc-content/kogito-docs/src/main/asciidoc/creating-running/con-kogito-modelers.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/creating-running/con-kogito-modelers.adoc
@@ -5,9 +5,9 @@
 
 For convenience, all {PRODUCT} BPMN and DMN modelers are available in the https://kiegroup.github.io/kogito-online/#/download[Business Modeler Hub] desktop application.
 
-* *{PRODUCT} VSCode extension*: (Recommended) Enables you to view and design BPMN and DMN models in Visual Studio Code. The VSCode extension in the {PRODUCT} Business Modeler Hub requires VSCode 1.44.0 or later.
+* *{PRODUCT} VSCode extension*: (Recommended) Enables you to view and design BPMN models, DMN models, and test scenario files in Visual Studio Code (VSCode). The VSCode extension in the {PRODUCT} Business Modeler Hub requires VSCode 1.46.0 or later.
 +
-To enable the {PRODUCT} VSCode extension without the {PRODUCT} Business Modeler Hub, you can download the `vscode_extension_kogito_kie_editors___VERSION__.vsix` file from the https://github.com/kiegroup/kogito-tooling/releases[`kogito-tooling`] releases page in GitHub and go to *Extensions* -> *More actions* -> *Install from VSIX* in VSCode to install the extension.
+To enable the {PRODUCT} VSCode extension without the {PRODUCT} Business Modeler Hub, go to *Extensions* in VSCode and search for and install the *{PRODUCT} Bundle* extension.
 * *{PRODUCT} GitHub Chrome extension*: Enables you to view and design BPMN and DMN models in GitHub repositories in Google Chrome.
 +
 To enable the {PRODUCT} GitHub Chrome extension without the {PRODUCT} Business Modeler Hub, you can download and extract the `chrome_extension_kogito_kie_editors___VERSION__.zip` file from the https://github.com/kiegroup/kogito-tooling/releases[`kogito-tooling`] releases page in GitHub, and then in the upper-right corner in Chrome, go to *Customize and control* -> *Settings* -> *Extensions* -> *Load unpacked* and open the extracted `dist` folder.

--- a/doc-content/kogito-docs/src/main/asciidoc/creating-running/con-kogito-modelers.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/creating-running/con-kogito-modelers.adoc
@@ -7,10 +7,10 @@ For convenience, all {PRODUCT} BPMN and DMN modelers are available in the https:
 
 * *{PRODUCT} VSCode extension*: (Recommended) Enables you to view and design BPMN models, DMN models, and test scenario files in Visual Studio Code (VSCode). The VSCode extension in the {PRODUCT} Business Modeler Hub requires VSCode 1.46.0 or later.
 +
-To enable the {PRODUCT} VSCode extension without the {PRODUCT} Business Modeler Hub, go to *Extensions* in VSCode and search for and install the *{PRODUCT} Bundle* extension.
+To install the {PRODUCT} VSCode extension directly in VSCode without the {PRODUCT} Business Modeler Hub, select the *Extensions* menu option in VSCode and search for and install the *{PRODUCT} Bundle* extension.
 * *{PRODUCT} GitHub Chrome extension*: Enables you to view and design BPMN and DMN models in GitHub repositories in Google Chrome.
 +
-To enable the {PRODUCT} GitHub Chrome extension without the {PRODUCT} Business Modeler Hub, you can download and extract the `chrome_extension_kogito_kie_editors___VERSION__.zip` file from the https://github.com/kiegroup/kogito-tooling/releases[`kogito-tooling`] releases page in GitHub, and then in the upper-right corner in Chrome, go to *Customize and control* -> *Settings* -> *Extensions* -> *Load unpacked* and open the extracted `dist` folder.
+To install the {PRODUCT} GitHub Chrome extension without the {PRODUCT} Business Modeler Hub, you can download and extract the `chrome_extension_kogito_kie_editors___VERSION__.zip` file from the https://github.com/kiegroup/kogito-tooling/releases[`kogito-tooling`] releases page in GitHub, and then in the upper-right corner in Chrome, go to *Customize and control* -> *Settings* -> *Extensions* -> *Load unpacked* and open the extracted `dist` folder.
 * *Business Modeler desktop application*: Enables you to view and design BPMN and DMN models locally.
 +
 To run the {PRODUCT} Business Modeler desktop application without the {PRODUCT} Business Modeler Hub, you can download and extract the `business_modeler_preview___RELEASE__.zip` file from the https://github.com/kiegroup/kogito-tooling/releases[`kogito-tooling`] releases page in GitHub, and then follow the instructions in the application `README` file to run the application on your specific operating system.

--- a/doc-content/kogito-docs/src/main/asciidoc/creating-running/proc-kogito-vscode-extension.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/creating-running/proc-kogito-vscode-extension.adoc
@@ -1,38 +1,22 @@
 [id='proc-kogito-vscode-extension_{context}']
-= Enabling the {PRODUCT} VSCode extension without the {PRODUCT} Business Modeler Hub
+= Installing the {PRODUCT} VSCode extension bundle without the {PRODUCT} Business Modeler Hub
 
-Visual Studio Code (VSCode) is the preferred integrated development environment (IDE) for developing {PRODUCT} services. {PRODUCT} provides a https://github.com/kiegroup/kogito-tooling/releases[VSCode extension] that enables you to design Business Process Model and Notation (BPMN) 2.0 business processes and Decision Model and Notation (DMN) decision models directly in VSCode.
+Although you can install and launch the {PRODUCT} Visual Studio Code (VSCode) extension from the https://kiegroup.github.io/kogito-online/#/download[Business Modeler Hub] desktop application, along with all other available {PRODUCT} modelers, you can also install {PRODUCT} VSCode extensions from Visual Studio Marketplace directly in VSCode.
 
-For convenience, you can install and launch the VSCode from the https://kiegroup.github.io/kogito-online/#/download[Business Modeler Hub] desktop application, along with all other available {PRODUCT} modelers.
-
-However, if you need to enable the VSCode extension without the {PRODUCT} Business Modeler Hub, follow this procedure to download and install the VSCode extension manually.
+VSCode is the preferred integrated development environment (IDE) for developing {PRODUCT} services. {PRODUCT} provides a *{PRODUCT} Bundle* VSCode extension that enables you to design Decision Model and Notation (DMN) decision models, Business Process Model and Notation (BPMN) 2.0 business processes, and test scenarios directly in VSCode. {PRODUCT} also provides individual *DMN Editor* and *BPMN Editor* VSCode extensions for DMN or BPMN support only, if needed.
 
 .Prerequisites
-* https://code.visualstudio.com/[VSCode] 1.44.0 or later is installed.
+* https://code.visualstudio.com/[VSCode] 1.46.0 or later is installed.
 
 .Procedure
-. In the https://github.com/kiegroup/kogito-tooling/releases[`kogito-tooling`] releases page in GitHub, download the latest version of the `vscode_extension_{PRODUCT_INIT}_kie_editors___VERSION__.vsix` file.
-. In your VSCode IDE, go to *Extensions* -> *More actions* -> *Install from VSIX* and select the downloaded extension file.
-. When the {PRODUCT} extension appears in the extension list in VSCode, select it and click *Enable*, if needed.
-. Close your instance of VSCode and re-launch VSCode from a command terminal with the following command and parameters:
+. In your VSCode IDE, go to *Extensions* and search for *{PRODUCT} Bundle* for DMN, BPMN, and test scenario file support.
 +
---
-.On Linux or Windows
-[source]
-----
-$ code --enable-proposed-api kiegroup.vscode-extension-pack-kogito-kie-editors
-----
-.On Mac
-[source]
-----
-$ code --args --enable-proposed-api kiegroup.vscode-extension-pack-kogito-kie-editors
-----
+For DMN or BPMN file support only, you can also search for the individual *DMN Editor* or *BPMN Editor* extensions.
+. When the {PRODUCT} extension appears in the extension list in VSCode, select it and click *Install*.
+. For optimal VSCode editor behavior, after the extension installation is complete, reload or close and re-launch your instance of VSCode.
 
-Use this method to open VSCode each time you develop {PRODUCT} services. This set of parameters enables the Microsoft https://code.visualstudio.com/api/advanced-topics/using-proposed-api[Proposed API] and is required to enable {PRODUCT} modelers in VSCode for DMN, BPMN, and test scenario files.
---
+After you install the VSCode extension bundle, any `.dmn` or `.bpmn2` files that you open in VSCode are automatically displayed as graphical models. Additionally, any `.scesim` files that you open are automatically displayed as tabular test scenario models for testing the functionality of your business decisions.
 
-After you enable this VSCode extension, any `.bpmn2` and `.dmn` files that you open in VSCode are automatically displayed as graphical models. Additionally, any `.scesim` files that you open are automatically displayed as tabular test scenario models for testing the functionality of your business decisions.
+If the {PRODUCT} DMN, BPMN, or test scenario modelers open only the XML source of a DMN, BPMN, or test scenario file and displays an error message, review the reported errors and the model file to ensure that all elements are correctly defined.
 
-If the {PRODUCT} BPMN or DMN modelers open only the XML source of a BPMN or DMN file and displays an error message, review the reported errors and the model file to ensure that all BPMN or DMN elements are correctly defined.
-
-NOTE: For new BPMN or DMN models, you can also enter `bpmn.new` or `dmn.new` in a web browser to design your BPMN or DMN model in the {PRODUCT} online modeler. When you finish creating your model, you can click *Download* in the online modeler page to import your BPMN or DMN file into your {PRODUCT} project in VSCode.
+NOTE: For new DMN or BPMN models, you can also enter `dmn.new` or `bpmn.new` in a web browser to design your DMN or BPMN model in the {PRODUCT} online modeler. When you finish creating your model, you can click *Download* in the online modeler page to import your DMN or BPMN file into your {PRODUCT} project in VSCode.

--- a/doc-content/kogito-docs/src/main/asciidoc/creating-running/proc-kogito-vscode-extension.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/creating-running/proc-kogito-vscode-extension.adoc
@@ -9,7 +9,7 @@ VSCode is the preferred integrated development environment (IDE) for developing 
 * https://code.visualstudio.com/[VSCode] 1.46.0 or later is installed.
 
 .Procedure
-. In your VSCode IDE, go to *Extensions* and search for *{PRODUCT} Bundle* for DMN, BPMN, and test scenario file support.
+. In your VSCode IDE, select the *Extensions* menu option and search for *{PRODUCT} Bundle* for DMN, BPMN, and test scenario file support.
 +
 For DMN or BPMN file support only, you can also search for the individual *DMN Editor* or *BPMN Editor* extensions.
 . When the {PRODUCT} extension appears in the extension list in VSCode, select it and click *Install*.

--- a/doc-content/kogito-docs/src/main/asciidoc/dmn/proc-dmn-model-creating.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/dmn/proc-dmn-model-creating.adoc
@@ -4,29 +4,14 @@
 You can use the {PRODUCT} DMN modeler in VSCode to design DMN decision requirements diagrams (DRDs) and define decision logic for a complete and functional DMN decision model. {PRODUCT} provides design and runtime support for DMN 1.2 models at conformance level 3, and includes enhancements and fixes to FEEL and DMN model components to optimize the experience of implementing DMN decision services with {PRODUCT}. {PRODUCT} also provides runtime-only support for DMN 1.1 and 1.3 models at conformance level 3, but any DMN 1.1 models that you import into your {PRODUCT} project, open in the DMN modeler, and save are converted to DMN 1.2 models. DMN 1.3 models are not supported in the {PRODUCT} DMN modeler.
 
 .Prerequisites
-* https://code.visualstudio.com/[VSCode] 1.44.0 or later is installed.
-* The {PRODUCT} https://github.com/kiegroup/kogito-tooling/releases[VSCode extension] is installed and enabled in your VSCode IDE. For information about enabling the VSCode extension, see
+* https://code.visualstudio.com/[VSCode] 1.46.0 or later is installed.
+* The *{PRODUCT} Bundle* VSCode extension is installed and enabled in your VSCode IDE. For information about enabling the VSCode extension, see
 ifdef::KOGITO[]
 {URL_CREATING_RUNNING}#proc-kogito-vscode-extension_kogito-creating-running[_{CREATING_RUNNING}_].
 endif::[]
 ifdef::KOGITO-COMM[]
 xref:proc-kogito-vscode-extension_kogito-creating-running[].
 endif::[]
-* You have launched VSCode from a command terminal with the following command and parameters. These parameters are required to enable {PRODUCT} modelers in VSCode for DMN, BPMN, and test scenario files.
-+
---
-.On Linux or Windows
-[source]
-----
-$ code --enable-proposed-api kiegroup.vscode-extension-pack-kogito-kie-editors
-----
-
-.On Mac
-[source]
-----
-$ code --args --enable-proposed-api kiegroup.vscode-extension-pack-kogito-kie-editors
-----
---
 * You have created a {PRODUCT} project and have included any Java objects required for your {PRODUCT} service. For information about creating a project, see
 ifdef::KOGITO[]
 {URL_CREATING_RUNNING}[_{CREATING_RUNNING}_].
@@ -37,6 +22,9 @@ endif::[]
 
 .Procedure
 . In your VSCode IDE, create or import a DMN file in the relevant folder of your {PRODUCT} project, typically in `src/main/resources`.
++
+NOTE: For a new DMN file, you can also enter `dmn.new` in a web browser to design your decision model in the {PRODUCT} online DMN modeler. When you finish creating your decision model, you can click *Download* in the online modeler page to import your DMN file into your {PRODUCT} project.
+
 . Open the new or imported DMN file to view the decision requirements diagram (DRD) in the {PRODUCT} DMN modeler.
 +
 --

--- a/doc-content/kogito-docs/src/main/asciidoc/openshift/con-kogito-travel-agency.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/openshift/con-kogito-travel-agency.adoc
@@ -31,23 +31,8 @@ The services expose REST API endpoints that are generated from the BPMN business
 * Use binary builds to deploy {PRODUCT} services on OpenShift.
 
 .Prerequisites
-* https://code.visualstudio.com/[VSCode] 1.44.0 or later is installed.
-* The {PRODUCT} https://github.com/kiegroup/kogito-tooling/releases[VSCode extension] is installed and enabled in your VSCode IDE.
-* You have launched VSCode from a command terminal with the following command and parameters. These parameters are required to enable {PRODUCT} modelers in VSCode for DMN, BPMN, and test scenario files.
-+
---
-.On Linux or Windows
-[source]
-----
-$ code --enable-proposed-api kiegroup.vscode-extension-pack-kogito-kie-editors
-----
-
-.On Mac
-[source]
-----
-$ code --args --enable-proposed-api kiegroup.vscode-extension-pack-kogito-kie-editors
-----
---
+* https://code.visualstudio.com/[VSCode] 1.46.0 or later is installed.
+* The *{PRODUCT} Bundle* VSCode extension is installed and enabled in your VSCode IDE.
 * {OPENSHIFT} 4.3 or later is installed.
 * The `oc` OpenShift CLI is installed. For `oc` installation instructions, see the
 ifdef::KOGITO[]

--- a/doc-content/kogito-docs/src/main/asciidoc/release-notes/0.11.0/ref-kogito-rn-new-features.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/release-notes/0.11.0/ref-kogito-rn-new-features.adoc
@@ -46,7 +46,7 @@ Beginning in VSCode 1.46.0, the {PRODUCT} VSCode extension is now available in V
 
 To install the {PRODUCT} VSCode extension directly in VSCode, go to *Extensions* and search for and install the *{PRODUCT} Bundle* extension.
 
-For more information about {PRODUCT} extensions and applications, see
+For more information about {PRODUCT} modeler extensions and applications, see
 ifdef::KOGITO[]
 {URL_CREATING_RUNNING}#con-kogito-modelers_kogito-creating-running[_{CREATING_RUNNING}_].
 endif::[]

--- a/doc-content/kogito-docs/src/main/asciidoc/release-notes/0.11.0/ref-kogito-rn-new-features.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/release-notes/0.11.0/ref-kogito-rn-new-features.adoc
@@ -44,7 +44,7 @@ Description
 
 Beginning in VSCode 1.46.0, the {PRODUCT} VSCode extension is now available in Visual Studio Marketplace. {PRODUCT} provides a *{PRODUCT} Bundle* VSCode extension that enables you to design Decision Model and Notation (DMN) decision models, Business Process Model and Notation (BPMN) 2.0 business processes, and test scenarios directly in VSCode. {PRODUCT} also provides individual *DMN Editor* and *BPMN Editor* VSCode extensions for DMN or BPMN support only, if needed.
 
-To install the {PRODUCT} VSCode extension directly in VSCode, go to *Extensions* and search for and install the *{PRODUCT} Bundle* extension.
+To install the {PRODUCT} VSCode extension directly in VSCode, select the *Extensions* menu option in VSCode and search for and install the *{PRODUCT} Bundle* extension.
 
 For more information about {PRODUCT} modeler extensions and applications, see
 ifdef::KOGITO[]

--- a/doc-content/kogito-docs/src/main/asciidoc/release-notes/0.11.0/ref-kogito-rn-new-features.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/release-notes/0.11.0/ref-kogito-rn-new-features.adoc
@@ -40,6 +40,20 @@ Description
 
 == {PRODUCT} tooling
 
+=== {PRODUCT} VSCode extension now available in Visual Studio Marketplace
+
+Beginning in VSCode 1.46.0, the {PRODUCT} VSCode extension is now available in Visual Studio Marketplace. {PRODUCT} provides a *{PRODUCT} Bundle* VSCode extension that enables you to design Decision Model and Notation (DMN) decision models, Business Process Model and Notation (BPMN) 2.0 business processes, and test scenarios directly in VSCode. {PRODUCT} also provides individual *DMN Editor* and *BPMN Editor* VSCode extensions for DMN or BPMN support only, if needed.
+
+To install the {PRODUCT} VSCode extension directly in VSCode, go to *Extensions* and search for and install the *{PRODUCT} Bundle* extension.
+
+For more information about {PRODUCT} extensions and applications, see
+ifdef::KOGITO[]
+{URL_CREATING_RUNNING}#con-kogito-modelers_kogito-creating-running[_{CREATING_RUNNING}_].
+endif::[]
+ifdef::KOGITO-COMM[]
+xref:con-kogito-modelers_kogito-creating-running[].
+endif::[]
+
 === Test scenarios now supported by the {PRODUCT} VSCode extension
 
 The {PRODUCT} https://github.com/kiegroup/kogito-tooling/releases[VSCode extension] now supports `.scesim` (scenario simulation) files that you can use to define test scenarios in the test scenario modeler in Visual Studio Code (VSCode).
@@ -66,7 +80,6 @@ The {PRODUCT} VSCode extension has been updated to incorporate enhancements and 
 For more details about these {PRODUCT} VSCode extension enhancements, see https://issues.redhat.com/browse/KOGITO-1863[KOGITO-1863] in Atlassian Jira.
 
 For more information about other VSCode API enhancements, see the https://code.visualstudio.com/updates/v1_45[April 2020 (version 1.45.0)] VSCode release notes.
-
 
 === Improvements to the {PRODUCT} BPMN modeler
 

--- a/doc-content/kogito-docs/src/main/asciidoc/test-scenarios/proc-test-scenarios-creating.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/test-scenarios/proc-test-scenarios-creating.adoc
@@ -14,29 +14,14 @@ A basic test scenario must have at least the following data:
 With this data, the test scenario can validate the expected and actual results for a decision instance based on the defined parameters.
 
 .Prerequisites
-* https://code.visualstudio.com/[VSCode] 1.44.0 or later is installed.
-* The {PRODUCT} https://github.com/kiegroup/kogito-tooling/releases[VSCode extension] 0.4.2 or later is installed and enabled in your VSCode IDE. For information about enabling the VSCode extension, see
+* https://code.visualstudio.com/[VSCode] 1.46.0 or later is installed.
+* The *{PRODUCT} Bundle* VSCode extension is installed and enabled in your VSCode IDE. For information about enabling the VSCode extension, see
 ifdef::KOGITO[]
 {URL_CREATING_RUNNING}#proc-kogito-vscode-extension_kogito-creating-running[_{CREATING_RUNNING}_].
 endif::[]
 ifdef::KOGITO-COMM[]
 xref:proc-kogito-vscode-extension_kogito-creating-running[].
 endif::[]
-* You have launched VSCode from a command terminal with the following command and parameters. These parameters are required to enable {PRODUCT} modelers in VSCode for DMN, BPMN, and test scenario files.
-+
---
-.On Linux or Windows
-[source]
-----
-$ code --enable-proposed-api kiegroup.vscode-extension-pack-kogito-kie-editors
-----
-
-.On Mac
-[source]
-----
-$ code --args --enable-proposed-api kiegroup.vscode-extension-pack-kogito-kie-editors
-----
---
 * You have created one or more DMN decision services in your {PRODUCT} project that you want to validate with test scenarios. For information about using DMN models in {PRODUCT} services, see xref:proc-dmn-model-creating_dmn-models[].
 
 .Procedure


### PR DESCRIPTION
@ederign , can you please review and verify both the doc update and the release note update for the VSCode release in Marketplace? I also made a few other changes summarized below.

**Important:** @paulovmr When I follow the standard instructions to [install and use the Business Modeler Hub](http://file.rdu.redhat.com/~sterobin/BXMSDOC-6024_CR/#proc-kogito-modelers_kogito-creating-running), I get the following error, similar to what you and I saw before. Is this a bug in the code, the docs, or with me :) ?

**Summary of changes:**
* Updated section on installing VSCode extension bundle directly in VSCode
* Updated all instances of "1.44.0 or later" to recommend 1.46.0 or later instead, to ensure users have access to the VSCode extension via Marketplace, and to have access to latest updates made.
* Removed requirement to run `code --enable-proposed-api  ...` throughout docs, since no longer required beginning 1.46.0. 

Links:
* [JIRA](https://issues.redhat.com/browse/BXMSDOC-6024)
* [Enterprise doc preview](http://file.rdu.redhat.com/~sterobin/BXMSDOC-6024_CR/#proc-kogito-vscode-extension_kogito-creating-running)
* [Community doc preview](http://file.rdu.redhat.com/~sterobin/BXMSDOC-6024_COMM/#proc-kogito-vscode-extension_kogito-creating-running) - Same, but for community
* [Release note](http://file.rdu.redhat.com/~sterobin/BXMSDOC-6024_COMM/#_kogito_tooling)
