### PR TITLE
Upstream PR BXMSDOC-6807-7.44.x to 7.44.x: Installing and configuring DM/PAM on EAP

### DIFF
--- a/doc-content/enterprise-only/installation/assembly_installing-on-eap-deployable.adoc
+++ b/doc-content/enterprise-only/installation/assembly_installing-on-eap-deployable.adoc
@@ -11,6 +11,8 @@ For information about installing the {HEADLESS_CONTROLLER}, see xref:controller-
 
 include::eap-dm-install-proc.adoc[leveloffset=+1]
 include::eap-execution-server-download-install-proc.adoc[leveloffset=+1]
+ifdef::PAM[]
 include::eap-data-source-add-proc.adoc[leveloffset=+1]
+endif::PAM[]
 include::eap-users-create-proc.adoc[leveloffset=+1]
 include::kie-server-configure-central-proc.adoc[leveloffset=+1]

--- a/doc-content/enterprise-only/installation/kie-server-configure-central-proc.adoc
+++ b/doc-content/enterprise-only/installation/kie-server-configure-central-proc.adoc
@@ -135,7 +135,7 @@ Example for {CENTRAL} Instance:
 
 --
 +
-. Send a GET request to `http://_SERVER:PORT_/kie-server/services/rest/server/` and verify the successful start of the {KIE_SERVER}.
+. Send a GET request to `http://_SERVER:PORT_/kie-server/services/rest/server/` and verify the successful start of the {KIE_SERVER}. 
 Once authenticated, you receive an XML response similar to the following example:
 +
 [source,xml]


### PR DESCRIPTION
Updates bases on final QE input.

Original jira: https://issues.redhat.com/browse/BXMSDOC-6807
7.9 rendered output
DM: http://file.rdu.redhat.com/~mhaglund/BXMSDOC-6807DM/#assembly-install-on-eap
PAM: http://file.rdu.redhat.com/~mhaglund/BXMSDOC-6807PAM/#assembly-install-on-eap
Pull request: https://github.com/michelehaglund/kie-docs/pull/167/files