### PR TITLE
BXMSDOC-6539 Demonstrate automatic integrity check of DMN/FEEL builtin fn adoc

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,6 +1,9 @@
 name: Quality sync checks
 
-on: [ push ]
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   build:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,19 @@
+name: Quality sync checks
+
+on: [ push ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [8, 11]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK
+      uses: actions/setup-java@v1
+      with:
+        java-version: ${{ matrix.java }}      
+    - name: Build and quality sync checks from Maven profile
+      run: mvn -B clean install -Psyncchecks --file pom.xml

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - master-kogito
 
 jobs:
   build:

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # Eclipse, Netbeans and IntelliJ files
 /.*
 !.gitignore
+!.github
 /nbproject
 /*.ipr
 /*.iws

--- a/doc-content/drools-docs/pom.xml
+++ b/doc-content/drools-docs/pom.xml
@@ -45,10 +45,45 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
       </plugin>
+      <plugin>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>verify</phase>
+            <configuration>
+              <target>
+                <mkdir dir="${project.build.directory}/download/DMN" />
+                <get src="https://raw.githubusercontent.com/kiegroup/drools/master/kie-dmn/ref-dmn-feel-builtin-functions.adoc"
+                     dest="${project.build.directory}/download/DMN/ref-dmn-feel-builtin-functions.adoc"
+                     verbose="true"
+                     usetimestamp="false"/>
+                <echo message="Now checking that DMN content is up-to-date with main source repo..."/>
+                <fail message="DMN content is not up-to-date with main source repo.">
+                  <condition>
+                      <not>
+                        <filesmatch file1="${project.basedir}/src/main/asciidoc/DMN/ref-dmn-feel-builtin-functions.adoc"
+                                    file2="${project.build.directory}/download/DMN/ref-dmn-feel-builtin-functions.adoc"
+                                    textfile="true"/>
+                      </not>
+                  </condition>
+                </fail>
+                <echo message="DMN content looks to be up-to-date with main source repo!"/>
+              </target>
+            </configuration>
+            <goals>
+              <goal>run</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
 
     <pluginManagement>
       <plugins>
+        <plugin>
+          <artifactId>maven-antrun-plugin</artifactId>
+          <version>1.7</version>
+        </plugin>
         <plugin>
           <groupId>org.asciidoctor</groupId>
           <artifactId>asciidoctor-maven-plugin</artifactId>

--- a/doc-content/drools-docs/pom.xml
+++ b/doc-content/drools-docs/pom.xml
@@ -45,37 +45,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
       </plugin>
-      <plugin>
-        <artifactId>maven-antrun-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>verify</phase>
-            <configuration>
-              <target>
-                <mkdir dir="${project.build.directory}/download/DMN" />
-                <get src="https://raw.githubusercontent.com/kiegroup/drools/master/kie-dmn/ref-dmn-feel-builtin-functions.adoc"
-                     dest="${project.build.directory}/download/DMN/ref-dmn-feel-builtin-functions.adoc"
-                     verbose="true"
-                     usetimestamp="false"/>
-                <echo message="Now checking that DMN content is up-to-date with main source repo..."/>
-                <fail message="DMN content is not up-to-date with main source repo.">
-                  <condition>
-                      <not>
-                        <filesmatch file1="${project.basedir}/src/main/asciidoc/DMN/ref-dmn-feel-builtin-functions.adoc"
-                                    file2="${project.build.directory}/download/DMN/ref-dmn-feel-builtin-functions.adoc"
-                                    textfile="true"/>
-                      </not>
-                  </condition>
-                </fail>
-                <echo message="DMN content looks to be up-to-date with main source repo!"/>
-              </target>
-            </configuration>
-            <goals>
-              <goal>run</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
 
     <pluginManagement>
@@ -96,4 +65,45 @@
       </plugins>
     </pluginManagement>
   </build>
+  
+  <profiles>
+    <profile>
+      <id>syncchecks</id>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>verify</phase>
+                <configuration>
+                  <target>
+                    <mkdir dir="${project.build.directory}/download/DMN" />
+                    <get src="https://raw.githubusercontent.com/kiegroup/drools/master/kie-dmn/ref-dmn-feel-builtin-functions.adoc"
+                         dest="${project.build.directory}/download/DMN/ref-dmn-feel-builtin-functions.adoc"
+                         verbose="true"
+                         usetimestamp="false"/>
+                    <echo message="Now checking that DMN content is up-to-date with main source repo..."/>
+                    <fail message="DMN content is not up-to-date with main source repo.">
+                      <condition>
+                          <not>
+                            <filesmatch file1="${project.basedir}/src/main/asciidoc/DMN/ref-dmn-feel-builtin-functions.adoc"
+                                        file2="${project.build.directory}/download/DMN/ref-dmn-feel-builtin-functions.adoc"
+                                        textfile="true"/>
+                          </not>
+                      </condition>
+                    </fail>
+                    <echo message="DMN content looks to be up-to-date with main source repo!"/>
+                  </target>
+                </configuration>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
Followups on https://github.com/kiegroup/kie-docs/pull/2816 and pivots to demonstrate automatic integrity check of DMN/FEEL builtin function adoc, if compared to main source repo

# Description
1. Maven antrun plugin is used to download from Drools repo source, the "master source" of the content adoc file
2. A check is performed to ensure the content is text-same by standard diff tools (embedded in Maven/Ant itself)
3. If the content is not the same, Maven build (of community doc) fails

# Demo
since the content are already not the same for the 1st line, the Adoc comment in the file itself, this already fails.
In other words it fails because this line: https://github.com/kiegroup/kie-docs/blame/master/doc-content/drools-docs/src/main/asciidoc/DMN/ref-dmn-feel-builtin-functions.adoc#L1
it is already NOT the same as of the master source repo this line: https://github.com/kiegroup/drools/blame/master/kie-dmn/ref-dmn-feel-builtin-functions.adoc#L1

Therefore: 
https://github.com/kiegroup/drools/blame/master/kie-dmn/ref-dmn-feel-builtin-functions.adoc#L1
![image](https://user-images.githubusercontent.com/1699252/93020462-7b187780-f5dd-11ea-9a1b-1c1e0ad72998.png)

Otherwise making the content the same, it would pass:
![image](https://user-images.githubusercontent.com/1699252/93020454-6fc54c00-f5dd-11ea-8a49-0bd3f49c1d2e.png)

for the purpose of this demo, the content was aligned only locally to demonstrate when OK

# Open questions

1. This check is performed after having generated the community doc, as a sort of "quality check", that is `verify` phase. Is this the preferred? Alternatively, we can do during phase `validate` which would prevent any documentation generation IFF the content was not in sync

2. This check is performed as part of the main community doc build. We could move it into a dedicated Maven profile, so that the community doc build would keep as of today, with no check performed. Then ask QE team to enable specific GitHub Action to perform this check periodically. Please notice: this would imply doc editors will never notice their out of sync when building the content locally! But up to doc team consideration which setup is best preferred ;) 