### PR TITLE
Removing headers with reference to dev preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ If either of the two badges above are not green, please get in contact with engi
 
 Kogito is a cloud-native business automation technology for building cloud-ready business applications. Kogito includes components that are based on well-known business automation projects in the Knowledge Is Everything (KIE) community, specifically [Drools](https://drools.org), [jBPM](https://jbpm.org), and [OptaPlanner](https://optaplanner.org), to offer dependable, open source solutions for business rules, business processes, and constraint solving.
 
-This `master-kogito` branch of the `kie-docs` repository contains the source of the Kogito documentation for both KIE community and Red Hat Business Automation enterprise publications. The latest version of the Kogito documentation for the KIE community is published at https://docs.jboss.org/kogito/release/latest/html_single/. 
+This `master-kogito` branch of the `kie-docs` repository contains the source of the Kogito documentation for both KIE community and Red Hat Business Automation enterprise publications. The latest version of the Kogito documentation for the KIE community is published at https://docs.jboss.org/kogito/release/latest/html_single/.
 
 As a Kogito user, developer, or technical writer, you can contribute to Kogito documentation by forking and cloning this repository, updating or adding content, and submitting a pull request for review.
 
 >**NOTE**: The other branches in the `kie-docs` repository contain the source of the Drools, jBPM, and OptaPlanner documentation, which are the basis for [Red Hat Decision Manager](https://access.redhat.com/documentation/en-us/red_hat_decision_manager/) and [Red Hat Process Automation Manager](https://access.redhat.com/documentation/en-us/red_hat_process_automation_manager/).
 
->**IMPORTANT**: Kogito is currently available for Development Preview. Development Preview releases contain features and APIs that might not be fully tested and that might change in the final GA version. Users are discouraged from using Development Preview software in production or for business-critical workloads.  Because this is not production-ready software, users are not able to open support tickets. To learn more about Kogito, please contact your Red Hat representative or send an email to Kogito-earlyaccess@redhat.com. Red Hat will address reported issues at its own discretion.
+>**IMPORTANT**: Kogito is currently in early stages of development. Kogito releases contain features and APIs that might not be fully tested and that might change in future versions. Users are discouraged from using Kogito software in production or for business-critical workloads.
 
 Contents
 =================

--- a/doc-content/kogito-docs/src/main/asciidoc/chap-kogito-release-notes.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/chap-kogito-release-notes.adoc
@@ -13,7 +13,7 @@ For the complete list of new features, fixed issues, and known issues in {PRODUC
 
 [IMPORTANT]
 ====
-{PRODUCT} is currently available for Development Preview. Development Preview releases contain features and APIs that might not be fully tested and that might change in the final GA version. Users are discouraged from using Development Preview software in production or for business-critical workloads.  Because this is not production-ready software, users are not able to open support tickets. To learn more about {PRODUCT}, please contact your Red Hat representative or send an email to Kogito-earlyaccess@redhat.com. Red Hat will address reported issues at its own discretion.
+{PRODUCT} is currently in early stages of development. {PRODUCT} releases contain features and APIs that might not be fully tested and that might change in future versions. Users are discouraged from using {PRODUCT} software in production or for business-critical workloads.
 ====
 
 include::release-notes/ref-kogito-rn-key-features.adoc[leveloffset=+1]

--- a/doc-content/kogito-docs/src/main/asciidoc/index.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/index.adoc
@@ -26,7 +26,7 @@ endif::[]
 
 [IMPORTANT]
 ====
-{PRODUCT} is currently available for Development Preview. Development Preview releases contain features and APIs that might not be fully tested and that might change in the final GA version. Users are discouraged from using Development Preview software in production or for business-critical workloads.  Because this is not production-ready software, users are not able to open support tickets. To learn more about {PRODUCT}, please contact your Red Hat representative or send an email to Kogito-earlyaccess@redhat.com. Red Hat will address reported issues at its own discretion.
+{PRODUCT} is currently in early stages of development. {PRODUCT} releases contain features and APIs that might not be fully tested and that might change in future versions. Users are discouraged from using {PRODUCT} software in production or for business-critical workloads.
 ====
 
 //Intro

--- a/doc-content/kogito-docs/src/main/asciidoc/release-notes/0.10.0/ref-kogito-rn-known-issues.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/release-notes/0.10.0/ref-kogito-rn-known-issues.adoc
@@ -1,7 +1,7 @@
 [id='ref-kogito-rn-known-issues_{context}']
 = Known issues in {PRODUCT} {PRODUCT_VERSION}
 
-The following list describes some of the known issues in {PRODUCT} Development Preview. This list is not comprehensive. For more information about each known issue, select the Atlassian Jira link provided.
+The following list describes some of the known issues in {PRODUCT} {PRODUCT_VERSION}. This list is not comprehensive. For more information about each known issue, select the Atlassian Jira link provided.
 
 * VSCode 1.44 currently has the following known issues [https://issues.redhat.com/browse/KOGITO-1835[KOGITO-1835]]:
 ** The *Undo* and *Redo* UI options and keyboard shortcuts (such as ctrl+Z and ctrl+Y) do not function.

--- a/doc-content/kogito-docs/src/main/asciidoc/release-notes/0.9.0/ref-kogito-rn-known-issues.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/release-notes/0.9.0/ref-kogito-rn-known-issues.adoc
@@ -1,7 +1,7 @@
 [id='ref-kogito-rn-known-issues_{context}']
 = Known issues in {PRODUCT} {PRODUCT_VERSION}
 
-The following list describes some of the known issues in {PRODUCT} Development Preview. This list is not comprehensive. For more information about each known issue, select the Atlassian Jira link provided.
+The following list describes some of the known issues in {PRODUCT} {PRODUCT_VERSION}. This list is not comprehensive. For more information about each known issue, select the Atlassian Jira link provided.
 
 * VSCode 1.44 currently has the following known issues [https://issues.redhat.com/browse/KOGITO-1835[KOGITO-1835]]:
 ** The *Undo* and *Redo* UI options and keyboard shortcuts (such as ctrl+Z and ctrl+Y) do not function.

--- a/doc-content/kogito-docs/src/main/asciidoc/release-notes/ref-kogito-rn-key-features.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/release-notes/ref-kogito-rn-key-features.adoc
@@ -1,7 +1,7 @@
 [id='ref-kogito-rn-key-features_{context}']
 = Summary of key features in {PRODUCT}
 
-{PRODUCT} offers the following key features in Development Preview. For more information about these and other features in {PRODUCT}, see the {PRODUCT} documentation links where provided. Not all {PRODUCT} features are fully documented for Development Preview.
+{PRODUCT} offers the following key features. For more information about these and other features in {PRODUCT}, see the {PRODUCT} documentation links where provided. Not all {PRODUCT} features are fully documented.
 
 == {PRODUCT} domain-specific services
 


### PR DESCRIPTION
This PR removes all the header references to the Dev Preview program in the kogito docs.