### PR TITLE
[KOGITO-4210] Quarkus apps must have health extension

### DIFF
--- a/doc-content/kogito-docs/src/main/asciidoc/creating-running/chap-kogito-creating-running.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/creating-running/chap-kogito-creating-running.adoc
@@ -579,20 +579,6 @@ $ mvn archetype:generate \
     -Dversion=1.0-SNAPSHOT
 ----
 
-If you are planning to run your application on OpenShift or Kubernetes, you must also import the https://quarkus.io/guides/microprofile-health[Quarkus `smallrye-health` extension] for the https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes[liveness/readiness probes]. This can be done by running the following command in your project base directory:
-----
-mvn quarkus:add-extension -Dextensions="smallrye-health"
-----
-
-This will add the following to your `pom.xml`:
-[source,xml]
-----
-<dependency>
-    <groupId>io.quarkus</groupId>
-    <artifactId>quarkus-smallrye-health</artifactId>
-</dependency>
-----
-
 ////
 @comment: The following standard command for Quarkus isn't working currently but may be restored for Dev Preview
 
@@ -611,6 +597,25 @@ $ mvn archetype:generate \
 ----
 
 This command generates a `sample-kogito` Maven project and imports the {PRODUCT} extension for all required dependencies and configurations to prepare your application for business automation.
+
+On Quarkus, if you plan to run your application on OpenShift or Kubernetes, you must also import the https://quarkus.io/guides/microprofile-health[Quarkus `smallrye-health` extension] for the https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes[liveness, readiness, and startup probes], as shown in the following example:
+
+.SmallRye Health extension for Quarkus applications on OpenShift
+[source]
+----
+$ mvn quarkus:add-extension -Dextensions="smallrye-health"
+----
+
+This command generates the following dependency in the `pom.xml` file of your {PRODUCT} project on Quarkus:
+
+.SmallRye Heath dependency for Quarkus applications on OpenShift
+[source,xml]
+----
+<dependency>
+  <groupId>io.quarkus</groupId>
+  <artifactId>quarkus-smallrye-health</artifactId>
+</dependency>
+----
 --
 . Open or import the project in your VSCode IDE to view the contents.
 

--- a/doc-content/kogito-docs/src/main/asciidoc/creating-running/chap-kogito-creating-running.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/creating-running/chap-kogito-creating-running.adoc
@@ -598,7 +598,7 @@ $ mvn archetype:generate \
 
 This command generates a `sample-kogito` Maven project and imports the {PRODUCT} extension for all required dependencies and configurations to prepare your application for business automation.
 
-On Quarkus, if you plan to run your application on OpenShift or Kubernetes, you must also import the https://quarkus.io/guides/microprofile-health[Quarkus `smallrye-health` extension] for the https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes[liveness, readiness, and startup probes], as shown in the following example:
+On Quarkus, if you plan to run your application on OpenShift or Kubernetes, you must also import the https://quarkus.io/guides/microprofile-health[Quarkus `smallrye-health` extension] for the https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes[liveness and readiness probes], as shown in the following example:
 
 .SmallRye Health extension for Quarkus applications on OpenShift
 [source]

--- a/doc-content/kogito-docs/src/main/asciidoc/creating-running/chap-kogito-creating-running.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/creating-running/chap-kogito-creating-running.adoc
@@ -579,9 +579,9 @@ $ mvn archetype:generate \
     -Dversion=1.0-SNAPSHOT
 ----
 
-If you are planning to run your application on OpenShift or Kubernetes, you must also import the https://quarkus.io/guides/microprofile-health[Quarkus `smallrye-health` extension] to pass the https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes[liveness/readiness checks]. This can be done by running the following command in your project base directory:
+If you are planning to run your application on OpenShift or Kubernetes, you must also import the https://quarkus.io/guides/microprofile-health[Quarkus `smallrye-health` extension] for the https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes[liveness/readiness probes]. This can be done by running the following command in your project base directory:
 ----
-mvnw quarkus:add-extension -Dextensions="smallrye-health"
+mvn quarkus:add-extension -Dextensions="smallrye-health"
 ----
 
 This will add the following to your `pom.xml`:

