### PR TITLE
BXMSDOC-7143: Finalized release notes for Kogito 1.3

### DIFF
--- a/doc-content/kogito-docs/src/main/asciidoc/release-notes/chap-kogito-release-notes.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/release-notes/chap-kogito-release-notes.adoc
@@ -9,7 +9,7 @@ These release notes highlight some of the new features, fixed issues, and known 
 
 For the complete list of new features, fixed issues, and known issues in {PRODUCT} {PRODUCT_VERSION}, see the following release notes pages in Atlassian Jira. Each {PRODUCT} release includes one or more {PRODUCT} tooling releases as shown in this list.
 
-* https://issues.redhat.com/secure/ReleaseNote.jspa?projectId=12322421&version=12352575[{PRODUCT} {COMMUNITY_VERSION_FINAL}]
+* https://issues.redhat.com/secure/ReleaseNote.jspa?projectId=12322421&version=12353310[{PRODUCT} {COMMUNITY_VERSION_FINAL}]
 ** https://issues.redhat.com/secure/ReleaseNote.jspa?projectId=12322421&version=12353376[{PRODUCT} tooling 0.8.3]
 
 [id="ref-kogito-rn-key-features_{context}"]
@@ -109,6 +109,8 @@ With this enhancement, the following new example application is available to dem
 
 For more information about Kafka Streams persistence in {PRODUCT}, see {URL_CONFIGURING_KOGITO}#proc-kafka-streams-persistence-enabling_kogito-configuring[_{CONFIGURING_KOGITO}_].
 
+////
+
 ==== Improved/new bla bla
 
 Description
@@ -119,11 +121,15 @@ Description
 
 Description
 
+////
+
 === {PRODUCT} supporting services
 
 ==== PatternFly updated to latest version
 
 PatternFly is now updated to the latest version for {PRODUCT} Management Console and Task Console.
+
+////
 
 === {PRODUCT} tooling
 
@@ -138,6 +144,7 @@ Description
 The following list describes some of the fixed issues in {PRODUCT} {PRODUCT_VERSION}. For more information about each fixed issue, select the Atlassian Jira link provided.
 
 * Start here
+////
 
 [id="ref-kogito-rn-known-issues_{context}"]
 == Known issues in {PRODUCT} {PRODUCT_VERSION}
@@ -150,6 +157,7 @@ The following list describes some of the known issues in {PRODUCT} {PRODUCT_VERS
 * In the DMN boxed literal expression editor, when a user presses the *Tab* key within a FEEL expression, the FEEL auto-complete feature adds white space between characters instead of navigating out of the expression editor. [https://issues.redhat.com/browse/KOGITO-1581[KOGITO-1581]]
 * In some cases, the names of task nodes in a BPMN process diagram cannot be edited. [https://issues.redhat.com/browse/KOGITO-1267[KOGITO-1267]]
 * In a {PRODUCT} service where a DMN decision model is invoked in a BPMN process model, when a user interacts with the service through REST API requests, a `HashMap cannot be cast to __OBJECT__` error is returned in the error log. [https://issues.redhat.com/browse/KOGITO-1332[KOGITO-1332]]
+* In some cases, Quarkus developer mode fails to reload DRL and DMN assets. To fix the issue, you can set the `quarkus.dev.instrumentation` configuration option to false. [https://issues.redhat.com/browse/KOGITO-4512[KOGITO-4512]]
 
 ifdef::KOGITO-ENT[]
 [role="_additional-resources"]


### PR DESCRIPTION
Finalized release notes for Kogito 1.3, added a KOGITO-4512 as a known issue and added JIRA release note links. 

See JIRA: https://issues.redhat.com/browse/BXMSDOC-7143

Doc preview:
[Kogito documentation 1.3.0 ](http://file.pnq.redhat.com/~hmanwani/BXMSDOC-7143-KOGITO-release-notes/#chap-kogito-release-notes)