### PR TITLE
BXMSPROD-1004 Switch OptaWeb releases from master to 7.x branch

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -20,7 +20,7 @@ jobs:
         uses: kiegroup/github-action-build-chain@v1.4
         with:
           parent-dependencies: 'jbpm-wb'
-          child-dependencies: 'optaweb-employee-rostering'
+          child-dependencies: 'optaweb-employee-rostering@master:7.x'
           build-command: 'mvn install'
           build-command-upstream: |
             mvn -e install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true


### PR DESCRIPTION
https://issues.redhat.com/browse/BXMSPROD-1004

https://github.com/kiegroup/optaweb-vehicle-routing/pull/368
https://github.com/kiegroup/optaweb-employee-rostering/pull/499
https://github.com/kiegroup/kie-docs/pull/2850
https://github.com/kiegroup/kie-wb-distributions/pull/1063