### PR TITLE
Upstream master PR for BXMSDOC-5871: Added Lambda externalization section in performance tuning chapter for decision engine doc

### DIFF
--- a/doc-content/drools-docs/src/main/asciidoc/DecisionEngine/performance-tuning-decision-engine-ref.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/DecisionEngine/performance-tuning-decision-engine-ref.adoc
@@ -36,3 +36,15 @@ try {
 
 For information about built-in event listeners and debug logging in the {DECISION_ENGINE}, see xref:engine-event-listeners-con_decision-engine[].
 --
+
+Use lambda externalization for executable model::
+Enable lambda externalization to optimize the memory consumption during runtime. It rewrites lambdas that are generated and used in the executable model. This enables you to reuse the same lambda multiple times with all the patterns and the same constraint. When the rete or phreak is instantiated, the executable model becomes garbage collectible. 
++
+--
+To enable lambda externalization for the executable model, include the following property:
+
+[source]
+----
+-Ddrools.externaliseCanonicalModelLambda=true
+----
+--


### PR DESCRIPTION
See JIRA: https://issues.redhat.com/browse/BXMSDOC-5871
Epic: https://issues.redhat.com/browse/BXMSDOC-5626

Rendered output: 
[Decision engine in Red Hat Process Automation Manager 7.8](http://file.pnq.redhat.com/~hmanwani/BXMSDOC-5871-RHPAM-7.8/#performance-tuning-decision-engine-ref_decision-engine)
[Decision engine in Red Hat Decision Manager 7.8](http://file.pnq.redhat.com/~hmanwani/BXMSDOC-5871-RHDM-7.8/#performance-tuning-decision-engine-ref_decision-engine)