### PR TITLE
[KOGITO-3148] - Kogito Operator does not install third party operator…

### DIFF
--- a/doc-content/kogito-docs/src/main/asciidoc/openshift/con-kogito-operator-architecture.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/openshift/con-kogito-operator-architecture.adoc
@@ -47,7 +47,7 @@ spec:
 
 In this example, the {PRODUCT} Operator uses the Infinispan Operator to deploy the Infinispan Server instance for persistence and uses the Strimzi Operator to deploy the Kafka cluster for event messaging.
 
-If the required third-party operators are not available to the {PRODUCT} Operator during {PRODUCT} service runtime, then the {PRODUCT} Operator cannot generate the infrastructure components and a user must install the infrastructure components.
+If the required third-party operators are not available to the {PRODUCT} Operator during {PRODUCT} service runtime, then the {PRODUCT} Operator cannot generate the infrastructure components and the user must install these operators in the OpenShift or Kubernetes cluster.
 
 The {PRODUCT} Data Index Service similarly depends on Infinispan and Kafka infrastructure components. Without Infinispan persistence and Kafka messaging, the Data Index Service cannot function properly. However, you can specify whether the Data Index Service uses the general infrastructure components that the {PRODUCT} Operator generates or a custom alternative for that component.
 

--- a/doc-content/kogito-docs/src/main/asciidoc/openshift/con-kogito-operator-architecture.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/openshift/con-kogito-operator-architecture.adoc
@@ -47,35 +47,7 @@ spec:
 
 In this example, the {PRODUCT} Operator uses the Infinispan Operator to deploy the Infinispan Server instance for persistence and uses the Strimzi Operator to deploy the Kafka cluster for event messaging.
 
-When you install the {PRODUCT} Operator, these third-party operators are also installed automatically by the Operator Lifecycle Manager (OLM) and defined in the {PRODUCT} Operator `ClusterServiceVersion` (CSV) manifest file:
-
-.Example CSV manifest file for the {PRODUCT} Operator
-[source,yaml]
-----
-required:
-    - description: Represents an Infinispan cluster
-      displayName: Infinispan Cluster
-      kind: Infinispan
-      name: infinispans.infinispan.org
-      version: v1
-    - description: Represents a Kafka cluster
-      displayName: Kafka
-      kind: Kafka
-      name: kafkas.kafka.strimzi.io
-      version: v1beta1
-    - description: Represents a topic inside a Kafka cluster
-      displayName: Kafka Topic
-      kind: KafkaTopic
-      name: kafkatopics.kafka.strimzi.io
-      version: v1beta1
-    - description: Represents a Keycloak server to provide SSO
-      displayName: Keycloak
-      kind: Keycloak
-      name: keycloaks.keycloak.org
-      version: v1alpha1
-----
-
-If the required third-party operators are not available to the {PRODUCT} Operator during {PRODUCT} service runtime, then the {PRODUCT} Operator cannot generate the infrastructure components and a user must install the infrastructure components manually.
+If the required third-party operators are not available to the {PRODUCT} Operator during {PRODUCT} service runtime, then the {PRODUCT} Operator cannot generate the infrastructure components and a user must install the infrastructure components.
 
 The {PRODUCT} Data Index Service similarly depends on Infinispan and Kafka infrastructure components. Without Infinispan persistence and Kafka messaging, the Data Index Service cannot function properly. However, you can specify whether the Data Index Service uses the general infrastructure components that the {PRODUCT} Operator generates or a custom alternative for that component.
 

--- a/doc-content/kogito-docs/src/main/asciidoc/openshift/con-kogito-operator-with-infinispan.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/openshift/con-kogito-operator-with-infinispan.adoc
@@ -11,9 +11,9 @@ $ {PRODUCT_INIT} install infinispan -p __PROJECT_NAME__
 
 When you install the Infinispan infrastructure for your {PRODUCT} project, the {PRODUCT} Operator creates a `KogitoInfra` custom resource to handle Infinispan deployment for you. This resource is added to your {PRODUCT} project and in the {PRODUCT} Operator page of the *Installed Operators* listed in the OpenShift web console, if applicable.
 
