### PR TITLE
Upstream 7.48.x PR for BXMSDOC-7225: Single-source and add "Data sets authoring" chapter in the upstream documents.

### DIFF
--- a/assemblies/assembly-building-custom-dashboard-widgets.adoc
+++ b/assemblies/assembly-building-custom-dashboard-widgets.adoc
@@ -11,11 +11,11 @@ As a business analyst or business rules developer, use the *Page Editor* tool to
 * You have sufficient permissions for creating pages.
 
 // Modules - concepts, procedures, refs, etc.
-include::{enterprise-dir}/project-data/data-sets-con.adoc[leveloffset=+1]
-include::{enterprise-dir}/project-data/data-sets-add-proc.adoc[leveloffset=+2]
-include::{enterprise-dir}/project-data/data-sets-edit-proc.adoc[leveloffset=+2]
-include::{enterprise-dir}/project-data/data-sets-refresh-con.adoc[leveloffset=+2]
-include::{enterprise-dir}/project-data/data-sets-caching-con.adoc[leveloffset=+2]
+include::{shared-dir}/Workbench/Authoring/DataSets/data-sets-authoring-con.adoc[leveloffset=+1]
+include::{shared-dir}/Workbench/Authoring/DataSets/adding-data-sets-proc.adoc[leveloffset=+2]
+include::{shared-dir}/Workbench/Authoring/DataSets/editing-data-sets-proc.adoc[leveloffset=+2]
+include::{shared-dir}/Workbench/Authoring/DataSets/refreshing-data-sets-con.adoc[leveloffset=+2]
+include::{shared-dir}/Workbench/Authoring/DataSets/data-sets-caching-con.adoc[leveloffset=+2]
 
 include::{enterprise-dir}/pages/building-custom-dashboard-widgets-pages-con.adoc[leveloffset=+1]
 include::{enterprise-dir}/pages/building-custom-dashboard-widgets-creating-pages-proc.adoc[leveloffset=+2]

--- a/assemblies/assembly-configuring-central.adoc
+++ b/assemblies/assembly-configuring-central.adoc
@@ -52,11 +52,11 @@ include::{enterprise-dir}/admin-and-config/managing-business-central-adding-data
 include::{enterprise-dir}/admin-and-config/managing-business-central-editing-data-sources-proc.adoc[leveloffset=+2]
 include::{enterprise-dir}/admin-and-config/managing-business-central-deleting-data-sources-proc.adoc[leveloffset=+2]
 
-include::{enterprise-dir}/project-data/data-sets-con.adoc[leveloffset=+1]
-include::{enterprise-dir}/project-data/data-sets-add-proc.adoc[leveloffset=+2]
-include::{enterprise-dir}/project-data/data-sets-edit-proc.adoc[leveloffset=+2]
-include::{enterprise-dir}/project-data/data-sets-refresh-con.adoc[leveloffset=+2]
-include::{enterprise-dir}/project-data/data-sets-caching-con.adoc[leveloffset=+2]
+include::{shared-dir}/Workbench/Authoring/DataSets/data-sets-authoring-con.adoc[leveloffset=+1]
+include::{shared-dir}/Workbench/Authoring/DataSets/adding-data-sets-proc.adoc[leveloffset=+2]
+include::{shared-dir}/Workbench/Authoring/DataSets/editing-data-sets-proc.adoc[leveloffset=+2]
+include::{shared-dir}/Workbench/Authoring/DataSets/refreshing-data-sets-con.adoc[leveloffset=+2]
+include::{shared-dir}/Workbench/Authoring/DataSets/data-sets-caching-con.adoc[leveloffset=+2]
 
 include::{enterprise-dir}/admin-and-config/managing-business-central-archetype-con.adoc[leveloffset=+1]
 include::{enterprise-dir}/admin-and-config/managing-business-central-listing-archetype-proc.adoc[leveloffset=+2]

