### PR TITLE
BXMSDOC-7142-master: Add table for DMN version support.

### DIFF
--- a/doc-content/drools-docs/src/main/asciidoc/DMN/dmn-support-con.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/DMN/dmn-support-con.adoc
@@ -7,6 +7,35 @@
 * Import DMN files into your project in {CENTRAL} (*Menu -> Design -> Projects -> Import Asset*). Any DMN 1.1 and 1.3 models (do not contain DMN 1.3 features) that you import into {CENTRAL}, open in the DMN designer, and save are converted to DMN 1.2 models.
 * Package DMN files as part of your project knowledge JAR (KJAR) file without {CENTRAL}.
 
+The following table summarizes the design and runtime support for each DMN version in {PRODUCT}:
+
+.DMN support in {PRODUCT}
+[cols="25%,25%,25%,25%"]
+|===
+.2+h|DMN version
+1+h|DMN engine support
+2+h|DMN modeler support
+
+h|Execution
+h|Open
+h|Save
+
+|DMN 1.1
+|image:BPMN2/grn_check.png[]
+|image:BPMN2/grn_check.png[]
+|image:BPMN2/bk_x.png[]
+
+|DMN 1.2
+|image:BPMN2/grn_check.png[]
+|image:BPMN2/grn_check.png[]
+|image:BPMN2/grn_check.png[]
+
+|DMN 1.3
+|image:BPMN2/grn_check.png[]
+|image:BPMN2/bk_x.png[]
+|image:BPMN2/bk_x.png[]
+|===
+
 In addition to all DMN conformance level 3 requirements, {PRODUCT} also includes enhancements and fixes to FEEL and DMN model components to optimize the experience of implementing DMN decision services with {PRODUCT}. From a platform perspective, DMN models are like any other business asset in {PRODUCT}, such as DRL files or spreadsheet decision tables, that you can include in your {PRODUCT} project and deploy to {KIE_SERVER} in order to start your DMN decision services.
 
 For more information about including external DMN files with your {PRODUCT} project packaging and deployment method, see

--- a/doc-content/drools-docs/src/main/asciidoc/DMN/dmn-support-con.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/DMN/dmn-support-con.adoc
@@ -32,7 +32,7 @@ h|Save
 
 |DMN 1.3
 |image:BPMN2/grn_check.png[]
-|image:BPMN2/bk_x.png[]
+|image:BPMN2/grn_check.png[]
 |image:BPMN2/bk_x.png[]
 |===
 


### PR DESCRIPTION
@tarilabs , @karreiro , @jomarko , @hmanwani-rh , would you mind verifying this new table on DMN version support? The request came from Rachid Snoussi on the Kogito side but it applies to DM/PAM the same. Matteo shared a quick table in the email thread that was actually very helpful, so we agreed that adding something like it in the docs would alone clarify things.

Side note: We're aware of the table header formatting issues/inconsistencies. It's a tooling issue where things look different in asciidoco vs. local enterprise build vs. customer portal enterprise build.

Links:
* [Jira](https://issues.redhat.com/browse/BXMSDOC-7142)
* [Enterprise rendered doc](http://file.rdu.redhat.com/~sterobin/BXMSDOC-7142_PAM/#dmn-support-con_dmn-models)
* [Community rendered doc](http://file.rdu.redhat.com/~sterobin/BXMSDOC-7142_DROOLS/#dmn-support-con_dmn-models)
* [Kogito rendered doc](http://file.rdu.redhat.com/~sterobin/BXMSDOC-7142_KOG/#con-dmn-support_kogito-dmn-models)