### PR TITLE
[Kogito] KOGITO-3807: [DMN Designer] Convert DMN 1.1/1.3 models to version 1.2 - Documentation

### DIFF
--- a/doc-content/kogito-docs/src/main/asciidoc/dmn/chap-kogito-using-dmn-models.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/dmn/chap-kogito-using-dmn-models.adoc
@@ -6,7 +6,7 @@ ifdef::context[:parent-context: {context}]
 [role="_abstract"]
 As a developer of business decisions, you can use Decision Model and Notation (DMN) to model a decision service graphically. The decision requirements of a DMN decision model are determined by a decision requirements graph (DRG) that is depicted in one or more decision requirements diagrams (DRDs). A DRD can represent part or all of the overall DRG for the DMN model. DRDs trace business decisions from start to finish, with each decision node using logic defined in DMN boxed expressions such as decision tables.
 
-{PRODUCT} provides design and runtime support for DMN 1.2 models at conformance level 3, and runtime-only support for DMN 1.1 and 1.3 models at conformance level 3. You can design your DMN models with the {PRODUCT} DMN modeler in VSCode or import existing DMN models into your {PRODUCT} projects for deployment and execution. Any DMN 1.1 and 1.3 models, non including DMN 1.3 features, that you import into your {PRODUCT} project, open in the DMN modeler, and save are converted to DMN 1.2 models.
+{PRODUCT} provides design and runtime support for DMN 1.2 models at conformance level 3, and runtime-only support for DMN 1.1 and 1.3 models at conformance level 3. You can design your DMN models with the {PRODUCT} DMN modeler in VSCode or import existing DMN models into your {PRODUCT} projects for deployment and execution. Any DMN 1.1 and 1.3 models (do not contain DMN 1.3 features) that you import, open in the DMN designer, and save are converted to DMN 1.2 models.
 
 For more information about DMN, see the Object Management Group (OMG) https://www.omg.org/spec/DMN[Decision Model and Notation specification].
 
@@ -83,7 +83,7 @@ A DMN conformance level 2 implementation includes the requirements in conformanc
 Conformance level 3::
 A DMN conformance level 3 implementation includes the requirements in conformance levels 1 and 2, and supports Friendly Enough Expression Language (FEEL) expressions, the full set of boxed expressions, and fully executable decision models.
 
-{PRODUCT} provides design and runtime support for DMN 1.2 models at conformance level 3, and runtime-only support for DMN 1.1 and 1.3 models at conformance level 3. You can design your DMN models with the {PRODUCT} DMN modeler in VSCode or import existing DMN models into your {PRODUCT} projects for deployment and execution. Any DMN 1.1 and 1.3 models, non including DMN 1.3 features, that you import into your {PRODUCT} project, open in the DMN modeler, and save are converted to DMN 1.2 models.
+{PRODUCT} provides design and runtime support for DMN 1.2 models at conformance level 3, and runtime-only support for DMN 1.1 and 1.3 models at conformance level 3. You can design your DMN models with the {PRODUCT} DMN modeler in VSCode or import existing DMN models into your {PRODUCT} projects for deployment and execution. Any DMN 1.1 and 1.3 models (do not contain DMN 1.3 features) that you import, open in the DMN designer, and save are converted to DMN 1.2 models.
 
 [id="ref-dmn-drd-components-ref-{context}"]
 === DMN decision requirements diagram (DRD) components
@@ -1054,7 +1054,7 @@ The following is the DMN source file for this decision model:
 == DMN support in {PRODUCT}
 
 [role="_abstract"]
