### PR TITLE
Upstream master PR for BXMSDOC-6143: Replaced kie-execution-server with kie-server

### DIFF
--- a/doc-content/enterprise-only/integration/sso-basic-auth-proc.adoc
+++ b/doc-content/enterprise-only/integration/sso-basic-auth-proc.adoc
@@ -10,11 +10,11 @@ If you enabled basic authentication in the RH-SSO client adapter configuration f
 curl http://admin:password@localhost:8080/{URL_COMPONENT_CENTRAL}/rest/repositories
 ----
 
-* For {KIE_SERVER}: 
+* For {KIE_SERVER}:
 +
 [source]
 ----
-curl http://admin:password@localhost:8080/kie-execution-server/services/rest/server/
+curl http://admin:password@localhost:8080/kie-server/services/rest/server/
 ----
 
 [id='_token_based_authentication']

--- a/doc-content/enterprise-only/integration/sso-kie-server-client-adapter-proc.adoc
+++ b/doc-content/enterprise-only/integration/sso-kie-server-client-adapter-proc.adoc
@@ -31,7 +31,7 @@ If you deployed {KIE_SERVER} to a different application server than {CENTRAL}, i
 [source,xml,subs="attributes+"]
 ----
 <subsystem xmlns="urn:jboss:domain:keycloak:1.1">
-  <secure-deployment name="kie-execution-server.war">
+  <secure-deployment name="kie-server.war">
      <realm>demo</realm>
      <realm-public-key>MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCrVrCuTtArbgaZzL1hvh0xtL5mc7o0NqPVnYXkLvgcwiC3BjLGw1tGEGoJaXDuSaRllobm53JBhjx33UNv+5z/UMG4kytBWxheNVKnL6GgqlNabMaFfPLPCF8kAgKnsi79NMo+n6KnSY8YeUmec/p2vjO2NjsSAVcWEQMVhJ31LwIDAQAB</realm-public-key>
      <auth-server-url>http://localhost:8180/auth</auth-server-url>
@@ -73,12 +73,12 @@ For example:
 +
 [source,subs="attributes+"]
 ----
-EXEC_SERVER_HOME/bin/standalone.sh -c standalone-full.xml -Dorg.kie.server.id=kieserver1 -Dorg.kie.server.user=kieserver -Dorg.kie.server.pwd=password -Dorg.kie.server.location=http://localhost:8080/kie-execution-server/services/rest/server -Dorg.kie.server.controller=http://localhost:8080/{URL_COMPONENT_CENTRAL}/rest/controller -Dorg.kie.server.controller.user=kiecontroller -Dorg.kie.server.controller.pwd=password
+EXEC_SERVER_HOME/bin/standalone.sh -c standalone-full.xml -Dorg.kie.server.id=kieserver1 -Dorg.kie.server.user=kieserver -Dorg.kie.server.pwd=password -Dorg.kie.server.location=http://localhost:8080/kie-server/services/rest/server -Dorg.kie.server.controller=http://localhost:8080/{URL_COMPONENT_CENTRAL}/rest/controller -Dorg.kie.server.controller.user=kiecontroller -Dorg.kie.server.controller.pwd=password
 ----
 +
 . When {KIE_SERVER} is running, enter the following command to check the server status, where `<KIE_SERVER_USER>` is a user with the `kie-server` role and `<PASSWORD>` is the password for that user:
 +
 [source,subs="attributes+"]
 ----
-curl http://<KIE_SERVER_USER>:<PASSWORD>@localhost:8080/kie-execution-server/services/rest/server/
+curl http://<KIE_SERVER_USER>:<PASSWORD>@localhost:8080/kie-server/services/rest/server/
 ----


### PR DESCRIPTION
See JIRA: https://issues.redhat.com/browse/BXMSDOC-6143
https://issues.redhat.com/browse/BXMSDOC-6144

Doc previews:
[Integrating Red Hat Process Automation Manager with Red Hat Single Sign-On](http://file.pnq.redhat.com/~hmanwani/BXMSDOC-6143-RHPAM/#sso-kie-server-client-adapter-proc)
[Integrating Red Decision Manager with Red Hat Single Sign-On](http://file.pnq.redhat.com/~hmanwani/BXMSDOC-6143-RHDM/#sso-kie-server-client-adapter-proc)