-The `KogitoInfra` resource uses the https://github.com/infinispan/infinispan-operator[Infinispan Operator] to deploy new Infinispan Server instances when needed. Hence make sure that you have https://infinispan.org/infinispan-operator/master/operator.html[it installed] in the same namespace you deployed the custom {PRODUCT} service. 
+The `KogitoInfra` resource uses the https://github.com/infinispan/infinispan-operator[Infinispan Operator] to deploy new Infinispan Server instances when needed. Due to this dependency, the Infinispan Operator must be installed in the same namespace where you deployed the custom {PRODUCT} service. For information about Infinispan Operator installation, see the https://infinispan.org/infinispan-operator/master/operator.html[Infinispan Operator Guide].
 
-You can edit and manage the Infinispan instance. The {PRODUCT} Operator *does not manage* Infinispan instances. For example, if you have plans to scale the Infinispan cluster, you can edit the `replicas` field in the https://github.com/infinispan/infinispan-operator/blob/master/pkg/apis/infinispan/v1/infinispan_types.go[`infinispan_types.go`] custom resource to meet your requirements.
+You can edit and manage an Infinispan instance, but the {PRODUCT} Operator does not manage Infinispan instances. For example, if you want to scale the Infinispan cluster, you can edit the `replicas` field in the https://github.com/infinispan/infinispan-operator/blob/master/pkg/apis/infinispan/v1/infinispan_types.go[`infinispan_types.go`] custom resource to meet your requirements.
 
 By default, the `KogitoInfra` resource creates a secret that holds the user name and password for Infinispan authentication. To view the credentials, enter the following command:
 

--- a/doc-content/kogito-docs/src/main/asciidoc/openshift/con-kogito-operator-with-infinispan.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/openshift/con-kogito-operator-with-infinispan.adoc
@@ -11,7 +11,7 @@ $ {PRODUCT_INIT} install infinispan -p __PROJECT_NAME__
 
 When you install the Infinispan infrastructure for your {PRODUCT} project, the {PRODUCT} Operator creates a `KogitoInfra` custom resource to handle Infinispan deployment for you. This resource is added to your {PRODUCT} project and in the {PRODUCT} Operator page of the *Installed Operators* listed in the OpenShift web console, if applicable.
 
-The `KogitoInfra` resource uses the https://github.com/infinispan/infinispan-operator[Infinispan Operator] to deploy new Infinispan Server instances when needed. Hence make sure that you have https://infinispan.org/infinispan-operator/master/operator.html[it installed] in the same namespace you deployed the custom Kogito service. 
+The `KogitoInfra` resource uses the https://github.com/infinispan/infinispan-operator[Infinispan Operator] to deploy new Infinispan Server instances when needed. Hence make sure that you have https://infinispan.org/infinispan-operator/master/operator.html[it installed] in the same namespace you deployed the custom {PRODUCT} service. 
 
 You can edit and manage the Infinispan instance. The {PRODUCT} Operator *does not manage* Infinispan instances. For example, if you have plans to scale the Infinispan cluster, you can edit the `replicas` field in the https://github.com/infinispan/infinispan-operator/blob/master/pkg/apis/infinispan/v1/infinispan_types.go[`infinispan_types.go`] custom resource to meet your requirements.
 

--- a/doc-content/kogito-docs/src/main/asciidoc/openshift/con-kogito-operator-with-infinispan.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/openshift/con-kogito-operator-with-infinispan.adoc
@@ -11,7 +11,9 @@ $ {PRODUCT_INIT} install infinispan -p __PROJECT_NAME__
 
 When you install the Infinispan infrastructure for your {PRODUCT} project, the {PRODUCT} Operator creates a `KogitoInfra` custom resource to handle Infinispan deployment for you. This resource is added to your {PRODUCT} project and in the {PRODUCT} Operator page of the *Installed Operators* listed in the OpenShift web console, if applicable.
 
