### PR TITLE
Upstream 7.48.x PR for BXMSDOC-7055: Single-source and add "Background instance in test scenarios" and "Exporting and importing test scenario spreadsheets"chapters in the upstream document.

### DIFF
--- a/_artifacts/document-attributes.adoc
+++ b/_artifacts/document-attributes.adoc
@@ -1,5 +1,6 @@
 
-:REBUILT: Thursday, November 05, 2020
+:REBUILT: Monday, January 18, 2021
+
 
 :ENTERPRISE_VERSION: 7.10
 :ENTERPRISE_VERSION_LONG: 7.10.0

--- a/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/TestScenarioEditor-section.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/TestScenarioEditor-section.adoc
@@ -13,19 +13,36 @@ include::test-designer-download-test-proc.adoc[leveloffset=+2]
 include::test-designer-latest-version-test-proc.adoc[leveloffset=+2]
 include::test-designer-view-hide-alerts-con.adoc[leveloffset=+2]
 include::test-designer-contextual-menu-ref.adoc[leveloffset=+2]
+
 include::test-designer-create-test-scenario-template-con.adoc[leveloffset=+1]
 include::test-designer-create-test-template-rule-based-proc.adoc[leveloffset=+2]
 include::test-designer-alias-proc.adoc[leveloffset=+2]
+
 include::test-designer-test-template-dmn-based-con.adoc[leveloffset=+1]
 include::test-designer-create-test-template-dmn-based-proc.adoc[leveloffset=+2]
+
 include::test-designer-test-scenario-definition-proc.adoc[leveloffset=+1]
+
+include::test-scenarios-background-instance-con.adoc[leveloffset=+1]
+include::test-scenarios-background-rule-based-proc.adoc[leveloffset=+2]
+include::test-scenarios-background-dmn-based-proc.adoc[leveloffset=+2]
+
 include::test-designer-list-map-add-remove-item-proc.adoc[leveloffset=+1]
+
 include::test-designer-expressions-syntax-intro-ref.adoc[leveloffset=+1]
 include::test-designer-expressions-syntax-rule-based-ref.adoc[leveloffset=+2]
 include::test-designer-expressions-syntax-dmn-based-ref.adoc[leveloffset=+2]
+
 include::test-designer-run-test-proc.adoc[leveloffset=+1]
+
 include::test-scenarios-running-locally-proc.adoc[leveloffset=+1]
+
+include::test-designer-test-scenario-export-import-spreadsheet-con.adoc[leveloffset=+1]
+include::test-designer-test-scenario-export-spreadsheet-proc.adoc[leveloffset=+2]
+include::test-designer-test-scenario-import-spreadsheet-proc.adoc[leveloffset=+2]
+
 include::test-designer-create-mortgages-example-proc.adoc[leveloffset=+1]
+
 include::test-scenarios-comparison-legacy-new-ref.adoc[leveloffset=+1]
 
 // Test Scenarios (Legacy) designer files

--- a/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/test-scenarios-comparison-legacy-new-ref.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/test-scenarios-comparison-legacy-new-ref.adoc
@@ -14,7 +14,7 @@ The following table highlights the main features of legacy and new test scenario
 * `-` indicates that the feature is not present in the test scenario designer.
 
 .Main features of legacy and new test scenario designer
-[cols="40%,10%,10%,40%", options="header"]
+[cols="40%,20%,20%,40%", options="header"]
 |===
 |Feature & highlights
 |New designer


### PR DESCRIPTION
I am currently updating and single-sourcing the upstream community test scenario content.

Assessment for the test scenario upstream-downstream in done in the [BXMSDOC-7052](https://issues.redhat.com/browse/BXMSDOC-7052) JIRA.
For more information, you can refer to the [Single-sourcing planning and tracking sheet](https://docs.google.com/spreadsheets/d/1FjRjaujiY2yxV0-GI6o39Mu-v24KVpJ3u81ojKLk86U/edit#gid=2135630892)

Following chapters were only present in the enterprise doc. In this JIRA I have included these chapters in the Drools upstream community doc as well.

[Enterprise RHPAM document preview](https://access.redhat.com/documentation/en-us/red_hat_process_automation_manager/7.9/html-single/developing_decision_services_in_red_hat_process_automation_manager/index#test-scenarios-background-instance-con)

- Chapter 65. Background instance in test scenarios
- Chapter 70. Exporting and importing test scenario spreadsheets

**Document previews:**

[Drools community document](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-7055-Drools-TestScenario/#test-scenarios-background-instance-con)

Please check the following chapters:
- 15.12.5. Background instance in test scenarios
- 15.12.10. Exporting and importing test scenario spreadsheets