-{PRODUCT} provides design and runtime support for DMN 1.2 models at conformance level 3, and runtime-only support for DMN 1.1 and 1.3 models at conformance level 3. You can design your DMN models with the {PRODUCT} DMN modeler in VSCode or import existing DMN models into your {PRODUCT} projects for deployment and execution. Any DMN 1.1 and 1.3 models, non including DMN 1.3 features, that you import into your {PRODUCT} project, open in the DMN modeler, and save are converted to DMN 1.2 models.
+{PRODUCT} provides design and runtime support for DMN 1.2 models at conformance level 3, and runtime-only support for DMN 1.1 and 1.3 models at conformance level 3. You can design your DMN models with the {PRODUCT} DMN modeler in VSCode or import existing DMN models into your {PRODUCT} projects for deployment and execution. Any DMN 1.1 and 1.3 models (do not contain DMN 1.3 features) that you import, open in the DMN designer, and save are converted to DMN 1.2 models.
 
 In addition to all DMN conformance level 3 requirements, {PRODUCT} also includes enhancements and fixes to FEEL and DMN model components to optimize the experience of implementing DMN decision services with {PRODUCT}. From a platform perspective, DMN models are like any other business asset in {PRODUCT}, such as DRL files or spreadsheet decision tables, that you can include in your {PRODUCT} project and execute to start your DMN decision services.
 
@@ -1293,7 +1293,7 @@ endif::[]
 == Creating and editing DMN models in the {PRODUCT} DMN modeler
 
 [role="_abstract"]
-You can use the {PRODUCT} DMN modeler in VSCode to design DMN decision requirements diagrams (DRDs) and define decision logic for a complete and functional DMN decision model. {PRODUCT} provides design and runtime support for DMN 1.2 models at conformance level 3, and includes enhancements and fixes to FEEL and DMN model components to optimize the experience of implementing DMN decision services with {PRODUCT}. {PRODUCT} also provides runtime-only support for DMN 1.1 and 1.3 models at conformance level 3. Any DMN 1.1 and 1.3 models, non including DMN 1.3 features, that you import into your {PRODUCT} project, open in the DMN modeler, and save are converted to DMN 1.2 models.
+You can use the {PRODUCT} DMN modeler in VSCode to design DMN decision requirements diagrams (DRDs) and define decision logic for a complete and functional DMN decision model. {PRODUCT} provides design and runtime support for DMN 1.2 models at conformance level 3, and includes enhancements and fixes to FEEL and DMN model components to optimize the experience of implementing DMN decision services with {PRODUCT}. {PRODUCT} also provides runtime-only support for DMN 1.1 and 1.3 models at conformance level 3. Any DMN 1.1 and 1.3 models (do not contain DMN 1.3 features) that you import, open in the DMN designer, and save are converted to DMN 1.2 models.
 
 .Prerequisites
 * https://code.visualstudio.com/[VSCode] 1.46.0 or later is installed.

--- a/doc-content/kogito-docs/src/main/asciidoc/dmn/chap-kogito-using-dmn-models.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/dmn/chap-kogito-using-dmn-models.adoc
@@ -6,7 +6,7 @@ ifdef::context[:parent-context: {context}]
 [role="_abstract"]
 As a developer of business decisions, you can use Decision Model and Notation (DMN) to model a decision service graphically. The decision requirements of a DMN decision model are determined by a decision requirements graph (DRG) that is depicted in one or more decision requirements diagrams (DRDs). A DRD can represent part or all of the overall DRG for the DMN model. DRDs trace business decisions from start to finish, with each decision node using logic defined in DMN boxed expressions such as decision tables.
 
-{PRODUCT} provides design and runtime support for DMN 1.2 models at conformance level 3, and runtime-only support for DMN 1.1 and 1.3 models at conformance level 3. You can design your DMN models with the {PRODUCT} DMN modeler in VSCode or import existing DMN models into your {PRODUCT} projects for deployment and execution. DMN 1.1 and 1.3 models are currently not supported in the {PRODUCT} DMN modeler.
+{PRODUCT} provides design and runtime support for DMN 1.2 models at conformance level 3, and runtime-only support for DMN 1.1 and 1.3 models at conformance level 3. You can design your DMN models with the {PRODUCT} DMN modeler in VSCode or import existing DMN models into your {PRODUCT} projects for deployment and execution. Any DMN 1.1 and 1.3 models, non including DMN 1.3 features, that you import into your {PRODUCT} project, open in the DMN modeler, and save are converted to DMN 1.2 models.
 
 For more information about DMN, see the Object Management Group (OMG) https://www.omg.org/spec/DMN[Decision Model and Notation specification].
 
