### PR TITLE
BXMSDOC-6539 Demonstrate automatic integrity check of DMN/FEEL builtin fn adoc

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,23 @@
+name: Quality sync checks
+
+on:
+  push:
+    branches:
+      - master
+      - master-kogito
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [8, 11]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK
+      uses: actions/setup-java@v1
+      with:
+        java-version: ${{ matrix.java }}      
+    - name: Build and quality sync checks from Maven profile
+      run: mvn -B clean install -Psyncchecks --file pom.xml

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # Eclipse, Netbeans and IntelliJ files
 /.*
 !.gitignore
+!.github
 /nbproject
 /*.ipr
 /*.iws


### PR DESCRIPTION
I am sorry,
I was mislead by another help document,
but it appears in fact the original comment https://github.com/kiegroup/kie-docs/pull/2853#issuecomment-696877085 was correct.

I still believe for the most part as I summarised here is still valid: https://github.com/kiegroup/kie-docs/pull/2853#issuecomment-697207650

But specifically one requirement more is necessary:

> The workflow files must be present in that commit SHA or Git ref to be considered. For example, if the event occurred on a particular repository branch, then the workflow files must be present in the repository on that branch.

from: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#example-using-multiple-events-with-activity-types-or-configuration

In short, I replicated the _only_ necessary workflow file _also_ on the `master-kogito` branch, to match the requirement.