### PR TITLE
Upstream master PR for BXMSDOC-6898: Added accept-language as HTTP Header for REST API

### DIFF
--- a/doc-content/shared-kie-docs/src/main/asciidoc/KieServer/controller-rest-api-requests-proc.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/KieServer/controller-rest-api-requests-proc.adoc
@@ -26,13 +26,13 @@ For curl utility:
 
 * `-u`: Enter the user name and password of the {CONTROLLER} user with the `rest-all` role or the {HEADLESS_CONTROLLER} user with the `kie-server` role.
 * `-H`: Set the following header:
-** `accept`: `application/json`
+** `Accept`: `application/json`
 * `-X`: Set to `GET`.
 * *URL*: Enter the {CONTROLLER} REST API base URL and endpoint, such as `\http://localhost:8080/{URL_COMPONENT_CENTRAL}/rest/controller/management/servers`.
 
 [source,subs="attributes+"]
 ----
-curl -u 'baAdmin:password@1' -H "accept: application/json" -X GET "http://localhost:8080/{URL_COMPONENT_CENTRAL}/rest/controller/management/servers"
+curl -u 'baAdmin:password@1' -H "Accept: application/json" -X GET "http://localhost:8080/{URL_COMPONENT_CENTRAL}/rest/controller/management/servers"
 ----
 --
 
@@ -161,20 +161,20 @@ For curl utility:
 
 * `-u`: Enter the user name and password of the {CONTROLLER} user with the `rest-all` role or the {HEADLESS_CONTROLLER} user with the `kie-server` role.
 * `-H`: Set the following headers:
-** `accept`: `application/json`
-** `content-type`: `application/json`
+** `Accept`: `application/json`
+** `Content-Type`: `application/json`
 * `-X`: Set to `PUT`.
 * *URL*: Enter the {CONTROLLER} REST API base URL and endpoint, such as `\http://localhost:8080/{URL_COMPONENT_CENTRAL}/rest/controller/management/servers/new-kieserver`.
 * `-d`: Add a JSON request body or file (`@file.json`) with the configurations for the new {KIE_SERVER} template:
 
 [source,subs="attributes+"]
 ----
-curl -u 'baAdmin:password@1' -H "accept: application/json" -H "content-type: application/json" -X PUT "http://localhost:8080/{URL_COMPONENT_CENTRAL}/rest/controller/management/servers/new-kieserver" -d "{ \"server-id\": \"new-kieserver\", \"server-name\": \"new-kieserver\", \"container-specs\": [], \"server-config\": {}, \"capabilities\": [ \"RULE\", \"PROCESS\", \"PLANNING\" ]}"
+curl -u 'baAdmin:password@1' -H "Accept: application/json" -H "Content-Type: application/json" -X PUT "http://localhost:8080/{URL_COMPONENT_CENTRAL}/rest/controller/management/servers/new-kieserver" -d "{ \"server-id\": \"new-kieserver\", \"server-name\": \"new-kieserver\", \"container-specs\": [], \"server-config\": {}, \"capabilities\": [ \"RULE\", \"PROCESS\", \"PLANNING\" ]}"
 ----
 
 [source,subs="attributes+"]
 ----
-curl -u 'baAdmin:password@1' -H "accept: application/json" -H "content-type: application/json" -X PUT "http://localhost:8080/{URL_COMPONENT_CENTRAL}/rest/controller/management/servers/new-kieserver" -d @my-server-template-configs.json
+curl -u 'baAdmin:password@1' -H "Accept: application/json" -H "Content-Type: application/json" -X PUT "http://localhost:8080/{URL_COMPONENT_CENTRAL}/rest/controller/management/servers/new-kieserver" -d @my-server-template-configs.json
 ----
 --
 . Execute the request and confirm the successful {CONTROLLER} response.

--- a/doc-content/shared-kie-docs/src/main/asciidoc/KieServer/kie-server-rest-api-requests-proc.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/KieServer/kie-server-rest-api-requests-proc.adoc
@@ -25,13 +25,13 @@ For curl utility:
 
 * `-u`: Enter the user name and password of the {KIE_SERVER} user with the `kie-server` role.
 * `-H`: Set the following header:
-** `accept`: `application/json`
+** `Accept`: `application/json`
 * `-X`: Set to `GET`.
 * *URL*: Enter the {KIE_SERVER} REST API base URL and endpoint, such as `\http://localhost:8080/kie-server/services/rest/server/containers`.
 
 [source]
 ----
-curl -u 'baAdmin:password@1' -H "accept: application/json" -X GET "http://localhost:8080/kie-server/services/rest/server/containers"
+curl -u 'baAdmin:password@1' -H "Accept: application/json" -X GET "http://localhost:8080/kie-server/services/rest/server/containers"
 ----
 --
 
@@ -129,20 +129,20 @@ For curl utility:
 
 * `-u`: Enter the user name and password of the {KIE_SERVER} user with the `kie-server` role.
 * `-H`: Set the following headers:
-** `accept`: `application/json`
-** `content-type`: `application/json`
+** `Accept`: `application/json`
+** `Content-Type`: `application/json`
 * `-X`: Set to `PUT`.
 * *URL*: Enter the {KIE_SERVER} REST API base URL and endpoint, such as `\http://localhost:8080/kie-server/services/rest/server/containers/MyContainer`.
 * `-d`: Add a JSON request body or file (`@file.json`) with the configuration items for the new KIE container:
 
 [source]
 ----
-curl -u 'baAdmin:password@1' -H "accept: application/json" -H "content-type: application/json" -X PUT "http://localhost:8080/kie-server/services/rest/server/containers/MyContainer" -d "{ \"config-items\": [ { \"itemName\": \"RuntimeStrategy\", \"itemValue\": \"SINGLETON\", \"itemType\": \"java.lang.String\" }, { \"itemName\": \"MergeMode\", \"itemValue\": \"MERGE_COLLECTIONS\", \"itemType\": \"java.lang.String\" }, { \"itemName\": \"KBase\", \"itemValue\": \"\", \"itemType\": \"java.lang.String\" }, { \"itemName\": \"KSession\", \"itemValue\": \"\", \"itemType\": \"java.lang.String\" } ], \"release-id\": { \"group-id\": \"itorders\", \"artifact-id\": \"itorders\", \"version\": \"1.0.0-SNAPSHOT\" }, \"scanner\": { \"poll-interval\": \"5000\", \"status\": \"STARTED\" }}"
+curl -u 'baAdmin:password@1' -H "Accept: application/json" -H "Content-Type: application/json" -X PUT "http://localhost:8080/kie-server/services/rest/server/containers/MyContainer" -d "{ \"config-items\": [ { \"itemName\": \"RuntimeStrategy\", \"itemValue\": \"SINGLETON\", \"itemType\": \"java.lang.String\" }, { \"itemName\": \"MergeMode\", \"itemValue\": \"MERGE_COLLECTIONS\", \"itemType\": \"java.lang.String\" }, { \"itemName\": \"KBase\", \"itemValue\": \"\", \"itemType\": \"java.lang.String\" }, { \"itemName\": \"KSession\", \"itemValue\": \"\", \"itemType\": \"java.lang.String\" } ], \"release-id\": { \"group-id\": \"itorders\", \"artifact-id\": \"itorders\", \"version\": \"1.0.0-SNAPSHOT\" }, \"scanner\": { \"poll-interval\": \"5000\", \"status\": \"STARTED\" }}"
 ----
 
 [source]
 ----
-curl -u 'baAdmin:password@1' -H "accept: application/json" -H "content-type: application/json" -X PUT "http://localhost:8080/kie-server/services/rest/server/containers/MyContainer" -d @my-container-configs.json
+curl -u 'baAdmin:password@1' -H "Accept: application/json" -H "Content-Type: application/json" -X PUT "http://localhost:8080/kie-server/services/rest/server/containers/MyContainer" -d @my-container-configs.json
 ----
 --
 . Execute the request and review the {KIE_SERVER} response.