--- a/doc-content/kogito-docs/src/main/asciidoc/creating-running/chap-kogito-creating-running.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/creating-running/chap-kogito-creating-running.adoc
@@ -578,6 +578,21 @@ $ mvn archetype:generate \
     -DarchetypeVersion={COMMUNITY_VERSION_FINAL} \
     -Dversion=1.0-SNAPSHOT
 ----
+
+If you are planning to run your application on OpenShift or Kubernetes, you must also import the https://quarkus.io/guides/microprofile-health[Quarkus `smallrye-health` extension] to pass the https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes[liveness/readiness checks]. This can be done by running the following command in your project base directory:
+----
+mvnw quarkus:add-extension -Dextensions="smallrye-health"
+----
+
+This will add the following to your `pom.xml`:
+[source,xml]
+----
+<dependency>
+    <groupId>io.quarkus</groupId>
+    <artifactId>quarkus-smallrye-health</artifactId>
+</dependency>
+----
+
 ////
 @comment: The following standard command for Quarkus isn't working currently but may be restored for Dev Preview
 

--- a/doc-content/kogito-docs/src/main/asciidoc/openshift/chap-kogito-deploying-on-openshift.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/openshift/chap-kogito-deploying-on-openshift.adoc
@@ -23,11 +23,27 @@ To help you deploy your services on OpenShift, {PRODUCT} provides an operator an
 * *{PRODUCT} Operator*: An operator that guides you through the deployment process. The {PRODUCT} Operator is based on the https://sdk.operatorframework.io/[Operator SDK] and automates many of the deployment steps for you. For example, when you give the operator a link to the Git repository that contains your application, the operator can automatically configure the components required to build your project from source and deploy the resulting services.
 * *{PRODUCT} command-line interface (CLI)*: A CLI tool that enables you to interact with the {PRODUCT} Operator for deployment tasks. The {PRODUCT} CLI also enables you to deploy {PRODUCT} services from source instead of relying on custom resources and YAML files. You can use the {PRODUCT} CLI as a command-line alternative for deploying {PRODUCT} services without the {OPENSHIFT} web console.
 
-[id="proc-kogito-setting-up-probes_{context}"]
-== Setting up {PRODUCT} probes
+[id="proc-kogito-enabling-probes_{context}"]
+== Enabling probes for Quarkus-based {PRODUCT} services on OpenShift
 
 [role="_abstract"]
-On OpenShift/Kubernetes, https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes[probes] are used to check whether an application is ready and working or needs to be restarted. For {PRODUCT} services running on the Spring Boot framework, a TCP socket is used for the probe, defaulting to port 8080. For {PRODUCT} services running on Quarkus, a HTTP reqest is used. Typically, the endpoint used for this request would be `/q/health`, which is exposed by the https://quarkus.io/guides/microprofile-health[Quarkus `smallrye-health` extension]. *The {PRODUCT} Operator expects {PRODUCT} services running on Quarkus to have this extension imported.* Refer to {URL_CONFIGURING_KOGITO}#proc-kogito-creating-project_kogito-creating-running[Creating a Maven project for a {PRODUCT} service] for instructions on how to import the extension. If you would like to set up your own custom endpoints for the liveness/readiness probes, you can do so in your `KogitoRuntime` YAML like so:
+On OpenShift and Kubernetes, https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes[liveness, readiness, and startup probes] check whether an application is ready and working or needs to be restarted. For {PRODUCT} services on Spring Boot, probes communicate with the application through a TCP socket, defaulting to port 8080. For {PRODUCT} services on Quarkus, probes communicate with the application through an HTTP request, typically using the endpoint `/q/health`. This endpoint is exposed by the https://quarkus.io/guides/microprofile-health[Quarkus `smallrye-health` extension], which is required for all Quarkus-based {PRODUCT} services on OpenShift or Kubernetes.
+
+Therefore, to run your Quarkus-based {PRODUCT} services on OpenShift or Kubernetes, you must import the Quarkus `smallrye-health` extension in order to enable the liveness, readiness, and startup probes for your application.
+
+.Procedure
+In a command terminal, navigate to the `pom.xml` file of your {PRODUCT} project and add the following dependency for the `smallrye-health` extension:
+
+.SmallRye Heath dependency for Quarkus applications on OpenShift
+[source,xml]
+----
+<dependency>
+  <groupId>io.quarkus</groupId>
+  <artifactId>quarkus-smallrye-health</artifactId>
+</dependency>
+----
+
+Alternatively, if you want to configure custom endpoints for the liveness, readiness, and startup probes, you can define the probes in the `KogitoRuntime` YAML file of your {PRODUCT} project, as shown in the following example:
 
 [source,yaml,subs="attributes+"]
 .Example {PRODUCT} service custom resource with custom probe endpoints