-The `KogitoInfra` resource uses the https://github.com/infinispan/infinispan-operator[Infinispan Operator] to deploy new Infinispan Server instances when needed. You can edit and manage the Infinispan instance. The {PRODUCT} Operator does not manage the Infinispan instances. For example, if you have plans to scale the Infinispan cluster, you can edit the `replicas` field in the https://github.com/infinispan/infinispan-operator/blob/master/pkg/apis/infinispan/v1/infinispan_types.go[`infinispan_types.go`] custom resource to meet your requirements.
+The `KogitoInfra` resource uses the https://github.com/infinispan/infinispan-operator[Infinispan Operator] to deploy new Infinispan Server instances when needed. Hence make sure that you have https://infinispan.org/infinispan-operator/master/operator.html[it installed] in the same namespace you deployed the custom Kogito service. 
+
+You can edit and manage the Infinispan instance. The {PRODUCT} Operator *does not manage* Infinispan instances. For example, if you have plans to scale the Infinispan cluster, you can edit the `replicas` field in the https://github.com/infinispan/infinispan-operator/blob/master/pkg/apis/infinispan/v1/infinispan_types.go[`infinispan_types.go`] custom resource to meet your requirements.
 
 By default, the `KogitoInfra` resource creates a secret that holds the user name and password for Infinispan authentication. To view the credentials, enter the following command:
 

