### PR TITLE
[DROOLS-5658] updated option for ANC

### DIFF
--- a/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.7.45.0.Final/drools-modularization.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.7.45.0.Final/drools-modularization.adoc
@@ -44,3 +44,24 @@ new wrapper modules have been created to cover the 2 different main usage scenar
 With the introduction of these 2 modules, to use {DECISION_ENGINE} with the executable model it will be enough to add `drools-engine` to a
 project's dependencies while for traditional use of {DECISION_ENGINE} without the model it will be necessary to just import `drools-engine-classic`.
 These names reflect the intention of the Drools team to promote the use of the executable model and make it the default choice.
+
+=== Descope of Alpha Network Compiler
+
+The Alpha Network Compiler feature has also been moved to a separated module.
+
+To use it, you need
+* to add the `drools-alphanetwork-compiler` module
+* to enable it in the kmodule.xml to `inmemory` compilation
+
+----
+<kmodule xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://www.drools.org/xsd/kmodule">
+  <configuration>
+    <property key="drools.alphaNetworkCompiler" value="inmemory"/>
+  </configuration>
+</kmodule>
+----
+
+OR
+* if you use the kie-maven-plugin, you can create an ANC compiled version with the `-DgenerateModel=WITHANC` option
+

--- a/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.7.9.0.Final-section.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.7.9.0.Final-section.adoc
@@ -15,7 +15,7 @@ longer compile due to this change.
 
 == Alpha Network Compiler
 
-Note: since 7.45.0.Final this option has changed. Refer to 7.45.0.Final release notess for the correct option.
+NOTE: Alpha Network Compiler is descoped from 7.45 version. For more information, see xref:drools-modularization[].
 
 Drools now supports an optimization on evaluating alpha nodes which involves generating an intermediate class that gets compiled to evaluate the constraint faster.
 

--- a/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.7.9.0.Final-section.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.7.9.0.Final-section.adoc
@@ -15,6 +15,8 @@ longer compile due to this change.
 
 == Alpha Network Compiler
 
+Note: since 7.45.0.Final this option has changed. Refer to 7.45.0.Final release notess for the correct option.
+
 Drools now supports an optimization on evaluating alpha nodes which involves generating an intermediate class that gets compiled to evaluate the constraint faster.
 
 It's highly experimental and it's supposed to work only with the new executable model system. To enable it use `drools.alphaNetworkCompiler` configuration key in the `KieModuleModel` configuration.


### PR DESCRIPTION
@hmanwani-rh @mariofusco 

Current option has been documented in the old release notes but this invalidates

https://github.com/kiegroup/kie-docs/blob/master/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.7.9.0.Final-section.adoc#alpha-network-compiler

What shall we do here?