@@ -58,6 +74,16 @@ After you create your {PRODUCT} services as part of a business application, you 
 .Prerequisites
 * The application with your {PRODUCT} services is in a Git repository that is reachable from your OpenShift environment.
 * You have access to the OpenShift web console with `cluster-admin` permissions.
+* (Quarkus only) The `pom.xml` file of your {PRODUCT} project contains the following dependency for the https://quarkus.io/guides/microprofile-health[Quarkus `smallrye-health` extension]. This extension enables the https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes[liveness, readiness, and startup probes] that are required for Quarkus-based projects on OpenShift or Kubernetes.
++
+.SmallRye Heath dependency for Quarkus applications on OpenShift
+[source,xml]
+----
+<dependency>
+  <groupId>io.quarkus</groupId>
+  <artifactId>quarkus-smallrye-health</artifactId>
+</dependency>
+----
 
 .Procedure
 . In the OpenShift web console, go to *Operators* -> *OperatorHub* in the left menu, search for and select *Kogito*, and follow the on-screen instructions to install the latest operator version.
@@ -195,6 +221,16 @@ ifdef::KOGITO-COMM[]
 https://docs.openshift.com/container-platform/4.2/cli_reference/openshift_cli/getting-started-cli.html[OpenShift documentation].
 endif::[]
 * You have OpenShift permissions to create resources in a specified namespace.
+* (Quarkus only) The `pom.xml` file of your {PRODUCT} project contains the following dependency for the https://quarkus.io/guides/microprofile-health[Quarkus `smallrye-health` extension]. This extension enables the https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes[liveness, readiness, and startup probes] that are required for Quarkus-based projects on OpenShift or Kubernetes.
++
+.SmallRye Heath dependency for Quarkus applications on OpenShift
+[source,xml]
+----
+<dependency>
+  <groupId>io.quarkus</groupId>
+  <artifactId>quarkus-smallrye-health</artifactId>
+</dependency>
+----
 
 .Procedure
 . Go to the https://github.com/kiegroup/kogito-cloud-operator/releases[`{PRODUCT_INIT}-cloud-operator`] releases page in GitHub and download the latest version of the `{PRODUCT_INIT}-cli-_RELEASE_` binary file that is specific to your operating system.
