### PR TITLE
Fixing entreprise docs: Support for catching and throwing Link Events

### DIFF
--- a/doc-content/enterprise-only/bpmn/bpmn-support-con.adoc
+++ b/doc-content/enterprise-only/bpmn/bpmn-support-con.adoc
@@ -34,7 +34,7 @@ a|Escalation       | image:BPMN2/grn_check.png[]   | image:BPMN2/grn_check.png[]
 a|Cancel           |         | image:BPMN2/bk_x.png[]
 a|Compensation     | image:BPMN2/grn_check.png[]     | image:BPMN2/grn_check.png[]
 a|Conditional      | image:BPMN2/grn_check.png[]     | image:BPMN2/grn_check.png[]
-a|Link             |        | image:BPMN2/bk_x.png[]
+a|Link             |        | image:BPMN2/grn_check.png[]
 a|Signal           | image:BPMN2/grn_check.png[]     | image:BPMN2/grn_check.png[]
 a|Multiple         | image:BPMN2/bk_x.png[]      | image:BPMN2/bk_x.png[]
 a|Parallel Multiple  | image:BPMN2/bk_x.png[]     | image:BPMN2/bk_x.png[]
@@ -62,7 +62,7 @@ a|Escalation       | image:BPMN2/grn_check.png[]   | image:BPMN2/grn_check.png[]
 a|Cancel           | image:BPMN2/bk_x.png[]        | image:BPMN2/bk_x.png[]        |                             | image:BPMN2/bk_x.png[]
 a|Compensation     | image:BPMN2/grn_check.png[]   | image:BPMN2/grn_check.png[]   |                             |
 a|Conditional      |                               |                               | image:BPMN2/grn_check.png[]  | image:BPMN2/grn_check.png[]
-a|Link             |                               | image:BPMN2/bk_x.png[]        |                             |
+a|Link             |                               | image:BPMN2/grn_check.png[]        |                             |
 a|Signal           | image:BPMN2/grn_check.png[]   | image:BPMN2/grn_check.png[]   | image:BPMN2/grn_check.png[]  | image:BPMN2/grn_check.png[]
 a|Terminate        | image:BPMN2/grn_check.png[]   |                               |                             |
 a|Multiple         | image:BPMN2/bk_x.png[]        | image:BPMN2/bk_x.png[]        | image:BPMN2/bk_x.png[]      | image:BPMN2/bk_x.png[]


### PR DESCRIPTION
In entreprise docs [1], fixing support for catching and throwing Link in:
-  _Table 2.3. BPMN2 catching events_ 
and 
- _Table 2.4. BPMN2 throwing and non-interrupting events_ 





[1] -  https://access.redhat.com/documentation/en-us/red_hat_process_automation_manager/7.9/html-single/developing_process_services_in_red_hat_process_automation_manager/index#bpmn-support_business-processes