### PR TITLE
Upstream 7.30.x PR for BXMSDOC-6171, 6123, 6191: Incorporate DDF changes in managing and monitoring KIE server doc.

### DIFF
--- a/_artifacts/document-attributes.adoc
+++ b/_artifacts/document-attributes.adoc
@@ -1,5 +1,5 @@
 
-:REBUILT: Tuesday, July 21, 2020
+:REBUILT: Wednesday, August 12, 2020
 
 :ENTERPRISE_VERSION: 7.6
 :COMMUNITY_VERSION: 7.30

--- a/doc-content/shared-kie-docs/src/main/asciidoc/KieServer/prometheus-monitoring-proc.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/KieServer/prometheus-monitoring-proc.adoc
@@ -17,25 +17,9 @@ endif::[]
 
 .Procedure
 . In your {KIE_SERVER} instance, set the `org.kie.prometheus.server.ext.disabled` system property to `false` to enable the Prometheus extension. You can define this property when you start {KIE_SERVER} or in the `standalone.xml` or `standalone-full.xml` file of {PRODUCT} distribution.
-. If you are running {PRODUCT} on Spring Boot, add the following dependencies in the `pom.xml` file of your Maven project and configure the required key in the `application.properties` system property:
+. If you are running {PRODUCT} on Spring Boot, configure the required key in the `application.properties` system property:
 +
 --
-.Spring Boot pom.xml dependencies for Prometheus
-[source,xml,subs="attributes+"]
-----
-<dependency>
-  <groupId>org.kie.server</groupId>
-  <artifactId>kie-server-services-prometheus</artifactId>
-  <version>${{PRODUCT_INIT}.version}</version>
-</dependency>
-
-<dependency>
-  <groupId>org.kie.server</groupId>
-  <artifactId>kie-server-rest-prometheus</artifactId>
-  <version>${{PRODUCT_INIT}.version}</version>
-</dependency>
-----
-
 .Spring Boot application.properties key for {PRODUCT} and Prometheus
 [source,xml]
 ----
@@ -56,7 +40,7 @@ kieserver.prometheus.enabled=true
 scrape_configs:
   - job_name: 'kie-server'
     metrics_path: /SERVER_PATH/services/rest/metrics
-    basic_auth:
+    basicAuth:
       username: USER_NAME
       password: PASSWORD
     static_configs:
@@ -109,9 +93,16 @@ For curl utility:
 * `-X`: Set to `GET`.
 * *URL*: Enter the {KIE_SERVER} REST API base URL and metrics endpoint, such as `\http://localhost:8080/kie-server/services/rest/metrics` (or on Spring Boot, `\http://localhost:8080/rest/metrics`).
 
+.Example curl command for {PRODUCT} on {EAP}
 [source]
 ----
-curl -u 'baAdmin:password@1' -H "accept: application/json" -X GET "http://localhost:8080/kie-server/services/rest/metrics"
+curl -u 'baAdmin:password@1' -X GET "http://localhost:8080/kie-server/services/rest/metrics"
+----
+
+.Example curl command for {PRODUCT} on Spring Boot
+[source]
+----
+curl -u 'baAdmin:password@1' -X GET "http://localhost:8080/rest/metrics"
 ----
 
 .Example server response


### PR DESCRIPTION
**JIRAs:**
- [BXMSDOC-6171](https://issues.redhat.com/browse/BXMSDOC-6171)
- [BXMSDOC-6123](https://issues.redhat.com/browse/BXMSDOC-6123)
- [BXMSDOC-6191](https://issues.redhat.com/browse/BXMSDOC-6191)

**Doc previews:**
- [7.6-RHPAM-Managing and monitoring KIE Server](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-RHPAM-MMKS-7.6-DDF/#prometheus-monitoring-proc_execution-server)
- [7.6-RHDM-Managing and monitoring KIE Server](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-RHDM-MMKS-7.6-DDF/#prometheus-monitoring-proc_execution-server)

**Doc impact:** 
- Please see **Chapter 17** in RHPAM and **Chapter 13** in RHDM docs for the changes.
- I have removed all the mentions of additional dependencies in the Spring Boot pom.xml.
- In section 17.1 --> Step no. 3 ---> Corrected syntax in prometheus.yaml file from **basic_auth** to **basicAuth**. 
- In section 17.1 --> Step no. 5 ---> Added example of curl command for spring boot and removed header part from URL