### PR TITLE
Upstream 7.48.x PR for Support for catching and throwing Link Events in 7.10

### DIFF
--- a/doc-content/enterprise-only/bpmn/bpmn-support-con.adoc
+++ b/doc-content/enterprise-only/bpmn/bpmn-support-con.adoc
@@ -34,7 +34,7 @@ a|Escalation       | image:BPMN2/grn_check.png[]   | image:BPMN2/grn_check.png[]
 a|Cancel           |         | image:BPMN2/bk_x.png[]
 a|Compensation     | image:BPMN2/grn_check.png[]     | image:BPMN2/grn_check.png[]
 a|Conditional      | image:BPMN2/grn_check.png[]     | image:BPMN2/grn_check.png[]
-a|Link             |        | image:BPMN2/bk_x.png[]
+a|Link             |        | image:BPMN2/grn_check.png[]
 a|Signal           | image:BPMN2/grn_check.png[]     | image:BPMN2/grn_check.png[]
 a|Multiple         | image:BPMN2/bk_x.png[]      | image:BPMN2/bk_x.png[]
 a|Parallel Multiple  | image:BPMN2/bk_x.png[]     | image:BPMN2/bk_x.png[]
@@ -62,7 +62,7 @@ a|Escalation       | image:BPMN2/grn_check.png[]   | image:BPMN2/grn_check.png[]
 a|Cancel           | image:BPMN2/bk_x.png[]        | image:BPMN2/bk_x.png[]        |                             | image:BPMN2/bk_x.png[]
 a|Compensation     | image:BPMN2/grn_check.png[]   | image:BPMN2/grn_check.png[]   |                             |
 a|Conditional      |                               |                               | image:BPMN2/grn_check.png[]  | image:BPMN2/grn_check.png[]
-a|Link             |                               | image:BPMN2/bk_x.png[]        |                             |
+a|Link             |                               | image:BPMN2/grn_check.png[]        |                             |
 a|Signal           | image:BPMN2/grn_check.png[]   | image:BPMN2/grn_check.png[]   | image:BPMN2/grn_check.png[]  | image:BPMN2/grn_check.png[]
 a|Terminate        | image:BPMN2/grn_check.png[]   |                               |                             |
 a|Multiple         | image:BPMN2/bk_x.png[]        | image:BPMN2/bk_x.png[]        | image:BPMN2/bk_x.png[]      | image:BPMN2/bk_x.png[]


### PR DESCRIPTION
In entreprise docs [1], fixing support for catching and throwing Link in 7.10:

Table 2.3. BPMN2 catching events
and
Table 2.4. BPMN2 throwing and non-interrupting events
