### PR TITLE
AF-2660: Allow default pages in Dashbuilder Runtime - Update communit…

### DIFF
--- a/doc-content/jbpm-docs/src/main/asciidoc/BAM/DashbuilderRuntime-section.adoc
+++ b/doc-content/jbpm-docs/src/main/asciidoc/BAM/DashbuilderRuntime-section.adoc
@@ -16,7 +16,7 @@ After login, users may upload dashboard files exported from {CENTRAL}
 image::BAM/DashbuilderRuntimeWelcomePage.png[]
 
 == Exporting Dashbuilder data
-You can export the dashbuilder related data such as datasets, pages, and navigation from {CENTRAL} as a ZIP file.
+You can export the dashbuilder related data such as datasets, pages, and navigation from {CENTRAL} as a ZIP file. If the exported dashboard contains only one page then it will be used as the default page or you can select a default page by just naming it *index*.
 
 .Procedure
 . In {CENTRAL}, select the *Admin* icon in the top-right corner of the screen and select *Dashbuilder Data Transfer*.

--- a/doc-content/jbpm-docs/src/main/asciidoc/ReleaseNotes/Release.7.44.0.Final/Release.7.44.0.Final-section.adoc
+++ b/doc-content/jbpm-docs/src/main/asciidoc/ReleaseNotes/Release.7.44.0.Final/Release.7.44.0.Final-section.adoc
@@ -7,3 +7,6 @@ The following features were added to jBPM 7.44.0
 include::process-editor-script-highlighting.adoc[leveloffset=+1]
 
 include::inline-text-editing.adoc[leveloffset=+1]
+
+include::dashbuilder-runtime-default-page.adoc[leveloffset=+1]
+

--- a/doc-content/jbpm-docs/src/main/asciidoc/ReleaseNotes/Release.7.44.0.Final/dashbuilder-runtime-default-page.adoc
+++ b/doc-content/jbpm-docs/src/main/asciidoc/ReleaseNotes/Release.7.44.0.Final/dashbuilder-runtime-default-page.adoc
@@ -1,0 +1,9 @@
+[id='dashbuilder-runtime-default-page']
+
+= Support for default home pages in Dashbuilder Runtime
+
+Dashboards imported in Dashbuilder Runtime can have a default page:
+
+* When the imported dashboard has only one page, then it is used as the default page;
+* If a page is named `index` then it will be used as the default page;
+* In other cases the generic Dashbuilder Runtime home page is used.

--- a/doc-content/jbpm-docs/src/main/asciidoc/ReleaseNotes/Release.7.44.0.Final/dashbuilder-runtime-default-page.adoc
+++ b/doc-content/jbpm-docs/src/main/asciidoc/ReleaseNotes/Release.7.44.0.Final/dashbuilder-runtime-default-page.adoc
@@ -2,8 +2,8 @@
 
 = Support for default home pages in Dashbuilder Runtime
 
-Dashboards imported in Dashbuilder Runtime can have a default page:
+Dashboards imported in dashbuilder runtime can have a default page. The following list provides a summary of dashbuilder runtime default page updates:
 
-* When the imported dashboard has only one page, then it is used as the default page;
-* If a page is named `index` then it will be used as the default page;
+* When an imported dashboard has only one page, then it is used as the default page;
+* If a page is named as `index` then it will be used as the default page;
 * In other cases the generic Dashbuilder Runtime home page is used.

--- a/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/ReleaseNotes/ReleaseNotesWorkbench.7.44.0.Final/dashbuilder-runtime-default-page.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/ReleaseNotes/ReleaseNotesWorkbench.7.44.0.Final/dashbuilder-runtime-default-page.adoc
@@ -1,9 +1,0 @@
-[id='dashbuilder-runtime-default-page']
-
-= Support for default home pages in Dashbuilder Runtime
-
-Dashboards imported in dashbuilder runtime can have a default page. The following list provides a summary of dashbuilder runtime default page updates:
-
-* When an imported dashboard has only one page, then it is used as the default page.
-* If a page is named `index` then it will be used as the default page.
-* In other cases the generic Dashbuilder Runtime home page is used.

--- a/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/ReleaseNotes/ReleaseNotesWorkbench.7.44.0.Final/dashbuilder-runtime-default-page.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/ReleaseNotes/ReleaseNotesWorkbench.7.44.0.Final/dashbuilder-runtime-default-page.adoc
@@ -2,8 +2,8 @@
 
 = Support for default home pages in Dashbuilder Runtime
 
-Dashboards imported in Dashbuilder Runtime can have a default page:
+Dashboards imported in dashbuilder runtime can have a default page. The following list provides a summary of dashbuilder runtime default page updates:
 
-* When the imported dashboard has only one page, then it is used as the default page;
-* If a page is named `index` then it will be used as the default page;
+* When an imported dashboard has only one page, then it is used as the default page.
+* If a page is named `index` then it will be used as the default page.
 * In other cases the generic Dashbuilder Runtime home page is used.

--- a/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/ReleaseNotes/ReleaseNotesWorkbench.7.44.0.Final/dashbuilder-runtime-default-page.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/ReleaseNotes/ReleaseNotesWorkbench.7.44.0.Final/dashbuilder-runtime-default-page.adoc
@@ -1,0 +1,9 @@
+[id='dashbuilder-runtime-default-page']
+
+= Support for default home pages in Dashbuilder Runtime
+
+Dashboards imported in Dashbuilder Runtime can have a default page:
+
+* When the imported dashboard has only one page, then it is used as the default page;
+* If a page is named `index` then it will be used as the default page;
+* In other cases the generic Dashbuilder Runtime home page is used.


### PR DESCRIPTION
…y docs

Updating docs for 7.44 to add a small Dashbuilder Runtime feature added in 7.44, which is allow users to select a default page.

I had to create the release notes for 7.44 because I didn't find it.