--- a/doc-content/kogito-docs/src/main/asciidoc/openshift/con-kogito-operator-with-infinispan.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/openshift/con-kogito-operator-with-infinispan.adoc
@@ -13,7 +13,7 @@ When you install the Infinispan infrastructure for your {PRODUCT} project, the {
 
 The `KogitoInfra` resource uses the https://github.com/infinispan/infinispan-operator[Infinispan Operator] to deploy new Infinispan Server instances when needed. Due to this dependency, the Infinispan Operator must be installed in the same namespace where you deployed the custom {PRODUCT} service. For information about Infinispan Operator installation, see the https://infinispan.org/infinispan-operator/master/operator.html[Infinispan Operator Guide].
 
-You can edit and manage an Infinispan instance, but the {PRODUCT} Operator does not manage Infinispan instances. For example, if you want to scale the Infinispan cluster, you can edit the `replicas` field in the https://github.com/infinispan/infinispan-operator/blob/master/pkg/apis/infinispan/v1/infinispan_types.go[`infinispan_types.go`] custom resource to meet your requirements.
+The {PRODUCT} Operator does not manage Infinispan instances, but you can edit and manage Infinispan instances as needed. For example, if you want to scale the Infinispan cluster, you can edit the `replicas` field in the https://github.com/infinispan/infinispan-operator/blob/master/pkg/apis/infinispan/v1/infinispan_types.go[`infinispan_types.go`] custom resource to meet your requirements.
 
 By default, the `KogitoInfra` resource creates a secret that holds the user name and password for Infinispan authentication. To view the credentials, enter the following command:
 

--- a/doc-content/kogito-docs/src/main/asciidoc/openshift/con-kogito-operator-with-kafka.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/openshift/con-kogito-operator-with-kafka.adoc
@@ -11,9 +11,9 @@ $ {PRODUCT_INIT} install kafka -p __PROJECT_NAME__
 
 When you install the Kafka infrastructure for your {PRODUCT} project, the {PRODUCT} Operator creates a `KogitoInfra` custom resource to handle the Kafka cluster deployment for you. This resource is added to your {PRODUCT} project and in the {PRODUCT} Operator page of the *Installed Operators* listed in the OpenShift web console, if applicable.
 
-The {PRODUCT} Operator relies on the https://strimzi.io/docs/latest/[Strimzi Operator] to deploy a Kafka cluster with Zookeeper to support sending and receiving messages within a process. Due to this dependency, the {PRODUCT} Operator requires the Strimzi Operator to be https://strimzi.io/docs/operators/master/quickstart.html#proc-install-product-str[installed in the cluster]. 
+The {PRODUCT} Operator uses the https://strimzi.io/docs/latest/[Strimzi Operator] to deploy a Kafka cluster with Zookeeper to support sending and receiving messages within a process. Due to this dependency, the Strimzi Operator must be installed in the Kafka cluster. For information about Strimzi Operator installation, see the https://strimzi.io/docs/operators/master/quickstart.html[Strimzi Quick Start guide].
 
-After having being created, you can edit the Kafka instance deployed by the Strimzi Operator to meet your requirements.
+After the Strimzi Operator deploys Kafka instances, you can edit the instances to meet your requirements.
 
 == Apache Kafka messaging in {PRODUCT} services
 

--- a/doc-content/kogito-docs/src/main/asciidoc/openshift/con-kogito-operator-with-kafka.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/openshift/con-kogito-operator-with-kafka.adoc
@@ -11,7 +11,9 @@ $ {PRODUCT_INIT} install kafka -p __PROJECT_NAME__
 
 When you install the Kafka infrastructure for your {PRODUCT} project, the {PRODUCT} Operator creates a `KogitoInfra` custom resource to handle the Kafka cluster deployment for you. This resource is added to your {PRODUCT} project and in the {PRODUCT} Operator page of the *Installed Operators* listed in the OpenShift web console, if applicable.
 
-The {PRODUCT} Operator relies on the https://strimzi.io/docs/latest/[Strimzi Operator] to deploy a Kafka cluster with Zookeeper to support sending and receiving messages within a process. Due to this dependency, the {PRODUCT} Operator installs the Strimzi Operator as part of the Kafka infrastructure. You can edit the Kafka instance deployed by the Strimzi Operator to meet your requirements.
+The {PRODUCT} Operator relies on the https://strimzi.io/docs/latest/[Strimzi Operator] to deploy a Kafka cluster with Zookeeper to support sending and receiving messages within a process. Due to this dependency, the {PRODUCT} Operator requires the Strimzi Operator to be https://strimzi.io/docs/operators/master/quickstart.html#proc-install-product-str[installed in the cluster]. 
+
+After having being created, you can edit the Kafka instance deployed by the Strimzi Operator to meet your requirements.
 
 == Apache Kafka messaging in {PRODUCT} services
 

--- a/doc-content/kogito-docs/src/main/asciidoc/openshift/con-kogito-operator-with-trusty-service.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/openshift/con-kogito-operator-with-trusty-service.adoc
@@ -1,7 +1,7 @@
 [id='con-kogito-operator-with-trusty-service_{context}']
 = {PRODUCT} Operator interaction with the {PRODUCT} Trusty Service
 
-{PRODUCT} provides a Trusty Service that stores all {PRODUCT} tracing events related to decisions made in {PRODUCT} services. The Trusty Service uses Apache Kafka messaging to consume https://cloudevents.io/[CloudEvents] messages from {PRODUCT} services, and then processes the tracing events and stores the data in the Infinispan persistence store. 
+{PRODUCT} provides a Trusty Service that stores all {PRODUCT} tracing events related to decisions made in {PRODUCT} services. The Trusty Service uses Apache Kafka messaging to consume https://cloudevents.io/[CloudEvents] messages from {PRODUCT} services, and then processes the tracing events and stores the data in the Infinispan persistence store.
 
 You can use the following {PRODUCT} command-line interface (CLI) operation to install the {PRODUCT} Trusty Service for auditing purposes in {PRODUCT} services:
 
@@ -11,13 +11,13 @@ You can use the following {PRODUCT} command-line interface (CLI) operation to in
 $ {PRODUCT_INIT} install trusty -p __PROJECT_NAME__
 ----
 
-To export tracing events from your {PRODUCT} project, you must additionally add the `tracing-addon` add-on as a dependency to your project. 
+To export tracing events from your {PRODUCT} project, you must additionally add the `tracing-addon` add-on as a dependency to your project.
 
 When you enable the Trusty Service for your {PRODUCT} project, the {PRODUCT} Operator creates a `KogitoTrusty` custom resource to handle the Trusty Service deployment for you. This resource is added to your {PRODUCT} project and in the {PRODUCT} Operator page of the *Installed Operators* listed in the OpenShift web console, if applicable.
 
-If an Infinispan Server instance and an Apache Kafka cluster are not installed in the OpenShift namespace, the {PRODUCT} Operator automatically installs the required `KogitoInfra` custom resources for the Infinispan and Apache Kafka components. 
+The {PRODUCT} Operator depends on the https://github.com/infinispan/infinispan-operator[Infinispan Operator] for persistence infrastructure and on the https://strimzi.io/docs/latest/[Strimzi Operator] for Kafka messaging infrastructure. The {PRODUCT} Operator uses the Infinispan Operator to deploy new Infinispan Server instances when needed, and uses the Strimzi Operator to deploy a Kafka cluster with Zookeeper to support sending and receiving messages within a process. Due to these dependencies, these operators must be installed in the same namespace as the {PRODUCT} project. For information about Infinispan Operator installation, see the https://infinispan.org/infinispan-operator/master/operator.html[Infinispan Operator Guide]. For information about Strimzi Operator installation, see the https://strimzi.io/docs/operators/master/quickstart.html[Strimzi Quick Start guide].
 
-If the {PRODUCT} Explainability Service is enabled, then the Trusty Service also stores the explainability results for all the tracing events. 
+If the {PRODUCT} Explainability Service is enabled, then the Trusty Service also stores the explainability results for all the tracing events.
 
 .Additional resources
 ifdef::KOGITO[]
@@ -26,4 +26,3 @@ endif::[]
 ifdef::KOGITO-COMM[]
 * xref:con-trusty-service_kogito-configuring[]
 endif::[]
-

--- a/doc-content/kogito-docs/src/main/asciidoc/openshift/proc-kogito-deploying-on-kubernetes.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/openshift/proc-kogito-deploying-on-kubernetes.adoc
@@ -39,7 +39,7 @@ NOTE: You must be logged in to the relevant Kubernetes cluster using the `kubect
 . If your {PRODUCT} project requires Infinispan persistence and Apache Kafka messaging, install the required Infinispan and Kafka infrastructure components, including the https://github.com/infinispan/infinispan-operator[Infinispan Operator] and the https://strimzi.io/docs/latest/[Strimzi Operator] (for Kafka cluster deployment with Zookeeper).
 +
 --
-The {PRODUCT} Operator cannot install Infinispan persistence and Kafka messaging operators automatically, so you must install these components manually. 
+The {PRODUCT} Operator cannot automatically install these operators for Infinispan persistence and Kafka messaging, so you must install the components manually, if needed.
 
 For information about Infinispan installation and configuration, see the https://infinispan.org/documentation/[Infinispan documentation].
 

--- a/doc-content/kogito-docs/src/main/asciidoc/openshift/proc-kogito-deploying-on-kubernetes.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/openshift/proc-kogito-deploying-on-kubernetes.adoc
@@ -39,7 +39,7 @@ NOTE: You must be logged in to the relevant Kubernetes cluster using the `kubect
 . If your {PRODUCT} project requires Infinispan persistence and Apache Kafka messaging, install the required Infinispan and Kafka infrastructure components, including the https://github.com/infinispan/infinispan-operator[Infinispan Operator] and the https://strimzi.io/docs/latest/[Strimzi Operator] (for Kafka cluster deployment with Zookeeper).
 +
 --
-In a Kubernetes deployment, the {PRODUCT} Operator cannot install Infinispan persistence and Kafka messaging infrastructures automatically, so you must install these components manually.
+The {PRODUCT} Operator cannot install Infinispan persistence and Kafka messaging operators automatically, so you must install these components manually. 
 
 For information about Infinispan installation and configuration, see the https://infinispan.org/documentation/[Infinispan documentation].
 

--- a/doc-content/kogito-docs/src/main/asciidoc/openshift/proc-kogito-travel-agency-create-ocp-project.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/openshift/proc-kogito-travel-agency-create-ocp-project.adoc
@@ -24,12 +24,13 @@ $ kogito use-project kogito-travel-agency
 Project set to 'kogito-travel-agency'
 ----
 
-The `kogito new-project` and `kogito use-project` commands automatically install the following components if they are not installed already:
+The `kogito new-project` and `kogito use-project` commands automatically install the *{PRODUCT} Operator* if it isn't installed already.
 
-* *{PRODUCT} Operator*: Provides automation for deployment on OpenShift
-* *Infinispan Operator*: Provides persistence infrastructure for {PRODUCT} services
-* *Strimzi Operator*: Provides messaging infrastructure for {PRODUCT} services
-* *Keycloak Operator*: Provides security and single sign-on infrastructure for {PRODUCT} services
+.Installing Additional components
+
+Some {PRODUCT} services require persistence and messaging infrastructure, such the Travel Agency services. {PRODUCT} Operator uses *Infinispan Operator* and *Strimzi* provided services to create the needed infrastructure for the {PRODUCT} services to run.
+
+These operators are available under the *Operators* -> *OperatorHub* left menu and needed to be installed before proceeding. Each of these operators also provide a way to install them manually, please refer to the https://infinispan.org/infinispan-operator/master/operator.html[Infinispan Operator] and https://strimzi.io/docs/operators/master/quickstart.html#proc-install-product-str[Strimzi] documentation for more information.
 
 After you create the OpenShift project using the {PRODUCT} CLI and install the {PRODUCT} Operator, the operator is also listed in the OpenShift web console in *Operators* -> *Installed Operators*:
 

--- a/doc-content/kogito-docs/src/main/asciidoc/openshift/proc-kogito-travel-agency-create-ocp-project.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/openshift/proc-kogito-travel-agency-create-ocp-project.adoc
@@ -24,15 +24,11 @@ $ kogito use-project kogito-travel-agency
 Project set to 'kogito-travel-agency'
 ----
 
-The `kogito new-project` and `kogito use-project` commands automatically install the *{PRODUCT} Operator* if it isn't installed already.
+The `kogito new-project` and `kogito use-project` commands automatically install the *{PRODUCT} Operator* if it is not installed already.
 
-.Installing Additional components
+If your {PRODUCT} project requires persistence and messaging infrastructures, you can use the left menu of the OpenShift web console to navigate to *Operators* -> *OperatorHub* and install the https://github.com/infinispan/infinispan-operator[Infinispan Operator] for persistence and the https://strimzi.io/docs/latest/[Strimzi Operator] for Apache Kafka clusters and messaging. You can also install these operators manually using the https://infinispan.org/infinispan-operator/master/operator.html[Infinispan Operator Guide] or the https://strimzi.io/docs/operators/master/quickstart.html[Strimzi Quick Start guide]. The {PRODUCT} Operator depends on these operators to create the needed persistence and messaging infrastructures.
 
-Some {PRODUCT} services require persistence and messaging infrastructure, such the Travel Agency services. {PRODUCT} Operator uses *Infinispan Operator* and *Strimzi* provided services to create the needed infrastructure for the {PRODUCT} services to run.
-
-These operators are available under the *Operators* -> *OperatorHub* left menu and needed to be installed before proceeding. Each of these operators also provide a way to install them manually, please refer to the https://infinispan.org/infinispan-operator/master/operator.html[Infinispan Operator] and https://strimzi.io/docs/operators/master/quickstart.html#proc-install-product-str[Strimzi] documentation for more information.
-
-After you create the OpenShift project using the {PRODUCT} CLI and install the {PRODUCT} Operator, the operator is also listed in the OpenShift web console in *Operators* -> *Installed Operators*:
+After you create the OpenShift project using the {PRODUCT} CLI and install the {PRODUCT} Operator, the operator is listed with any other installed operators in the OpenShift web console in *Operators* -> *Installed Operators*:
 
 .Installed operators in web console
 image::kogito/openshift/kogito-ocp-installed-operators.png[Image of installed operators in web console]

--- a/doc-content/kogito-docs/src/main/asciidoc/openshift/proc-kogito-travel-agency-enable-messaging.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/openshift/proc-kogito-travel-agency-enable-messaging.adoc
@@ -1,6 +1,11 @@
 [id='proc-kogito-travel-agency-enable-messaging_{context}']
 = Installing the Kafka messaging infrastructure for {PRODUCT} services on OpenShift
 
+[NOTE]
+====
+Make sure that you have installed https://strimzi.io/docs/operators/master/quickstart.html#proc-install-product-str[Strimzi] before proceding.
+====
+
 {PRODUCT} supports the https://github.com/eclipse/microprofile-reactive-messaging[MicroProfile Reactive Messaging] specification for messaging in your services. {PRODUCT} messaging is based on https://kafka.apache.org/[Apache Kafka] and enables you to configure messages as either input or output of business process execution.
 
 The {PRODUCT} Operator uses the https://strimzi.io/[Strimzi Operator] to deploy and manage the Kafka infrastructure in a {PRODUCT} project. For optimal {PRODUCT} deployment on OpenShift, enable Kafka messaging for your {PRODUCT} services. You can install the Kafka infrastructure using the {PRODUCT} Operator page in the OpenShift web console or using the {PRODUCT} CLI.

--- a/doc-content/kogito-docs/src/main/asciidoc/openshift/proc-kogito-travel-agency-enable-messaging.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/openshift/proc-kogito-travel-agency-enable-messaging.adoc
@@ -1,14 +1,9 @@
 [id='proc-kogito-travel-agency-enable-messaging_{context}']
 = Installing the Kafka messaging infrastructure for {PRODUCT} services on OpenShift
 
-[NOTE]
-====
-Make sure that you have installed https://strimzi.io/docs/operators/master/quickstart.html#proc-install-product-str[Strimzi] before proceding.
-====
-
 {PRODUCT} supports the https://github.com/eclipse/microprofile-reactive-messaging[MicroProfile Reactive Messaging] specification for messaging in your services. {PRODUCT} messaging is based on https://kafka.apache.org/[Apache Kafka] and enables you to configure messages as either input or output of business process execution.
 
-The {PRODUCT} Operator uses the https://strimzi.io/[Strimzi Operator] to deploy and manage the Kafka infrastructure in a {PRODUCT} project. For optimal {PRODUCT} deployment on OpenShift, enable Kafka messaging for your {PRODUCT} services. You can install the Kafka infrastructure using the {PRODUCT} Operator page in the OpenShift web console or using the {PRODUCT} CLI.
+The {PRODUCT} Operator uses the https://strimzi.io/[Strimzi Operator] to deploy and manage the Kafka infrastructure in a {PRODUCT} project. For optimal {PRODUCT} deployment on OpenShift, install the Strimzi Operator and enable Kafka messaging for your {PRODUCT} services. You can install the Kafka infrastructure using the {PRODUCT} Operator page in the OpenShift web console or using the {PRODUCT} CLI.
 
 This example uses the {PRODUCT} CLI to install the Kafka infrastructure and the {PRODUCT} Operator page in the web console to verify that the infrastructure is enabled.
 
@@ -18,6 +13,9 @@ Instead of explicitly enabling Kafka messaging, you can enable the {PRODUCT} Dat
 
 For information about enabling the Data Index Service, see xref:proc-kogito-travel-agency-enable-data-index_kogito-deploying-on-openshift[].
 ====
+
+.Prerequisites
+* The https://strimzi.io/[Strimzi Operator] is installed in the same OpenShift namespace as your {PRODUCT} project. You can install the Strimzi Operator using the *Operators* -> *OperatorHub* page in the OpenShift web console or manually as described in the https://strimzi.io/docs/operators/master/quickstart.html[Strimzi Quick Start guide].
 
 .Procedure
 . In a command terminal, enter the following command to install the Kafka infrastructure for the {PRODUCT} services:

--- a/doc-content/kogito-docs/src/main/asciidoc/openshift/proc-kogito-travel-agency-enable-persistence.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/openshift/proc-kogito-travel-agency-enable-persistence.adoc
@@ -1,14 +1,9 @@
 [id='proc-kogito-travel-agency-enable-persistence_{context}']
 = Installing the Infinispan persistence infrastructure for {PRODUCT} services on OpenShift
 
-[NOTE]
-====
-Make sure that you have installed https://infinispan.org/infinispan-operator/master/operator.html[Infinispan Operator] before proceding.
-====
-
 {PRODUCT} supports runtime persistence for process data in your services. {PRODUCT} persistence is based on https://infinispan.org/[Infinispan] and enables you to configure key-value storage definitions to persist data, such as active nodes and process instance variables, so that the data is preserved across application restarts.
 
-The {PRODUCT} Operator uses the https://github.com/infinispan/infinispan-operator/blob/master/README.md[Infinispan Operator] to deploy and manage the Infinispan infrastructure in a {PRODUCT} project. For optimal {PRODUCT} deployment on OpenShift, enable Inifinispan persistence for your {PRODUCT} services. You can install the Infinispan infrastructure using the {PRODUCT} Operator page in the OpenShift web console or using the {PRODUCT} CLI.
+The {PRODUCT} Operator uses the https://github.com/infinispan/infinispan-operator[Infinispan Operator] to deploy the Infinispan infrastructure in a {PRODUCT} project. For optimal {PRODUCT} deployment on OpenShift, install the Infinispan Operator and enable Inifinispan persistence for your {PRODUCT} services. You can install the Infinispan infrastructure using the {PRODUCT} Operator page in the OpenShift web console or using the {PRODUCT} CLI.
 
 This example uses the {PRODUCT} CLI to install the Infinispan infrastructure and the {PRODUCT} Operator page in the web console to verify that the infrastructure is enabled.
 
@@ -18,6 +13,9 @@ Instead of explicitly enabling Infinispan persistence, you can enable the {PRODU
 
 For information about enabling the Data Index Service, see xref:proc-kogito-travel-agency-enable-data-index_kogito-deploying-on-openshift[].
 ====
+
+.Prerequisites
+* The https://github.com/infinispan/infinispan-operator[Infinispan Operator] is installed in the same OpenShift namespace as your {PRODUCT} project. You can install the Infinispan Operator using the *Operators* -> *OperatorHub* page in the OpenShift web console or manually as described in the https://infinispan.org/infinispan-operator/master/operator.html[Infinispan Operator Guide].
 
 .Procedure
 . In a command terminal, enter the following command to install the Infinispan infrastructure for the {PRODUCT} services:

--- a/doc-content/kogito-docs/src/main/asciidoc/openshift/proc-kogito-travel-agency-enable-persistence.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/openshift/proc-kogito-travel-agency-enable-persistence.adoc
@@ -1,6 +1,11 @@
 [id='proc-kogito-travel-agency-enable-persistence_{context}']
 = Installing the Infinispan persistence infrastructure for {PRODUCT} services on OpenShift
 
+[NOTE]
+====
+Make sure that you have installed https://infinispan.org/infinispan-operator/master/operator.html[Infinispan Operator] before proceding.
+====
+
 {PRODUCT} supports runtime persistence for process data in your services. {PRODUCT} persistence is based on https://infinispan.org/[Infinispan] and enables you to configure key-value storage definitions to persist data, such as active nodes and process instance variables, so that the data is preserved across application restarts.
 
 The {PRODUCT} Operator uses the https://github.com/infinispan/infinispan-operator/blob/master/README.md[Infinispan Operator] to deploy and manage the Infinispan infrastructure in a {PRODUCT} project. For optimal {PRODUCT} deployment on OpenShift, enable Inifinispan persistence for your {PRODUCT} services. You can install the Infinispan infrastructure using the {PRODUCT} Operator page in the OpenShift web console or using the {PRODUCT} CLI.


### PR DESCRIPTION
…s any more

Signed-off-by: Ricardo Zanini <zanini@redhat.com>

Please see: https://issues.redhat.com/browse/KOGITO-3148

@sterobin I've removed all references for "operator installs X operator for you", since now we are removing them from our manifests. Users should install these operators manually from now on.