### PR TITLE
Upstream 7.39.x PR for BXMSDOC-6774: conditionalized the Configuring JDBC data sources for KIE Server chapter for PAM and DM

### DIFF
--- a/doc-content/enterprise-only/installation/assembly_installing-on-eap-deployable.adoc
+++ b/doc-content/enterprise-only/installation/assembly_installing-on-eap-deployable.adoc
@@ -11,6 +11,8 @@ For information about installing the {HEADLESS_CONTROLLER}, see xref:controller-
 
 include::eap-dm-install-proc.adoc[leveloffset=+1]
 include::eap-execution-server-download-install-proc.adoc[leveloffset=+1]
+ifdef::PAM[]
 include::eap-data-source-add-proc.adoc[leveloffset=+1]
+endif::PAM[]
 include::eap-users-create-proc.adoc[leveloffset=+1]
 include::eap-execution-server-configure-proc.adoc[leveloffset=+1]


### PR DESCRIPTION
Conditionalized the 5.3. Configuring JDBC data sources for KIE Server chapter for PAM. This section is already conditionalized in 7.9 and master. Therefore, the fix is applied for 7.8 version. 

Doc previews:
Chapter [5. Installing Red Hat Process Automation Manager from ZIP files](http://file.pnq.redhat.com/~hmanwani/BXMSDOC-6774-RHPAM/#assembly_installing-on-eap-deployable) in RHPAM with [5.3. Configuring JDBC data sources for KIE Server](http://file.pnq.redhat.com/~hmanwani/BXMSDOC-6774-RHPAM/#eap-data-source-add-proc) section. 

Chapter [5. Installing Red Hat Decision Manager from ZIP files](http://file.pnq.redhat.com/~hmanwani/BXMSDOC-6774-RHDM/#assembly_installing-on-eap-deployable) in RHDM without 5.3. Configuring JDBC data sources for KIE Server section. 


