### PR TITLE
Upstream master PR for BXMSDOC-6503: Document dashbuilder external components feature.

### DIFF
--- a/assemblies/assembly-building-custom-dashboard-widgets.adoc
+++ b/assemblies/assembly-building-custom-dashboard-widgets.adoc
@@ -32,6 +32,8 @@ include::{enterprise-dir}/pages/building-custom-dashboard-widgets-components-con
 include::{enterprise-dir}/pages/building-custom-dashboard-widgets-placing-components-proc.adoc[leveloffset=+3]
 include::{enterprise-dir}/pages/building-custom-dashboard-widgets-previewing-pages-proc.adoc[leveloffset=+3]
 include::{enterprise-dir}/pages/building-custom-dashboard-widgets-components-properties-ref.adoc[leveloffset=+3]
+include::{enterprise-dir}/pages/building-custom-dashboard-widgets-external-components-con.adoc[leveloffset=+2]
+include::{enterprise-dir}/pages/building-custom-dashboard-widgets-creating-external-components-proc.adoc[leveloffset=+3]
 
 include::{enterprise-dir}/admin-and-config/business-central-settings-security-con.adoc[leveloffset=+1]
 include::{enterprise-dir}/admin-and-config/business-central-settings-creating-new-users-proc.adoc[leveloffset=+2]

--- a/doc-content/enterprise-only/pages/building-custom-dashboard-widgets-creating-external-components-proc.adoc
+++ b/doc-content/enterprise-only/pages/building-custom-dashboard-widgets-creating-external-components-proc.adoc
@@ -1,0 +1,26 @@
+[id='building-custom-dashboard-widgets-creating-external-components-proc']
+= Creating external components
+
+The following procedure describes how to create and add the external components to a page:
+
+.Procedure
+
+. Set the component under components directory with a parent directory.
++
+For example, if the component ID is `mycomp` and the component directory is `/tmp/dashbuilder/components`, then the component base directory is `/tmp/dashbuilder/components/mycomp`.
+. Create the `manifest.json` file in the component directory.
+. Create `index.html` file with HTML content.
+. In a terminal application, navigate to `EAP_HOME/bin`.
+. To enable the external components, set the value of `dashbuilder.components.enable` system property to `true`:
++
+[source]
+----
+$ ~/EAP_HOME/bin/standalone.sh -c standalone-full.xml
+-Ddashbuilder.components.dir={component directory base path} -Ddashbuilder.components.enable=true
+----
+. Start {CENTRAL}, go to *Menu → Design → Pages*.
++
+*External Components* is available under *Components* pane.
+
+. In the *Components* pane, expand the *External Components* and drag the required component types to the canvas.
+. Click *Save*.

--- a/doc-content/enterprise-only/pages/building-custom-dashboard-widgets-external-components-con.adoc
+++ b/doc-content/enterprise-only/pages/building-custom-dashboard-widgets-external-components-con.adoc
@@ -1,0 +1,62 @@
+[id='building-custom-dashboard-widgets-external-components-con']
+= External components
+
+In {CENTRAL}, you can add external components to a page. The components are disabled by default. To enable the external components, change the value of `dashbuilder.components.enable` system property to `true`.
+
+The external component location is set and configured with the `dashbuilder.components.dir` system property. The default value of this system property is `/tmp/dashbuilder/components`.
+You must set the component under the components directory with a parent directory, which is used as the component ID. For example, if the component ID is `mycomp` and the component directory is `/tmp/dashbuilder/components`, then the component base directory is `/tmp/dashbuilder/components/mycomp`.
+
+{CENTRAL} checks the `manifest.json` file in the components directory. The `manifest.json` must contain at least one `name` text parameter.
+
+.manifest.json file descriptions
+[cols="1,1", options="header"]
+|===
+| Parameter
+| Description
+
+|`name`
+|Name of the component displayed under *Components* section.
+
+|`icon`
+|Icon of the component displayed under *Components* section.
+
+|`noData`
+|A flag that indicates that the component does not require a data set.
+
+|`parameters`
+|The list of parameters are using `ComponentParameter` type. Supported parameter types include `name`, `type`, `category`, `defaultValue`, `label`, and `comboValues`.
+
+|===
+
+.Sample `manifest.json` file
+[source,json,options="nowrap"]
+----
+{
+    "name": "Heat Map Experiment",
+    "icon": "fa fa-bell-o",
+    "parameters": [
+        {
+            "name": "svg",
+            "type": "text",
+            "defaultValue": "",
+            "label": "SVG XML",
+            "category": "SVG Content"
+        },
+        {
+            "name": "svgUrl",
+            "type": "text",
+            "defaultValue": "",
+            "label": "SVG URL",
+            "category": "SVG URL"
+        }
+        ,
+        {
+            "name": "ksProcessId",
+            "type": "text",
+            "defaultValue": "",
+            "label": "Process ID",
+            "category": "Kie Server"
+        }
+    ]
+}
+----


### PR DESCRIPTION
**JIRAs:** 
- [Epic](https://issues.redhat.com/browse/BXMSDOC-6276) 
- [Dedicated JIRA](https://issues.redhat.com/browse/BXMSDOC-6503)

**Doc previews:**
- [RHPAM-Building custom dashboard widgets](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-6503-RHPAM-externalcomponents/#building-custom-dashboard-widgets-external-components-con)
- [RHDM-Building custom dashboard widgets](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-6503-RHDM-externalcomponents/#building-custom-dashboard-widgets-external-components-con)

**Doc impact:** 
- For **RHPAM**, go to IV. Building custom dashboard widgets ---> Chapter **57.5. External components**.
- For **RHDM**, go to IV. Building custom dashboard widgets  ---> Chapter **51.5. External components**.