@@ -315,6 +351,16 @@ endif::[]
 * Git is installed.
 * JDK 11 or later is installed. (https://www.graalvm.org/[GraalVM] is recommended.)
 * Apache Maven 3.6.2 or later is installed.
+* (Quarkus only) The `pom.xml` file of your {PRODUCT} project contains the following dependency for the https://quarkus.io/guides/microprofile-health[Quarkus `smallrye-health` extension]. This extension enables the https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes[liveness, readiness, and startup probes] that are required for Quarkus-based projects on OpenShift or Kubernetes.
++
+.SmallRye Heath dependency for Quarkus applications on OpenShift
+[source,xml]
+----
+<dependency>
+  <groupId>io.quarkus</groupId>
+  <artifactId>quarkus-smallrye-health</artifactId>
+</dependency>
+----
 
 [id="proc-kogito-travel-agency-clone-repo_{context}"]
 === Cloning the {PRODUCT} examples Git repository
@@ -2176,7 +2222,7 @@ The metrics exposed by the {PRODUCT} service appear in the *Graph* view:
 .Graph view in Prometheus web console
 image::kogito/openshift/kogito-operator-prometheus-graph.png[Image of Kogito service graph view in Prometheus]
 
-The {PRODUCT} Operator also creates a `GrafanaDashboard` custom resource defined by the https://operatorhub.io/operator/grafana-operator[Grafana Operator] for each of the Grafana dashboards generated by the add-on. The `app` label for the dashboards is the name of the deployed {PRODUCT} service. You must set the `dashboardLabelSelector` property of the `Grafana` custom resource according to the relevant {PRODUCT} service. 
+The {PRODUCT} Operator also creates a `GrafanaDashboard` custom resource defined by the https://operatorhub.io/operator/grafana-operator[Grafana Operator] for each of the Grafana dashboards generated by the add-on. The `app` label for the dashboards is the name of the deployed {PRODUCT} service. You must set the `dashboardLabelSelector` property of the `Grafana` custom resource according to the relevant {PRODUCT} service.
 
 .Example `Grafana` resource
 [source,yaml]

--- a/doc-content/kogito-docs/src/main/asciidoc/openshift/chap-kogito-deploying-on-openshift.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/openshift/chap-kogito-deploying-on-openshift.adoc
@@ -27,9 +27,9 @@ To help you deploy your services on OpenShift, {PRODUCT} provides an operator an
 == Enabling probes for Quarkus-based {PRODUCT} services on OpenShift
 
 [role="_abstract"]
-On OpenShift and Kubernetes, https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes[liveness, readiness, and startup probes] check whether an application is ready and working or needs to be restarted. For {PRODUCT} services on Spring Boot, probes communicate with the application through a TCP socket, defaulting to port 8080. For {PRODUCT} services on Quarkus, probes communicate with the application through an HTTP request, typically using the endpoint `/q/health`. This endpoint is exposed by the https://quarkus.io/guides/microprofile-health[Quarkus `smallrye-health` extension], which is required for all Quarkus-based {PRODUCT} services on OpenShift or Kubernetes.
+On OpenShift and Kubernetes, https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes[liveness and readiness probes] check whether an application is ready and working or needs to be restarted. For {PRODUCT} services on Spring Boot, probes communicate with the application through a TCP socket, defaulting to port 8080. For {PRODUCT} services on Quarkus, probes communicate with the application through an HTTP request, typically using the endpoint `/q/health`. This endpoint is exposed by the https://quarkus.io/guides/microprofile-health[Quarkus `smallrye-health` extension], which is required for all Quarkus-based {PRODUCT} services on OpenShift or Kubernetes.
 
-Therefore, to run your Quarkus-based {PRODUCT} services on OpenShift or Kubernetes, you must import the Quarkus `smallrye-health` extension in order to enable the liveness, readiness, and startup probes for your application.
+Therefore, to run your Quarkus-based {PRODUCT} services on OpenShift or Kubernetes, you must import the Quarkus `smallrye-health` extension in order to enable the liveness and readiness probes for your application.
 
 .Procedure
 In a command terminal, navigate to the `pom.xml` file of your {PRODUCT} project and add the following dependency for the `smallrye-health` extension:
@@ -43,7 +43,7 @@ In a command terminal, navigate to the `pom.xml` file of your {PRODUCT} project 
 </dependency>
 ----
 
-Alternatively, if you want to configure custom endpoints for the liveness, readiness, and startup probes, you can define the probes in the `KogitoRuntime` YAML file of your {PRODUCT} project, as shown in the following example:
+Alternatively, if you want to configure custom endpoints for the liveness and readiness probes, you can define the probes in the `KogitoRuntime` YAML file of your {PRODUCT} project, as shown in the following example:
 
 [source,yaml,subs="attributes+"]
 .Example {PRODUCT} service custom resource with custom probe endpoints
@@ -74,7 +74,7 @@ After you create your {PRODUCT} services as part of a business application, you 
 .Prerequisites
 * The application with your {PRODUCT} services is in a Git repository that is reachable from your OpenShift environment.
 * You have access to the OpenShift web console with `cluster-admin` permissions.
-* (Quarkus only) The `pom.xml` file of your {PRODUCT} project contains the following dependency for the https://quarkus.io/guides/microprofile-health[Quarkus `smallrye-health` extension]. This extension enables the https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes[liveness, readiness, and startup probes] that are required for Quarkus-based projects on OpenShift or Kubernetes.
+* (Quarkus only) The `pom.xml` file of your {PRODUCT} project contains the following dependency for the https://quarkus.io/guides/microprofile-health[Quarkus `smallrye-health` extension]. This extension enables the https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes[liveness and readiness probes] that are required for Quarkus-based projects on OpenShift or Kubernetes.
 +
 .SmallRye Heath dependency for Quarkus applications on OpenShift
 [source,xml]
@@ -221,7 +221,7 @@ ifdef::KOGITO-COMM[]
 https://docs.openshift.com/container-platform/4.2/cli_reference/openshift_cli/getting-started-cli.html[OpenShift documentation].
 endif::[]
 * You have OpenShift permissions to create resources in a specified namespace.
-* (Quarkus only) The `pom.xml` file of your {PRODUCT} project contains the following dependency for the https://quarkus.io/guides/microprofile-health[Quarkus `smallrye-health` extension]. This extension enables the https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes[liveness, readiness, and startup probes] that are required for Quarkus-based projects on OpenShift or Kubernetes.
+* (Quarkus only) The `pom.xml` file of your {PRODUCT} project contains the following dependency for the https://quarkus.io/guides/microprofile-health[Quarkus `smallrye-health` extension]. This extension enables the https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes[liveness and readiness probes] that are required for Quarkus-based projects on OpenShift or Kubernetes.
 +
 .SmallRye Heath dependency for Quarkus applications on OpenShift
 [source,xml]
@@ -351,7 +351,7 @@ endif::[]
 * Git is installed.
 * JDK 11 or later is installed. (https://www.graalvm.org/[GraalVM] is recommended.)
 * Apache Maven 3.6.2 or later is installed.
-* (Quarkus only) The `pom.xml` file of your {PRODUCT} project contains the following dependency for the https://quarkus.io/guides/microprofile-health[Quarkus `smallrye-health` extension]. This extension enables the https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes[liveness, readiness, and startup probes] that are required for Quarkus-based projects on OpenShift or Kubernetes.
+* (Quarkus only) The `pom.xml` file of your {PRODUCT} project contains the following dependency for the https://quarkus.io/guides/microprofile-health[Quarkus `smallrye-health` extension]. This extension enables the https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes[liveness and readiness probes] that are required for Quarkus-based projects on OpenShift or Kubernetes.
 +
 .SmallRye Heath dependency for Quarkus applications on OpenShift
 [source,xml]

--- a/doc-content/kogito-docs/src/main/asciidoc/openshift/chap-kogito-deploying-on-openshift.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/openshift/chap-kogito-deploying-on-openshift.adoc
@@ -31,6 +31,7 @@ After you create your {PRODUCT} services as part of a business application, you 
 
 .Prerequisites
 * The application with your {PRODUCT} services is in a Git repository that is reachable from your OpenShift environment.
+** If the {PRODUCT} services run on the Quarkus framework, then they must have the https://quarkus.io/guides/microprofile-health[Quarkus `smallrye-health` extension] imported. See {URL_CONFIGURING_KOGITO}#proc-kogito-creating-project_kogito-creating-running[Creating a Maven project for a {PRODUCT} service] on how to import the extension.
 * You have access to the OpenShift web console with `cluster-admin` permissions.
 
 .Procedure

--- a/doc-content/kogito-docs/src/main/asciidoc/openshift/chap-kogito-deploying-on-openshift.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/openshift/chap-kogito-deploying-on-openshift.adoc
@@ -31,6 +31,8 @@ On OpenShift and Kubernetes, https://kubernetes.io/docs/tasks/configure-pod-cont
 
 Therefore, to run your Quarkus-based {PRODUCT} services on OpenShift or Kubernetes, you must import the Quarkus `smallrye-health` extension in order to enable the liveness and readiness probes for your application.
 
+NOTE: The {PRODUCT} Operator currently does not support startup probes.
+
 .Procedure
 In a command terminal, navigate to the `pom.xml` file of your {PRODUCT} project and add the following dependency for the `smallrye-health` extension:
 

--- a/doc-content/kogito-docs/src/main/asciidoc/openshift/chap-kogito-deploying-on-openshift.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/openshift/chap-kogito-deploying-on-openshift.adoc
@@ -23,6 +23,32 @@ To help you deploy your services on OpenShift, {PRODUCT} provides an operator an
 * *{PRODUCT} Operator*: An operator that guides you through the deployment process. The {PRODUCT} Operator is based on the https://sdk.operatorframework.io/[Operator SDK] and automates many of the deployment steps for you. For example, when you give the operator a link to the Git repository that contains your application, the operator can automatically configure the components required to build your project from source and deploy the resulting services.
 * *{PRODUCT} command-line interface (CLI)*: A CLI tool that enables you to interact with the {PRODUCT} Operator for deployment tasks. The {PRODUCT} CLI also enables you to deploy {PRODUCT} services from source instead of relying on custom resources and YAML files. You can use the {PRODUCT} CLI as a command-line alternative for deploying {PRODUCT} services without the {OPENSHIFT} web console.
 
+[id="proc-kogito-setting-up-probes_{context}"]
+== Setting up {PRODUCT} probes
+
+[role="_abstract"]
+On OpenShift/Kubernetes, https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes[probes] are used to check whether an application is ready and working or needs to be restarted. For {PRODUCT} services running on the Spring Boot framework, a TCP socket is used for the probe, defaulting to port 8080. For {PRODUCT} services running on Quarkus, a HTTP reqest is used. Typically, the endpoint used for this request would be `/q/health`, which is exposed by the https://quarkus.io/guides/microprofile-health[Quarkus `smallrye-health` extension]. *The {PRODUCT} Operator expects {PRODUCT} services running on Quarkus to have this extension imported.* Refer to {URL_CONFIGURING_KOGITO}#proc-kogito-creating-project_kogito-creating-running[Creating a Maven project for a {PRODUCT} service] for instructions on how to import the extension. If you would like to set up your own custom endpoints for the liveness/readiness probes, you can do so in your `KogitoRuntime` YAML like so:
+
+[source,yaml,subs="attributes+"]
+.Example {PRODUCT} service custom resource with custom probe endpoints
+----
+apiVersion: app.kiegroup.org/v1beta1 # Kogito API for this service
+kind: KogitoRuntime
+metadata:
+  name: process-quarkus-example # Application name
+spec:
+  replicas: 1
+  probes:
+    livenessProbe:
+      httpGet:
+        path: /probes/live # Liveness endpoint
+        port: 8080
+    readinessProbe:
+      httpGet:
+        path: /probes/ready # Readiness endpoint
+        port: 8080
+----
+
 [id="proc-kogito-deploying-on-ocp-console_{context}"]
 == Deploying {PRODUCT} services on OpenShift using the OpenShift web console
 
@@ -31,7 +57,6 @@ After you create your {PRODUCT} services as part of a business application, you 
 
 .Prerequisites
 * The application with your {PRODUCT} services is in a Git repository that is reachable from your OpenShift environment.
-** If the {PRODUCT} services run on the Quarkus framework, then they must have the https://quarkus.io/guides/microprofile-health[Quarkus `smallrye-health` extension] imported. See {URL_CONFIGURING_KOGITO}#proc-kogito-creating-project_kogito-creating-running[Creating a Maven project for a {PRODUCT} service] on how to import the extension.
 * You have access to the OpenShift web console with `cluster-admin` permissions.
 
 .Procedure


### PR DESCRIPTION
See: https://issues.redhat.com/browse/KOGITO-4210

With [this PR](https://github.com/kiegroup/kogito-cloud-operator/pull/733), the operator now expects that Quarkus applications have [the health extension](https://quarkus.io/guides/microprofile-health) imported. This is now clarified in the docs when setting up an example project and in the OpenShift section. I also added information about to set custom endpoints for probes.

[Stetson] Do not merge: For 1.3 and pending above PR.
