### PR TITLE
Upstream 7.48.x PR for BXMSDOC-7021: Added a note in DMN and PMML document indicating deprecation of kie-pmml 

### DIFF
--- a/doc-content/drools-docs/src/main/asciidoc/DMN/dmn-included-models-pmml-proc.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/DMN/dmn-included-models-pmml-proc.adoc
@@ -48,6 +48,19 @@ To access the project `pom.xml` file in {CENTRAL}, you can select any existing a
 If you want to use the full PMML specification implementation with the Java Evaluator API for PMML (JPMML), use the alternative set of JPMML dependencies in your DMN project. If the JPMML dependencies and the standard `kie-pmml` dependency are both present, the `kie-pmml` dependency is disabled. For information about JPMML licensing terms, see https://openscoring.io/[Openscoring.io].
 
 ifdef::DM,PAM[]
+[IMPORTANT]
+====
+The legacy `kie-pmml` dependency is deprecated with {PRODUCT} 7.10.0 and will be replaced by `kie-pmml-trusty` dependency in a future {PRODUCT} release.
+====
+endif::[]
+ifdef::DROOLS,JBPM,OP[]
+[IMPORTANT]
+====
+The legacy `kie-pmml` dependency is deprecated with {PRODUCT} 7.48.0 and will be replaced by `kie-pmml-trusty` dependency in a future {PRODUCT} release.
+====
+endif::[]
+
+ifdef::DM,PAM[]
 [NOTE]
 ====
 Instead of specifying a {PRODUCT} `<version>` for individual dependencies, consider adding the {PRODUCT_BA} bill of materials (BOM) dependency to your project `pom.xml` file. The {PRODUCT_BA} BOM applies to both {PRODUCT_DM} and {PRODUCT_PAM}. When you add the BOM files, the correct versions of transitive dependencies from the provided Maven repositories are included in the project.

--- a/doc-content/drools-docs/src/main/asciidoc/PMML/pmml-invocation-embedded-proc.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/PMML/pmml-invocation-embedded-proc.adoc
@@ -45,6 +45,19 @@ endif::[]
 The `<version>` is the Maven artifact version for {PRODUCT} currently used in your project (for example, {MAVEN_ARTIFACT_VERSION}).
 
 ifdef::DM,PAM[]
+[IMPORTANT]
+====
+The legacy `kie-pmml` dependency is deprecated with {PRODUCT} 7.10.0 and will be replaced by `kie-pmml-trusty` dependency in a future {PRODUCT} release.
+====
+endif::[]
+ifdef::DROOLS,JBPM,OP[]
+[IMPORTANT]
+====
+The legacy `kie-pmml` dependency is deprecated with {PRODUCT} 7.48.0 and will be replaced by `kie-pmml-trusty` dependency in a future {PRODUCT} release.
+====
+endif::[]
+
+ifdef::DM,PAM[]
 [NOTE]
 ====
 Instead of specifying a {PRODUCT} `<version>` for individual dependencies, consider adding the {PRODUCT_BA} bill of materials (BOM) dependency to your project `pom.xml` file. The {PRODUCT_BA} BOM applies to both {PRODUCT_DM} and {PRODUCT_PAM}. When you add the BOM files, the correct versions of transitive dependencies from the provided Maven repositories are included in the project.

--- a/doc-content/drools-docs/src/main/asciidoc/PMML/pmml-invocation-kie-server-proc.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/PMML/pmml-invocation-kie-server-proc.adoc
@@ -58,6 +58,19 @@ endif::[]
 The `<version>` is the Maven artifact version for {PRODUCT} currently used in your project (for example, {MAVEN_ARTIFACT_VERSION}).
 
 ifdef::DM,PAM[]
+[IMPORTANT]
+====
+The legacy `kie-pmml` dependency is deprecated with {PRODUCT} 7.10.0 and will be replaced by `kie-pmml-trusty` dependency in a future {PRODUCT} release.
+====
+endif::[]
+ifdef::DROOLS,JBPM,OP[]
+[IMPORTANT]
+====
+The legacy `kie-pmml` dependency is deprecated with {PRODUCT} 7.48.0 and will be replaced by `kie-pmml-trusty` dependency in a future {PRODUCT} release.
+====
+endif::[]
+
+ifdef::DM,PAM[]
 [NOTE]
 ====
 Instead of specifying a {PRODUCT} `<version>` for individual dependencies, consider adding the {PRODUCT_BA} bill of materials (BOM) dependency to your project `pom.xml` file. The {PRODUCT_BA} BOM applies to both {PRODUCT_DM} and {PRODUCT_PAM}. When you add the BOM files, the correct versions of transitive dependencies from the provided Maven repositories are included in the project.