--- a/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/RemoteAPI/knowledge-store-rest-api-requests-proc.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/RemoteAPI/knowledge-store-rest-api-requests-proc.adoc
@@ -121,6 +121,7 @@ For REST client:
 * *Authentication*: Enter the user name and password of the {CENTRAL} user with the `rest-all` role.
 * *HTTP Headers*: Set the following header:
 ** `Accept`: `application/json`
+** `Accept-Language`: `en-US`
 ** `Content-Type`: `application/json`
 * *HTTP method*: Set to `POST`.
 * *URL*: Enter the Knowledge Store REST API base URL and endpoint, such as `\http://localhost:8080/{URL_COMPONENT_CENTRAL}/rest/spaces/MySpace/projects`.
@@ -141,6 +142,7 @@ For curl utility:
 * `-u`: Enter the user name and password of the {CENTRAL} user with the `rest-all` role.
 * `-H`: Set the following headers:
 ** `Accept`: `application/json`
+** `Accept-Language`: `en-US` (If not defined, the default locale from the JVM is reflected)
 ** `Content-Type`: `application/json`
 * `-X`: Set to `POST`.
 * *URL*: Enter the Knowledge Store REST API base URL and endpoint, such as `\http://localhost:8080/{URL_COMPONENT_CENTRAL}/rest/spaces/MySpace/projects`.
@@ -148,12 +150,12 @@ For curl utility:
 
 [source,subs="attributes+"]
 ----
-curl -u 'baAdmin:password@1' -H "Accept: application/json" -H "Content-Type: application/json" -X POST "http://localhost:8080/{URL_COMPONENT_CENTRAL}/rest/spaces/MySpace/projects" -d "{ \"name\": \"Employee_Rostering\", \"groupId\": \"employeerostering\", \"version\": \"1.0.0-SNAPSHOT\", \"description\": \"Employee rostering problem optimisation using Planner. Assigns employees to shifts based on their skill.\"}"
+curl -u 'baAdmin:password@1' -H "Accept: application/json" -H "Accept-Language: en-US" -H "Content-Type: application/json" -X POST "http://localhost:8080/{URL_COMPONENT_CENTRAL}/rest/spaces/MySpace/projects" -d "{ \"name\": \"Employee_Rostering\", \"groupId\": \"employeerostering\", \"version\": \"1.0.0-SNAPSHOT\", \"description\": \"Employee rostering problem optimisation using Planner. Assigns employees to shifts based on their skill.\"}"
 ----
 
 [source,subs="attributes+"]
 ----
-curl -u 'baAdmin:password@1' -H "Accept: application/json" -H "Content-Type: application/json" -X POST "http://localhost:8080/{URL_COMPONENT_CENTRAL}/rest/spaces/MySpace/projects" -d @my-project.json
+curl -u 'baAdmin:password@1' -H "Accept: application/json" -H "Accept-Language: en-US" -H "Content-Type: application/json" -X POST "http://localhost:8080/{URL_COMPONENT_CENTRAL}/rest/spaces/MySpace/projects" -d @my-project.json
 ----
 --
 . Execute the request and review the {KIE_SERVER} response.

--- a/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/RemoteAPI/security-management-rest-api-con.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/RemoteAPI/security-management-rest-api-con.adoc
@@ -45,6 +45,7 @@ The Security Management REST API supports the following HTTP methods for API req
 +
 * `GET`: Retrieves specified information from a specified resource endpoint
 * `POST`: Creates or updates a resource
+* `PUT`: Updates a resource
 * `DELETE`: Deletes a resource
 
 Base URL::


### PR DESCRIPTION
See JIRA: https://issues.redhat.com/browse/BXMSDOC-6898

Doc previews:
Interacting with Red Hat Process Automation Manager using KIE APIs
[28.1. Sending requests with the Knowledge Store REST API using a REST client or curl utility](http://file.pnq.redhat.com/~hmanwani/BXMSDOC-6898-RHPAM/#knowledge-store-rest-api-requests-proc_kie-apis)

Interacting with Red Hat Decision Manager using KIE APIs
[28.1. Sending requests with the Knowledge Store REST API using a REST client or curl utility](http://file.pnq.redhat.com/~hmanwani/BXMSDOC-6898-RHDM/#knowledge-store-rest-api-requests-proc_kie-apis)