### PR TITLE
Upstream 7.39.x PR for BXMSDOC-6142: Deleted the step of removing single sign-on element

### DIFF
--- a/doc-content/enterprise-only/integration/sso-client-adapter-proc.adoc
+++ b/doc-content/enterprise-only/integration/sso-client-adapter-proc.adoc
@@ -18,8 +18,6 @@ After you install RH-SSO, you must install the RH-SSO client adapter for {EAP} a
 +
 NOTE: Install the adapter with the `-Dserver.config=standalone-full.xml` property.
 
-. Go to `_EAP_HOME_/standalone/configuration` and open the `standalone-full.xml` file.
-. Delete the `<single-sign-on/>` element from both of the files.
 . Navigate to the `_EAP_HOME_/standalone/configuration` directory in your {EAP} installation and open the `standalone-full.xml` file in a text editor.
 . Add the system properties listed in the following example to `<system-properties>`:
 +


### PR DESCRIPTION
See JIRA: https://issues.redhat.com/browse/BXMSDOC-6142

Doc Previews:
[Integrating Red Hat Process Automation Manager with Red Hat Single Sign-On](http://file.pnq.redhat.com/~hmanwani/BXMSDOC-6142-RHPAM/#sso-client-adapter-proc)
[Integrating Red Hat Decision Manager with Red Hat Single Sign-On](http://file.pnq.redhat.com/~hmanwani/BXMSDOC-6142-RHDm/#sso-client-adapter-proc)