### PR TITLE
Fixed product versions for creating projects for a Kogito service sections

### DIFF
--- a/doc-content/kogito-docs/src/main/asciidoc/creating-running/chap-kogito-creating-running.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/creating-running/chap-kogito-creating-running.adoc
@@ -418,7 +418,7 @@ $ mvn archetype:generate \
     -DarchetypeGroupId=org.kie.kogito \
     -DarchetypeArtifactId=kogito-quarkus-archetype \
     -DgroupId=org.acme -DartifactId=sample-kogito \
-    -DarchetypeVersion={PRODUCT_VERSION_LONG} \
+    -DarchetypeVersion={COMMUNITY_VERSION_FINAL} \
     -Dversion=1.0-SNAPSHOT
 ----
 ////
@@ -434,7 +434,7 @@ $ mvn archetype:generate \
     -DarchetypeGroupId=org.kie.kogito \
     -DarchetypeArtifactId=kogito-springboot-archetype \
     -DgroupId=org.acme -DartifactId=sample-kogito \
-    -DarchetypeVersion={PRODUCT_VERSION_LONG} \
+    -DarchetypeVersion={COMMUNITY_VERSION_FINAL} \
     -Dversion=1.0-SNAPSHOT
 ----
 
@@ -467,7 +467,7 @@ $ mvn archetype:generate \
     -DarchetypeGroupId=org.kie.kogito \
     -DarchetypeArtifactId=kogito-quarkus-archetype \
     -DgroupId=org.acme -DartifactId=sample-kogito \
-    -DarchetypeVersion={PRODUCT_VERSION_LONG} \
+    -DarchetypeVersion={COMMUNITY_VERSION_FINAL} \
     -Dversion=1.0-SNAPSHOT
 ----
 ////
@@ -483,7 +483,7 @@ $ mvn archetype:generate \
     -DarchetypeGroupId=org.kie.kogito \
     -DarchetypeArtifactId=kogito-springboot-archetype \
     -DgroupId=org.acme -DartifactId=sample-kogito \
-    -DarchetypeVersion={PRODUCT_VERSION_LONG} \
+    -DarchetypeVersion={COMMUNITY_VERSION_FINAL} \
     -Dversion=1.0-SNAPSHOT
 ----
 


### PR DESCRIPTION
@r00ta I have updated the product version at four places, available in the following sections:

2.3. Creating a Maven project for a Kogito service
2.3.1. Creating a custom Kogito project using code scaffolding

Please review the changes and let me know if the changes are fine. 
Following is the doc preview of the Kogito community document:
[Kogito community documentation](http://file.pnq.redhat.com/~hmanwani/BXMSDOC-KOGITO-Fixversion/#proc-kogito-creating-project_kogito-creating-running)