### PR TITLE
Upstream 7.39.x PR for BXMSDOC-5459: Added clarification regarding users and roles

### DIFF
--- a/doc-content/enterprise-only/installation/roles-users-con.adoc
+++ b/doc-content/enterprise-only/installation/roles-users-con.adoc
@@ -1,7 +1,13 @@
 [id='roles-users-con']
 = {PRODUCT} roles and users
 
-To access {CENTRAL} or {KIE_SERVER}, you must create users and assign them appropriate roles before the servers are started. This section describes available {PRODUCT} user roles.
+To access {CENTRAL} or {KIE_SERVER}, you must create users and assign them appropriate roles before the servers are started.
+
+The {CENTRAL} and {KIE_SERVER} use Java Authentication and Authorization Service (JAAS) login module to authenticate the users. If both {CENTRAL} and {KIE_SERVER} are running on a single instance, then they share the same JAAS subject and security domain. Therefore, a user, who is authenticated for {CENTRAL} can also access {KIE_SERVER}.
+
+However, if {CENTRAL} and {KIE_SERVER} are running on different instances, then the JAAS login module is triggered for both individually. Therefore, a user, who is authenticated for {CENTRAL}, needs to be authenticated separately to access the {KIE_SERVER} (for example, to view or manage process definitions in {CENTRAL}). In case, the user is not authenticated on the {KIE_SERVER}, then 401 error is logged in the log file, displaying `Invalid credentials to load data from remote server. Contact your system administrator.` message in {CENTRAL}.
+
+This section describes available {PRODUCT} user roles.
 
 [NOTE]
 ====


### PR DESCRIPTION
Added clarification in **CHAPTER 2. RED HAT DECISION MANAGER ROLES AND USERS**

See JIRA: https://issues.redhat.com/browse/BXMSDOC-5459

Doc previews:
[Installing and configuring Red Hat Process Automation Manager on Red Hat JBoss EAP](http://file.pnq.redhat.com/~hmanwani/BXMSDOC-5459-EAP-RHPAM/#roles-users-con)
[Installing and configuring Red Hat Decision Manager on Red Hat JBoss EAP](http://file.pnq.redhat.com/~hmanwani/BXMSDOC-5459-EAP-RHDM/#roles-users-con)