@@ -83,7 +83,7 @@ A DMN conformance level 2 implementation includes the requirements in conformanc
 Conformance level 3::
 A DMN conformance level 3 implementation includes the requirements in conformance levels 1 and 2, and supports Friendly Enough Expression Language (FEEL) expressions, the full set of boxed expressions, and fully executable decision models.
 
-{PRODUCT} provides design and runtime support for DMN 1.2 models at conformance level 3, and runtime-only support for DMN 1.1 and 1.3 models at conformance level 3. You can design your DMN models with the {PRODUCT} DMN modeler in VSCode or import existing DMN models into your {PRODUCT} projects for deployment and execution. DMN 1.1 and 1.3 models are currently not supported in the {PRODUCT} DMN modeler.
+{PRODUCT} provides design and runtime support for DMN 1.2 models at conformance level 3, and runtime-only support for DMN 1.1 and 1.3 models at conformance level 3. You can design your DMN models with the {PRODUCT} DMN modeler in VSCode or import existing DMN models into your {PRODUCT} projects for deployment and execution. Any DMN 1.1 and 1.3 models, non including DMN 1.3 features, that you import into your {PRODUCT} project, open in the DMN modeler, and save are converted to DMN 1.2 models.
 
 [id="ref-dmn-drd-components-ref-{context}"]
 === DMN decision requirements diagram (DRD) components
@@ -1054,7 +1054,7 @@ The following is the DMN source file for this decision model:
 == DMN support in {PRODUCT}
 
 [role="_abstract"]
-{PRODUCT} provides design and runtime support for DMN 1.2 models at conformance level 3, and runtime-only support for DMN 1.1 and 1.3 models at conformance level 3. You can design your DMN models with the {PRODUCT} DMN modeler in VSCode or import existing DMN models into your {PRODUCT} projects for deployment and execution. DMN 1.1 and 1.3 models are currently not supported in the {PRODUCT} DMN modeler.
+{PRODUCT} provides design and runtime support for DMN 1.2 models at conformance level 3, and runtime-only support for DMN 1.1 and 1.3 models at conformance level 3. You can design your DMN models with the {PRODUCT} DMN modeler in VSCode or import existing DMN models into your {PRODUCT} projects for deployment and execution. Any DMN 1.1 and 1.3 models, non including DMN 1.3 features, that you import into your {PRODUCT} project, open in the DMN modeler, and save are converted to DMN 1.2 models.
 
 In addition to all DMN conformance level 3 requirements, {PRODUCT} also includes enhancements and fixes to FEEL and DMN model components to optimize the experience of implementing DMN decision services with {PRODUCT}. From a platform perspective, DMN models are like any other business asset in {PRODUCT}, such as DRL files or spreadsheet decision tables, that you can include in your {PRODUCT} project and execute to start your DMN decision services.
 
@@ -1293,7 +1293,7 @@ endif::[]
 == Creating and editing DMN models in the {PRODUCT} DMN modeler
 
 [role="_abstract"]
-You can use the {PRODUCT} DMN modeler in VSCode to design DMN decision requirements diagrams (DRDs) and define decision logic for a complete and functional DMN decision model. {PRODUCT} provides design and runtime support for DMN 1.2 models at conformance level 3, and includes enhancements and fixes to FEEL and DMN model components to optimize the experience of implementing DMN decision services with {PRODUCT}. {PRODUCT} also provides runtime-only support for DMN 1.1 and 1.3 models at conformance level 3. DMN 1.1 and 1.3 models are currently not supported in the {PRODUCT} DMN modeler.
+You can use the {PRODUCT} DMN modeler in VSCode to design DMN decision requirements diagrams (DRDs) and define decision logic for a complete and functional DMN decision model. {PRODUCT} provides design and runtime support for DMN 1.2 models at conformance level 3, and includes enhancements and fixes to FEEL and DMN model components to optimize the experience of implementing DMN decision services with {PRODUCT}. {PRODUCT} also provides runtime-only support for DMN 1.1 and 1.3 models at conformance level 3. Any DMN 1.1 and 1.3 models, non including DMN 1.3 features, that you import into your {PRODUCT} project, open in the DMN modeler, and save are converted to DMN 1.2 models.
 
 .Prerequisites
 * https://code.visualstudio.com/[VSCode] 1.46.0 or later is installed.