--- a/doc-content/enterprise-only/pages/building-custom-dashboard-widgets-components-con.adoc
+++ b/doc-content/enterprise-only/pages/building-custom-dashboard-widgets-components-con.adoc
@@ -51,7 +51,7 @@ Core components are not mandatory.
 The target div setting is *not* needed for non-target div components such as Carousel or Tile navigator.
 =======
 
-* *Reporting* components: Used for displaying data from data sets (see xref:data_sets_con_building-custom-dashboard-widgets[Data sets authoring] section) in the form of graphs, tables, maps, and so on. There are ten types of reporting components. The reporting components can be configured using the *New Displayer* widget, which has the following three tabs:
+* *Reporting* components: Used for displaying data from data sets (see xref:data-sets-authoring-con_building-custom-dashboard-widgets[Data sets authoring] section) in the form of graphs, tables, maps, and so on. There are ten types of reporting components. The reporting components can be configured using the *New Displayer* widget, which has the following three tabs:
 
 ** *Type*: Choose how to display custom data graphically.
 ** *Data*: Choose a data set from the list of custom data sets that you had created from the *Data Sets* section available in the *Settings* menu.

--- a/doc-content/enterprise-only/pages/building-custom-dashboard-widgets-creating-dashboard-proc.adoc
+++ b/doc-content/enterprise-only/pages/building-custom-dashboard-widgets-creating-dashboard-proc.adoc
@@ -5,7 +5,7 @@ In order to create custom dashboards, users must combine some of the features of
 
 There are four stages in the creation of a custom dashboard:
 
-* Data set authoring - In this stage, you define a data set for accessing the data and displaying it through the pages. For more information, see xref:data_sets_add_proc_building-custom-dashboard-widgets[Adding data sets].
+* Data set authoring - In this stage, you define a data set for accessing the data and displaying it through the pages. For more information, see xref:adding-data-sets-proc_building-custom-dashboard-widgets[Adding data sets].
 * Page authoring - In this stage, you create the pages which are used to display the data from the data sets, among other things. For more information, see xref:building-custom-dashboard-widgets-creating-pages-proc[Creating pages].
 * Publication - In this stage, navigation between pages are defined when you create the custom navigation trees or modify the existing default one (*Workbench* tree). For more information, see xref:building-custom-dashboard-widgets-creating-navigation-tree-proc[Creating a navigation tree] or xref:building-custom-dashboard-widgets-editing-navigation-tree-con[Editing a navigation tree].
 * Security management - In this stage, role and group permissions are set which defines the privileges a user enjoys when working on {CENTRAL}. For more information, see xref:business-central-settings-security-proc_building-custom-dashboard-widgets[Security management].

--- a/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/Authoring/Authoring-section.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/Authoring/Authoring-section.adoc
@@ -2,12 +2,23 @@
 = Authoring (General)
 
 include::ArtifactRepository/ArtifactRepository-section.adoc[leveloffset=+1]
-include::AssetEditor/AssetEditor-section.adoc[leveloffset=+1]
-include::TagsEditor/TagsEditor-section.adoc[leveloffset=+1]
-include::ProjectExplorer/ProjectExplorer-section.adoc[leveloffset=+1]
-include::ProjectEditor/ProjectEditor-section.adoc[leveloffset=+1]
-include::Validation/Validation-section.adoc[leveloffset=+1]
-include::DataModeller/DataModeller-section.adoc[leveloffset=+1]
-include::DataSets/DataSets-section.adoc[leveloffset=+1]
-include::DataSourceManagement/DataSourceManagement-section.adoc[leveloffset=+1]
 