--- a/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes-chapter.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes-chapter.adoc
@@ -6,6 +6,8 @@
 //include::ReleaseNotes/ReleaseNotesDrools.7.24.0.Final/ReleaseNotesDrools.7.24.0.Final-section.adoc[leveloffset=+1]
 //include::{shared-dir}/Workbench/ReleaseNotes/ReleaseNotesWorkbench.7.24.0.Final/ReleaseNotesWorkbench.7.24.0.Final-section.adoc[leveloffset=+1]
 
+include::ReleaseNotes/ReleaseNotesDrools.7.48.0.Final/ReleaseNotesDrools.7.48.0.Final-section.adoc[leveloffset=+1]
+
 include::ReleaseNotes/ReleaseNotesDrools.7.47.0.Final/ReleaseNotesDrools.7.47.0.Final-section.adoc[leveloffset=+1]
 include::{shared-dir}/Workbench/ReleaseNotes/ReleaseNotesWorkbench.7.47.0.Final/ReleaseNotesWorkbench.7.47.0.Final-section.adoc[leveloffset=+1]
 

--- a/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.7.48.0.Final/ReleaseNotesDrools.7.48.0.Final-section.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.7.48.0.Final/ReleaseNotesDrools.7.48.0.Final-section.adoc
@@ -1,0 +1,5 @@
+[id='drools.releasenotesdrools.7.48.0']
+
+= New and Noteworthy in {PRODUCT} 7.48.0
+
+include::drools-kie-pmml-deprecate.adoc[leveloffset=+1]

--- a/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.7.48.0.Final/drools-kie-pmml-deprecate.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.7.48.0.Final/drools-kie-pmml-deprecate.adoc
@@ -1,0 +1,4 @@
+[id='drools-kie-pmml-deprecate']
+
+== `kie-pmml` deprecation from {PRODUCT}
+The legacy `kie-pmml` dependency is deprecated with {PRODUCT} 7.48.0 and will be replaced by `kie-pmml-trusty` dependency in a future {PRODUCT} release.


### PR DESCRIPTION
Added a note indicating deprecation of kie-pmml dependency. See the following links:

**JIRA**: https://issues.redhat.com/browse/BXMSDOC-7021
**BAPL**-https://issues.redhat.com/browse/BAPL-1790

****Doc previews**
**RHPAM sections:****
[4.3.2. Including PMML models within a DMN file in Business Central](http://file.pnq.redhat.com/~hmanwani/BXMSDOC-7021-RHPAM/#dmn-included-models-pmml-proc_dmn-models)
[11.1. Embedding a PMML call directly in a Java application](http://file.pnq.redhat.com/~hmanwani/BXMSDOC-7021-RHPAM/#pmml-invocation-embedded-proc_pmml-models)
[11.2. Executing a PMML model using KIE server](http://file.pnq.redhat.com/~hmanwani/BXMSDOC-7021-RHPAM/#pmml-invocation-kie-server-proc_pmml-models)

**RHDM sections:**
[4.3.2. Including PMML models within a DMN file in Business Central](http://file.pnq.redhat.com/~hmanwani/BXMSDOC-7021-RHDM/#dmn-included-models-pmml-proc_dmn-models)
[11.1. Embedding a PMML call directly in a Java application](http://file.pnq.redhat.com/~hmanwani/BXMSDOC-7021-RHDM/#pmml-invocation-embedded-proc_pmml-models)
[11.2. Executing a PMML model using KIE server](http://file.pnq.redhat.com/~hmanwani/BXMSDOC-7021-RHDM/#pmml-invocation-kie-server-proc_pmml-models)

**Drools sections:**
[5.3.3.2. Including PMML models within a DMN file in Business Central](http://file.pnq.redhat.com/~hmanwani/BXMSDOC-7021-DROOLS/#dmn-included-models-pmml-proc_dmn-models)
[6.4.1. Embedding a PMML call directly in a Java application](http://file.pnq.redhat.com/~hmanwani/BXMSDOC-7021-DROOLS/#pmml-invocation-embedded-proc_pmml-models)
[6.4.2. Executing a PMML model using KIE Server](http://file.pnq.redhat.com/~hmanwani/BXMSDOC-7021-DROOLS/#pmml-invocation-kie-server-proc_pmml-models)
[Drools release note](http://file.pnq.redhat.com/~hmanwani/BXMSDOC-7021-DROOLS/#drools.releasenotesdrools.7.48.0)
