### PR TITLE
Upstream PR for BXMSDOC-5862-7.39.x to 7.39.x Integrating PAM/DM 7.8 with Fuse

### DIFF
--- a/doc-content/enterprise-only/fuse/installing-ba-fuse-karaf-maven-proc.adoc
+++ b/doc-content/enterprise-only/fuse/installing-ba-fuse-karaf-maven-proc.adoc
@@ -3,7 +3,7 @@
 Install {PRODUCT} with {FUSE} on Apache Karaf to deploy integrated services where required.
 
 .Prerequisites
-* A {FUSE_LONG} 7.3 or 7.4 on Apache Karaf installation exists. For installation instructions, see  https://access.redhat.com/documentation/en-us/red_hat_fuse/7.2/html-single/installing_on_apache_karaf/[_Installing Red Hat Fuse on the Apache Karaf container_] .
+* A {FUSE_LONG} 7.6 on Apache Karaf installation exists. For installation instructions, see  https://access.redhat.com/documentation/en-us/red_hat_fuse/7.2/html-single/installing_on_apache_karaf/[_Installing Red Hat Fuse on the Apache Karaf container_] .
 * Any obsolete features XML files have been removed, as described in <<ba-karaf-xml-uninstall-proc>>.
 
 .Procedure

--- a/doc-content/enterprise-only/fuse/installing-on-fuse-eap-proc.adoc
+++ b/doc-content/enterprise-only/fuse/installing-on-fuse-eap-proc.adoc
@@ -1,12 +1,19 @@
 [id='installing-on-fuse-eap-proc']
-= Installing {FUSE} in {EAP} with {PRODUCT}
-Install {FUSE} in {EAP} with {PRODUCT} to deploy integrated services where required.
+= Installing {FUSE} on {EAP_LONG}
+Install {FUSE_LONG} 7.6 on {EAP} 7.2.3 to use with {PRODUCT} to deploy integrated services where required.
+
+[NOTE]
+====
+{FUSE_LONG} 7.6 is supported on {EAP} 7.2.3, whereas {PRODUCT} is supported on {EAP} {EAP_VERSION}. To ensure a stable deployment environment, install {FUSE} and {PRODUCT} on different instances of {EAP} according to the supported {EAP} versions.
+====
 
 .Prerequisites
-* A {PRODUCT} installation on {EAP_LONG} 7.2 is available. For installation instructions, see {URL_INSTALLING_ON_EAP}[_{INSTALLING_ON_EAP}_].
+* A {PRODUCT} installation on {EAP_LONG} {EAP_VERSION} is available. For installation instructions, see {URL_INSTALLING_ON_EAP}[_{INSTALLING_ON_EAP}_].
+* A separate instance of {EAP_LONG} 7.2.3 is available.
 
 .Procedure
-. Install {FUSE_LONG} in the {EAP_LONG} 7.2 container where you installed {PRODUCT}. For installation instructions, see the https://access.redhat.com/documentation/en-us/red_hat_fuse/7.3/html-single/installing_on_jboss_eap/index[_Install Fuse 7.3 on JBoss EAP 7.2_].
+. Install {FUSE_LONG} 7.6 on {EAP_LONG} 7.2.3. For installation instructions, see the https://access.redhat.com/documentation/en-us/red_hat_fuse/7.6/html-single/installing_on_jboss_eap/index[_Install Fuse 7.6 on JBoss EAP 7.2_].
+
 . Open the `pom.xml` file in the {FUSE} home directory in a text editor.
 . Create the integration project with a dependency on the `kie-camel` component by editing the `pom.xml` file as shown in the following example:
 +


### PR DESCRIPTION
Original jira: https://issues.redhat.com/browse/BXMSDOC-5862
Rendered output: http://file.rdu.redhat.com/~mhaglund/BXMSDOC-5862/#installing-on-fuse-eap-proc