+include::AssetEditor/AssetEditor-section.adoc[leveloffset=+1]
+
+include::TagsEditor/TagsEditor-section.adoc[leveloffset=+1]
+
+include::ProjectExplorer/ProjectExplorer-section.adoc[leveloffset=+1]
+
+include::ProjectEditor/ProjectEditor-section.adoc[leveloffset=+1]
+
+include::Validation/Validation-section.adoc[leveloffset=+1]
+
+include::DataModeller/DataModeller-section.adoc[leveloffset=+1]
+
+include::DataSets/data-sets-authoring-con.adoc[leveloffset=+1]
+include::DataSets/adding-data-sets-proc.adoc[leveloffset=+2]
+include::DataSets/editing-data-sets-proc.adoc[leveloffset=+2]
+include::DataSets/refreshing-data-sets-con.adoc[leveloffset=+2]
+include::DataSets/data-sets-caching-con.adoc[leveloffset=+2]
+
+include::DataSourceManagement/DataSourceManagement-section.adoc[leveloffset=+1]

--- a/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/Authoring/DataSets/adding-data-sets-proc.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/Authoring/DataSets/adding-data-sets-proc.adoc
@@ -1,0 +1,29 @@
+[id='adding-data-sets-proc_{context}']
+= Adding data sets
+
+You can create a data set to fetch data from an external data source and use that data for the reporting components.
+
+.Procedure
+. In {CENTRAL}, go to *Admin* -> *Data Sets*.
++
+The *Data Sets* page opens.
+. Click *New Data Set* and select one of the following provider types:
++
+* *Bean:* Generates a data set from a Java class
+* *CSV:* Generates a data set from a remote or local CSV file
+* *SQL:* Generates a data set from an ANSI-SQL compliant database
+* *Elastic Search:* Generates a data set from Elastic Search nodes
+* *Prometheus:* Generates a data set using the Prometheus query
+* *Execution Server:* Generates a data set using the custom query feature of an Execution Server
++
+
+NOTE: You must configure *{KIE_SERVER}* for *Execution Server* option.
+
++
+. Complete the *Data Set Creation Wizard* and click *Test*.
++
+
+NOTE: The configuration steps differ based on the provider you choose.
+
++
+. Click *Save*.

--- a/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/Authoring/DataSets/data-sets-authoring-con.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/Authoring/DataSets/data-sets-authoring-con.adoc
@@ -1,0 +1,10 @@
+[id='data-sets-authoring-con_{context}']
+= Data sets authoring
+
+A data set is a collection of related sets of information and can be stored in many ways. For example, in a database, in a Microsoft Excel file, or in memory. A data set definition instructs {CENTRAL} methods to access, read, and parse a data set. {CENTRAL} does not store data. It enables you to define access to a data set regardless of where the data is stored.
+
+For example, if data is stored in a database, a valid data set can contain the entire database or a subset of the database as a result of an SQL query. In both cases the data is used as input for the reporting components of {CENTRAL} which then displays the information.
+
+To access a data set, you must create and register a data set definition. The data set definition specifies the location of the data set, options to access it, read it, and parse it, and the columns that it contains.
+
+NOTE: The *Data Sets* page is visible only to users with the *admin* role.

--- a/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/Authoring/DataSets/data-sets-caching-con.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/Authoring/DataSets/data-sets-caching-con.adoc
@@ -1,5 +1,5 @@
-[id='data_sets_caching_con_{context}']
-= Caching
+[id='data-sets-caching-con_{context}']
+= Caching data
 
 {CENTRAL} provides caching mechanisms for storing data sets and performing data operations using in-memory data. Caching data reduces network traffic, remote system payload, and processing time. To avoid performance issues, configure the cache settings in {CENTRAL}.
 
@@ -9,6 +9,8 @@ For any data lookup call that results in a data set, the caching method determin
 
 * Client level
 * Back-end level
+
+You can set the *Client Cache* and *Backend Cache* settings on the *Advanced* tab of the data set.
 
 [float]
 == Client cache
@@ -20,7 +22,4 @@ When the cache is turned on, the data set is cached in a web browser during the 
 
 When the cache is enabled, the {DECISION_ENGINE} caches the data set. This reduces the number of back-end requests to the remote storage system. All data set operations are performed in the {DECISION_ENGINE} using in-memory data. Enable back-end caching only if the data set size is not updated frequently and it can be stored and processed in memory. Using back-end caching is also useful in cases with low latency connectivity issues with the remote storage.
 
