### PR TITLE
Upstream 7.26.x PR for BXMSDOC-6395: Added a note for Namespace and DMN Model Name fields value to be same

### DIFF
--- a/_artifacts/document-attributes.adoc
+++ b/_artifacts/document-attributes.adoc
@@ -1,4 +1,4 @@
-:REBUILT: Tuesday, July 21, 2020
+:REBUILT: Monday, August 31, 2020
 
 
 :ENTERPRISE_VERSION: 7.5

--- a/doc-content/jbpm-docs/src/main/asciidoc/BPMN2/dmn-execution-business-process.adoc
+++ b/doc-content/jbpm-docs/src/main/asciidoc/BPMN2/dmn-execution-business-process.adoc
@@ -57,6 +57,8 @@ image::dmn/dmn-execution-business-process.png[]
 * *Namespace*: Enter the unique namespace from the DMN model file. Example: `\https://www.drools.org/kie-dmn`
 * *Decision Name*: Enter the name of the DMN decision node that you want to invoke in the selected process node. Example: `Rail`
 * *DMN Model Name*: Enter the DMN model name. Example: `Compute Rail`
++
+IMPORTANT: When you explore the root node, ensure that the *Namespace* and *DMN Model Name* fields consist of the same value in BPMN as DMN diagram. 
 
 . Under *Data Assignments* -> *Assignments*, click the *Edit* icon and add the DMN input and output data to define the mapping between the DMN service and the process data.
 +


### PR DESCRIPTION
See JIRA: https://issues.redhat.com/browse/BXMSDOC-6395

Added a Note for Namespace and DMN Model Name fields in Invoking a Decision Model and Notation (DMN) service in a business process in the process designer document.

Doc preview:
[Designing business processes in Business Central 7.5](http://file.pnq.redhat.com/~hmanwani/BXMSDOC-6395-RHPAM-7.5/#dmn-execution-business-process)