### PR TITLE
Upstream master PR for BXMSDOC-7191: Added a statement for compensation event

### DIFF
--- a/doc-content/jbpm-docs/src/main/asciidoc/BPMN2/bpmn-intermediate-events-ref.adoc
+++ b/doc-content/jbpm-docs/src/main/asciidoc/BPMN2/bpmn-intermediate-events-ref.adoc
@@ -1,7 +1,7 @@
 [id='bpmn-intermediate-events-ref_{context}']
 
 = Intermediate events
-Intermediate events drive the flow of a business process. Intermediate events are used to either catch or throw an event during the execution of the business process. These events are placed between the start and end events and can also be used on the boundary of an activity, like a subprocess or a human task, as a catch event. In the BPMN modeler, you can set a data output in the *Data Output and Assignments* field for a boundary event, which is used in a further process to access the process instance details.
+Intermediate events drive the flow of a business process. Intermediate events are used to either catch or throw an event during the execution of the business process. These events are placed between the start and end events and can also be used on the boundary of an activity, like a subprocess or a human task, as a catch event. In the BPMN modeler, you can set a data output in the *Data Output and Assignments* field for a boundary event, which is used in a further process to access the process instance details. Note that the compensation events do not support the feature of setting a data output variable.
 
 For example, you can set the following data output variables for a boundary event:
 


### PR DESCRIPTION
See JIRA: https://issues.redhat.com/browse/BXMSDOC-7191

Doc previews:
Enterprise
**Designing business processes using BPMN models**
Added a note stating compensation not supporting data output feature in [4.2.2. Intermediate events section](http://file.pnq.redhat.com/~hmanwani/BXMSDOC-7191-BPMN-RHPAM/#bpmn-intermediate-events-ref_business-processes).

Community
**JBPM documentation**
Added a note stating compensation not supporting data output feature in [10.6.2. Intermediate events](http://file.pnq.redhat.com/~hmanwani/BXMSDOC-7191-JBPM/#bpmn-intermediate-events-ref_business-processes) section.