### PR TITLE
Upstream 7.48.x PR for BXMSDOC-7213: Changed the Java command for BatchExecutionCommand in KIE API doc

### DIFF
--- a/_artifacts/document-attributes.adoc
+++ b/_artifacts/document-attributes.adoc
@@ -1,5 +1,5 @@
 
-:REBUILT: Monday, February 24, 2021
+:REBUILT: Monday, March 01, 2021
 
 
 

--- a/doc-content/shared-kie-docs/src/main/asciidoc/Commands/runtime-commands-samples-ref.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/Commands/runtime-commands-samples-ref.adoc
@@ -103,16 +103,10 @@ NOTE: KIE session IDs are in the `kmodule.xml` file of your {PRODUCT} project. T
 .Example Java command
 [source,java]
 ----
-BatchExecutionCommand command = new BatchExecutionCommand();
-command.setLookup("ksession1");
+InsertObjectCommand insertCommand = new InsertObjectCommand(new Person("john", 25));
+FireAllRulesCommand fireCommand = new FireAllRulesCommand();
 
-InsertObjectCommand insertObjectCommand = new InsertObjectCommand(new Person("john", 25));
-FireAllRulesCommand fireAllRulesCommand = new FireAllRulesCommand();
-
-command.getCommands().add(insertObjectCommand);
-command.getCommands().add(fireAllRulesCommand);
-
-ksession.execute(command);
+BatchExecutionCommand batch = new BatchExecutionCommandImpl(Arrays.asList(insertCommand, fireCommand), "ksession1");
 ----
 
 .Example server response (JSON)


### PR DESCRIPTION
See JIRA: https://issues.redhat.com/browse/BXMSDOC-7213

Doc previews:
**Interacting with Red Hat Process Automation Manager using KIE APIs**
[24.1. Sample runtime commands in Red Hat Process Automation Manager](http://file.pnq.redhat.com/~hmanwani/BXMSDOC-7213-RHPAM/#runtime-commands-samples-ref_kie-apis)

**Interacting with Red Hat Decision Manager using KIE APIs**
[24.1. Sample runtime commands in Red Hat Decision Manager](http://file.pnq.redhat.com/~hmanwani/BXMSDOC-7213-RHDM/#runtime-commands-samples-ref_kie-apis)