### PR TITLE
Correct default document storage path

### DIFF
--- a/doc-content/jbpm-docs/src/main/asciidoc/BPMN2/cust-marshalling-cms-proc.adoc
+++ b/doc-content/jbpm-docs/src/main/asciidoc/BPMN2/cust-marshalling-cms-proc.adoc
@@ -2,7 +2,7 @@
 
 = Using a custom document marshalling strategy for a content management system (CMS)
 
-The document marshalling strategy for your project determines where documents are stored for use with forms and processes. The default document marshalling strategy in {PRODUCT} is `org.jbpm.document.marshalling.DocumentMarshallingStrategy`. This strategy uses a `DocumentStorageServiceImpl` class that stores documents locally in your `_PROJECT_HOME_/docs` folder. If you want to store form and process documents in a custom location, such as in a centralized content management system (CMS), add a custom document marshalling strategy to your project. You can set this document marshalling strategy in {CENTRAL} or in the `kie-deployment-descriptor.xml` file directly.
+The document marshalling strategy for your project determines where documents are stored for use with forms and processes. The default document marshalling strategy in {PRODUCT} is `org.jbpm.document.marshalling.DocumentMarshallingStrategy`. This strategy uses a `DocumentStorageServiceImpl` class that stores documents locally in your `_PROJECT_HOME_/.docs` folder. If you want to store form and process documents in a custom location, such as in a centralized content management system (CMS), add a custom document marshalling strategy to your project. You can set this document marshalling strategy in {CENTRAL} or in the `kie-deployment-descriptor.xml` file directly.
 
 .Procedure
 . Create a custom marshalling strategy `.java` file that includes an implementation of the `org.kie.api.marshalling.ObjectMarshallingStrategy` interface. This interface enables you to implement the variable persistence required for your custom document marshalling strategy.

--- a/doc-content/jbpm-docs/src/main/asciidoc/BPMN2/set-marshalling-proc.adoc
+++ b/doc-content/jbpm-docs/src/main/asciidoc/BPMN2/set-marshalling-proc.adoc
@@ -2,7 +2,7 @@
 
 = Setting the document marshalling strategy
 
-The document marshalling strategy for your project determines where documents are stored for use with forms and processes. The default document marshalling strategy in {PRODUCT} is `org.jbpm.document.marshalling.DocumentMarshallingStrategy`. This strategy uses a `DocumentStorageServiceImpl` class that stores documents locally in your `_PROJECT_HOME_/docs` folder. You can set this document marshalling strategy or a custom document marshalling strategy for your project in {CENTRAL} or in the `kie-deployment-descriptor.xml` file.
+The document marshalling strategy for your project determines where documents are stored for use with forms and processes. The default document marshalling strategy in {PRODUCT} is `org.jbpm.document.marshalling.DocumentMarshallingStrategy`. This strategy uses a `DocumentStorageServiceImpl` class that stores documents locally in your `_PROJECT_HOME_/.docs` folder. You can set this document marshalling strategy or a custom document marshalling strategy for your project in {CENTRAL} or in the `kie-deployment-descriptor.xml` file.
 
 .Procedure
 . In {CENTRAL}, go to *Menu* -> *Design* -> *Projects*.


### PR DESCRIPTION
Found a little typo while going over the documentation of document marshalling. As per source code [DocumentStorageServiceImpl.java#L50-L51](
https://github.com/kiegroup/jbpm/blob/e52da0cfbcf17f36674d73bc7db20377c7e1984e/jbpm-document/src/main/java/org/jbpm/document/service/impl/DocumentStorageServiceImpl.java#L50-L51)

I have corrected the path from _PROJECT_HOME_/docs to _PROJECT_HOME_/.docs