--- a/doc-content/kogito-docs/src/main/asciidoc/release-notes/chap-kogito-release-notes.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/release-notes/chap-kogito-release-notes.adoc
@@ -73,6 +73,7 @@ For the complete list of new features, fixed issues, and known issues in {PRODUC
 ** {PRODUCT} GitHub Chrome extension for viewing graphical business models directly in GitHub, including model differences in GitHub pull requests
 ** Business Modeler desktop application for local modeling
 ** Business Modeler online viewer for online modeling
+** {PRODUCT} DMN modeler editor supports opening DMN 1.1, DMN 1.2, and DMN 1.3 models, and still saves any model as DMN 1.2
 
 [role="_additional-resources"]
 .Additional resources

--- a/doc-content/kogito-docs/src/main/asciidoc/release-notes/chap-kogito-release-notes.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/release-notes/chap-kogito-release-notes.adoc
@@ -73,7 +73,7 @@ For the complete list of new features, fixed issues, and known issues in {PRODUC
 ** {PRODUCT} GitHub Chrome extension for viewing graphical business models directly in GitHub, including model differences in GitHub pull requests
 ** Business Modeler desktop application for local modeling
 ** Business Modeler online viewer for online modeling
-** {PRODUCT} DMN modeler editor supports opening DMN 1.1, DMN 1.2, and DMN 1.3 models, and still saves any model as DMN 1.2
+** {PRODUCT} DMN editor supports opening DMN 1.1, DMN 1.2, and DMN 1.3 models and saves any model as DMN 1.2
 
 [role="_additional-resources"]
 .Additional resources

--- a/doc-content/kogito-docs/src/main/asciidoc/release-notes/enterprise/chap-kogito-release-notes-enterprise.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/release-notes/enterprise/chap-kogito-release-notes-enterprise.adoc
@@ -73,6 +73,7 @@ For the complete list of new features, fixed issues, and known issues in {PRODUC
 ** {PRODUCT} GitHub Chrome extension for viewing graphical business models directly in GitHub, including model differences in GitHub pull requests
 ** Business Modeler desktop application for local modeling
 ** Business Modeler online viewer for online modeling
+** {PRODUCT} DMN modeler editor supports opening DMN 1.1, DMN 1.2, and DMN 1.3 models, and still saves any model as DMN 1.2
 
 [role="_additional-resources"]
 .Additional resources

--- a/doc-content/kogito-docs/src/main/asciidoc/release-notes/enterprise/chap-kogito-release-notes-enterprise.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/release-notes/enterprise/chap-kogito-release-notes-enterprise.adoc
@@ -73,7 +73,7 @@ For the complete list of new features, fixed issues, and known issues in {PRODUC
 ** {PRODUCT} GitHub Chrome extension for viewing graphical business models directly in GitHub, including model differences in GitHub pull requests
 ** Business Modeler desktop application for local modeling
 ** Business Modeler online viewer for online modeling
-** {PRODUCT} DMN modeler editor supports opening DMN 1.1, DMN 1.2, and DMN 1.3 models, and still saves any model as DMN 1.2
+** {PRODUCT} DMN modeler editor supports opening DMN 1.1, DMN 1.2, and DMN 1.3 models and saves any model as DMN 1.2
 
 [role="_additional-resources"]
 .Additional resources


### PR DESCRIPTION
**JIRA**: [KOGITO-3807](https://issues.redhat.com/browse/KOGITO-3807): [DMN Designer] Convert DMN 1.1/1.3 models to version 1.2 - Documentation

Now the DMN Designer supports 1.1 and 1.3 models, non including DMN 1.3 features, when users that import assets on Kogito or Business Central . However, when users save their models, we're still saving them as DMN 1.2 models.

Thus, I've updated everything related to the DMN versions support, and also I've added an entry in the release notes section. Please, let me know if it needs any change :-)