### PR TITLE
BXMSPROD-921 build chain event to workflow_dispatch and new pull request added

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,6 +1,6 @@
 name: Build Chain
 
-on: [pull_request]
+on: [ workflow_dispatch ]
 
 jobs:
   build-chain-openjdk8:

--- a/.github/workflows/pull_request_no_chain.yml
+++ b/.github/workflows/pull_request_no_chain.yml
@@ -1,6 +1,3 @@
-# This workflow will build a Java project with Maven
-# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
-
 name: Pull Request
 
 on: [ pull_request ]

--- a/.github/workflows/pull_request_no_chain.yml
+++ b/.github/workflows/pull_request_no_chain.yml
@@ -1,0 +1,23 @@
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Pull Request
+
+on: [ pull_request ]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        java: [8, 11]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK
+      uses: actions/setup-java@v1
+      with:
+        java-version: ${{ matrix.java }}      
+    - name: Build with Maven
+      run: mvn -B clean install --file pom.xml


### PR DESCRIPTION
https://issues.redhat.com/browse/BXMSPROD-921
`pull_request.yml` event moved to `workflow_dispatch` to not trigger the flow by a PR and a new PR flow created just to build `kie-docs` (java 8 and 11, ubuntu and windows)
the pull_request.yml is still needed by the chain https://github.com/kiegroup/optaweb-employee-rostering/blob/22da730f5928fa33da3e4dcc6f0572012c07aa31/.github/workflows/pull_request.yml#L15  `build-command-upstream`