### PR TITLE
Upstream 7.11.x PR for BXMSDOC-7213: Changed the Java command for BatchExecutionCommand in KIE API doc

### DIFF
--- a/doc-content/shared-kie-docs/src/main/asciidoc/Commands/runtime-commands-samples-ref.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/Commands/runtime-commands-samples-ref.adoc
@@ -103,16 +103,10 @@ NOTE: KIE session IDs are in the `kmodule.xml` file of your {PRODUCT} project. T
 .Example Java command
 [source,java]
 ----
-BatchExecutionCommand command = new BatchExecutionCommand();
-command.setLookup("ksession1");
+InsertObjectCommand insertCommand = new InsertObjectCommand(new Person("john", 25));
+FireAllRulesCommand fireCommand = new FireAllRulesCommand();
 
-InsertObjectCommand insertObjectCommand = new InsertObjectCommand(new Person("john", 25));
-FireAllRulesCommand fireAllRulesCommand = new FireAllRulesCommand();
-
-command.getCommands().add(insertObjectCommand);
-command.getCommands().add(fireAllRulesCommand);
-
-ksession.execute(command);
+BatchExecutionCommand batch = new BatchExecutionCommandImpl(Arrays.asList(insertCommand, fireCommand), "ksession1");
 ----
 
 .Example server response (JSON)


### PR DESCRIPTION
See JIRA: https://issues.redhat.com/browse/BXMSDOC-7213

Doc previews:
Interacting with Red Hat Process Automation Manager using KIE APIs
[4.1. Sample runtime commands in Red Hat Process Automation Manager](http://file.pnq.redhat.com/~hmanwani/BXMSDOC-7213-RHPAM-7.1/#runtime-commands-samples-ref_kie-apis)