### PR TITLE
Upstream master PR for BXMSDOC-5957: Made changes for terminate end event description in process designer doc

### DIFF
--- a/doc-content/enterprise-only/bpmn/bpmn-end-events-ref.adoc
+++ b/doc-content/enterprise-only/bpmn/bpmn-end-events-ref.adoc
@@ -74,4 +74,4 @@ The escalation end event finishes the incoming workflow, which means consumes th
 [[_terminate_end_event]]
 .Terminate
 
-The terminate end event finishes all execution flows in the specified process instance. Activities being executed are canceled. If a terminate end event is reached in a subprocess, the entire process instance is terminated.
+The terminate end event finishes all execution flows in the specified process instance. Activities being executed are canceled. The subprocess instance terminates if it reaches a terminate end event.

--- a/doc-content/jbpm-docs/src/main/asciidoc/BPMN2/appe-process-elements.adoc
+++ b/doc-content/jbpm-docs/src/main/asciidoc/BPMN2/appe-process-elements.adoc
@@ -1078,7 +1078,7 @@ The Escalation End Event finishes the incoming workflow, that means consumes the
 [[_terminate_end_event]]
 ===== Terminate End Event
 
-The Terminate End Event finishes all execution flows in the specified process instance. Activities being executed are canceled. If a Terminate End Event is reached in a sub-process, the entire process instance is terminated.
+The Terminate End Event finishes all execution flows in the specified process instance. Activities being executed are canceled. The subprocess instance terminates if it reaches a terminate end event.
 
 [[_error_end_event]]
 ===== Throwing Error End Event


### PR DESCRIPTION
Changed the description for Terminate end event

See JIRA: https://issues.redhat.com/browse/BXMSDOC-5957

Rendered output:
[Designing business processes in Business Central](http://file.pnq.redhat.com/~hmanwani/BXMSDOC-5957-RHPAM/#terminate_end_event)
[Process designer Business Process Model and Notation (BPMN2) reference guide](http://file.pnq.redhat.com/~hmanwani/BXMSDOC-5957-bpmn-RHPAM/#terminate_end_event)