-[NOTE]
-====
-Back-end cache settings are not always visible in the *Advanced* tab of the *Data Set Editor* because Java and CSV data providers rely on back-end caching (data set must be in the memory) in order to resolve any data lookup operation using the in-memory {DECISION_ENGINE}.
-====
+NOTE: Back-end cache settings are not always visible in the *Advanced* tab of the *Data Set Editor* because Java and CSV data providers rely on back-end caching (data set must be in the memory) in order to resolve any data lookup operation using the in-memory {DECISION_ENGINE}.

--- a/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/Authoring/DataSets/editing-data-sets-proc.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/Authoring/DataSets/editing-data-sets-proc.adoc
@@ -1,11 +1,13 @@
-[id='data_sets_edit_proc_{context}']
+[id='editing-data-sets-proc_{context}']
 = Editing data sets
 
 You can edit existing data sets to ensure that the data fetched to the reporting components is up-to-date.
 
 .Procedure
-. In {CENTRAL}, go to *Admin* -> *Data Sets*. The *Data Set Explorer* page opens.
-. In the *Data Set Explorer* pane, search for the data set you want to edit and click *Edit*.
+. In {CENTRAL}, go to *Admin* -> *Data Sets*.
++
+The *Data Set Explorer* page opens.
+. In the *Data Set Explorer* pane, search for the data set you want to edit, select the data set, and click *Edit*.
 . In the *Data Set Editor* pane, use the appropriate tab to edit the data as required. The tabs differ based on the data set provider type you chose.
 +
 For example, the following changes are applicable for editing a *CSV* data provider:
@@ -15,7 +17,7 @@ For example, the following changes are applicable for editing a *CSV* data provi
 ** *Data columns:* Enables you to specify what columns are part of your data set definition.
 ** *Filter:* Enables you to add a new filter.
 * *Advanced:* Enables you to manage the following configurations:
-** *Caching:* See <<data-sets-caching-con_con_building-custom-dashboard-widgets>> for more information.
+** *Caching:* See xref:data-sets-caching-con_building-custom-dashboard-widgets[Caching] for more information.
 ** *Cache life-cycle* Enables you to specify an interval of time after which a data set (or data) is refreshed. The *Refresh on stale data* feature refreshes the cached data when the back-end data changes.
 . After making the required changes, click *Validate*.
 . Click *Save*.

--- a/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/Authoring/DataSets/refreshing-data-sets-con.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/Workbench/Authoring/DataSets/refreshing-data-sets-con.adoc
@@ -1,0 +1,5 @@
+[id='refreshing-data-sets-con_{context}']
+= Data refresh
+
+The data refresh feature enables you to specify an interval of time after which a data set (or data) is refreshed. You can access the *Data refresh every* feature on the *Advanced* tab of the data set. 
+The *Refresh on stale data* feature refreshes the cached data when the back-end data changes.


### PR DESCRIPTION
Associated JIRA: https://issues.redhat.com/browse/BXMSDOC-7225

**Enterprise document previews:**
- [RHPAM-IV. Building custom dashboard widgets](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-7225-RHPAM-DataSets/#data-sets-authoring-con_building-custom-dashboard-widgets)
- [RHDM-IV. Building custom dashboard widgets](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-7225-RHDM-DataSets/#data-sets-authoring-con_building-custom-dashboard-widgets)

**Doc impact for enterprise documents:**
- Check section **54. Data sets authoring** in RHPAM doc
- Check section **48. Data sets authoring** in RHDM doc (Same as RHPAM)

**Community document previews:**
- [Drools document](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-7225-Drools/#data-sets-authoring-con_kie-apis)
- [jBPM document](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-7225-jBPM/#data-sets-authoring-con_business-processes)

**Doc impact for community documents:**
- Check **15.7.8. Data sets authoring** in Drools doc
- Check **13.7.8. Data sets authoring** in jBPM doc (Same as Drools)
