### PR TITLE
[KOGITO-4199] KogitoInfra does not create third-party resources anymore

### DIFF
--- a/doc-content/kogito-docs/src/main/asciidoc/openshift/chap-kogito-deploying-on-openshift.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/openshift/chap-kogito-deploying-on-openshift.adoc
@@ -458,7 +458,7 @@ This example uses the {PRODUCT} CLI to install the Infinispan infrastructure and
 .Prerequisites
 * The https://github.com/infinispan/infinispan-operator[Infinispan Operator] is installed in the same OpenShift namespace as your {PRODUCT} project. You can install the Infinispan Operator using the *Operators* -> *OperatorHub* page in the OpenShift web console or manually as described in the https://infinispan.org/infinispan-operator/master/operator.html[Infinispan Operator Guide].
 
-* https://infinispan.org/infinispan-operator/master/operator.html#minimal_crd-start[An Infinispan Server resource] is deployed in the same OpenShift namespace as your {PRODUCT} project. You can try one of their examples as described in the https://infinispan.org/infinispan-operator/master/operator.html#creating_minimal_clusters-start[Infinispan Operator Guide]. For this procedure, we expect that the Infinispan Server resource is named as `kogito-infinispan`.
+* https://infinispan.org/infinispan-operator/master/operator.html#minimal_crd-start[An Infinispan Server resource] is deployed in the same OpenShift namespace as your {PRODUCT} project. You can try one of the examples as described in the https://infinispan.org/infinispan-operator/master/operator.html#creating_minimal_clusters-start[Infinispan Operator Guide]. For this procedure, set `kogito-infinispan` as the name of the Infinispan Server resource.
 
 .Procedure
 . In a command terminal, enter the following command to install the Infinispan infrastructure for the {PRODUCT} services:
@@ -491,12 +491,12 @@ image::kogito/openshift/kogito-ocp-stateful-sets-infinispan.png[Image of Statefu
 
 The {PRODUCT} Operator uses the https://strimzi.io/[Strimzi Operator] to deploy and manage the Kafka infrastructure in a {PRODUCT} project. For optimal {PRODUCT} deployment on OpenShift, install the Strimzi Operator and enable Kafka messaging for your {PRODUCT} services. You can install the Kafka infrastructure using the {PRODUCT} Operator page in the OpenShift web console or using the {PRODUCT} CLI.
 
-This example uses the {PRODUCT} CLI to auto-configure an existent Kafka infrastructure and the {PRODUCT} Operator page in the web console to verify that the infrastructure is enabled.
+This example uses the {PRODUCT} CLI to auto-configure an existing Kafka infrastructure and the {PRODUCT} Operator page in the web console to verify that the infrastructure is enabled.
 
 .Prerequisites
 * The https://strimzi.io/[Strimzi Operator] is installed in the same OpenShift namespace as your {PRODUCT} project. You can install the Strimzi Operator using the *Operators* -> *OperatorHub* page in the OpenShift web console or manually as described in the https://strimzi.io/docs/operators/master/quickstart.html[Strimzi Quick Start guide].
 
-* https://strimzi.io/docs/operators/master/overview.html#configuration-points-broker_str[A Kafka Cluster resource] is deployed in the same OpenShift cluster as your {PRODUCT} project. You can try one of their examples as described in the https://strimzi.io/docs/operators/master/quickstart.html#proc-kafka-cluster-str[Strimzi Guide]. For this procedure, we expect that the Kafka Cluster resource is named as `kogito-kafka`.
+* https://strimzi.io/docs/operators/master/overview.html#configuration-points-broker_str[A Kafka Cluster resource] is deployed in the same OpenShift cluster as your {PRODUCT} project. You can try one of the examples as described in the https://strimzi.io/docs/operators/master/quickstart.html#proc-kafka-cluster-str[Strimzi Guide]. For this procedure, set `kogito-kafka` as the name of the Kafka Cluster resource.
 
 .Procedure
 . In a command terminal, enter the following command to install the Kafka infrastructure for the {PRODUCT} services:
@@ -1011,14 +1011,14 @@ The {PRODUCT} Operator uses the following custom resources to deploy {PRODUCT} d
 
 ==== {PRODUCT} Operator dependencies on third-party operators
 
-The {PRODUCT} Operator uses the following third-party operators to auto-configure {PRODUCT} service infrastructure components:
+The {PRODUCT} Operator uses the following third-party operators to auto-configure the {PRODUCT} service infrastructure components:
 
-* *https://github.com/infinispan/infinispan-operator[Infinispan Operator]*: Used to interact Infinispan Server instances for process data persistence in {PRODUCT} services
-* *https://github.com/strimzi/strimzi-kafka-operator[Strimzi Operator]*: Used to interact Apache Kafka clusters with Zookeeper for messaging in {PRODUCT} services
-* *https://github.com/keycloak/keycloak-operator[Keycloak Operator]*: Used to interact Keycloak server instances for security and single sign-on capabilities in {PRODUCT} services
+* *https://github.com/infinispan/infinispan-operator[Infinispan Operator]*: Used to interact with Infinispan Server instances for process data persistence in the {PRODUCT} services
+* *https://github.com/strimzi/strimzi-kafka-operator[Strimzi Operator]*: Used to interact with Apache Kafka clusters with Zookeeper for messaging in {PRODUCT} services
+* *https://github.com/keycloak/keycloak-operator[Keycloak Operator]*: Used to interact with Keycloak server instances for security and single sign-on capabilities in {PRODUCT} services
 * *https://github.com/mongodb/mongodb-kubernetes-operator[MongoDB Operator]*: Used to interact with MongoDB instances for process data persistence in {PRODUCT} services
 
-When you enable an infrastructure mechanism through a `KogitoInfra` deployment, the {PRODUCT} Operator uses the relevant third-party operator to configure the infrastructure.
+When you enable an infrastructure mechanism through `KogitoInfra` deployment, the {PRODUCT} Operator uses the relevant third-party operator to configure the infrastructure.
 
 You must define your custom infrastructure resource and link it in the `KogitoInfra`. You can specify your custom infrastructure resource in the `spec.resource.name` and `spec.resource.namespace` configurations:
 
@@ -1610,7 +1610,7 @@ spec:
 
 When you install the Infinispan infrastructure for your {PRODUCT} project using the {PRODUCT} CLI, the {PRODUCT} Operator creates a `KogitoInfra` custom resource to handle Infinispan configuration for you. This resource is added to your {PRODUCT} project and in the {PRODUCT} Operator page of the *Installed Operators* listed in the OpenShift web console, if applicable.
 
-The `KogitoInfra` resource uses the https://github.com/infinispan/infinispan-operator[Infinispan Operator] to interact with the Infinispan Server instances when needed. These Infinispan Server instances must be previously deployed. Due to this dependency, the Infinispan Operator must be installed in the same namespace where you deployed the custom {PRODUCT} service. For information about Infinispan Operator installation, see the https://infinispan.org/infinispan-operator/master/operator.html[Infinispan Operator Guide].
+The `KogitoInfra` resource uses the https://github.com/infinispan/infinispan-operator[Infinispan Operator] to interact with the Infinispan Server instances when needed. The Infinispan Server instances must be already deployed. Due to this dependency, the Infinispan Operator must be installed in the same namespace where you deployed the custom {PRODUCT} service. For information about Infinispan Operator installation, see the https://infinispan.org/infinispan-operator/master/operator.html[Infinispan Operator Guide].
 
 The {PRODUCT} Operator does not manage Infinispan instances, but you can edit and manage Infinispan instances as needed. For example, if you want to scale the Infinispan cluster, you can edit the `replicas` field in the https://github.com/infinispan/infinispan-operator/blob/master/pkg/apis/infinispan/v1/infinispan_types.go[`infinispan_types.go`] custom resource to meet your requirements.
 
@@ -2270,7 +2270,7 @@ NOTE: You must be logged in to the relevant Kubernetes cluster using the `kubect
 . If your {PRODUCT} project requires Infinispan or MongoDB persistence and Apache Kafka messaging, install the required Infinispan or MongoDB, and Kafka infrastructure components, including the https://github.com/infinispan/infinispan-operator[Infinispan Operator], https://github.com/mongodb/mongodb-kubernetes-operator/blob/master/README.md[MongoDB Operator] and the https://strimzi.io/docs/latest/[Strimzi Operator] (for Kafka cluster deployment with Zookeeper).
 +
 --
-The {PRODUCT} Operator cannot automatically install these operators for Infinispan or MongoDB persistence, and Kafka messaging, so you must install the components manually if needed. Also, the specific resources are not created by the {PRODUCT} Operator, so you must create them before deploying the `KogitoInfra` resource.
+The {PRODUCT} Operator cannot automatically install these operators for Infinispan or MongoDB persistence, and Kafka messaging, so you must install the components manually if needed. Also, {PRODUCT} Operator does not create the specific resource therefore, you must create them before deploying the `KogitoInfra` resource.
 
 For information about Infinispan installation and configuration, see the https://infinispan.org/documentation/[Infinispan documentation].
 

--- a/doc-content/kogito-docs/src/main/asciidoc/openshift/chap-kogito-deploying-on-openshift.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/openshift/chap-kogito-deploying-on-openshift.adoc
@@ -458,13 +458,15 @@ This example uses the {PRODUCT} CLI to install the Infinispan infrastructure and
 .Prerequisites
 * The https://github.com/infinispan/infinispan-operator[Infinispan Operator] is installed in the same OpenShift namespace as your {PRODUCT} project. You can install the Infinispan Operator using the *Operators* -> *OperatorHub* page in the OpenShift web console or manually as described in the https://infinispan.org/infinispan-operator/master/operator.html[Infinispan Operator Guide].
 
+* https://infinispan.org/infinispan-operator/master/operator.html#minimal_crd-start[An Infinispan Server resource] is deployed in the same OpenShift namespace as your {PRODUCT} project. You can try one of their examples as described in the https://infinispan.org/infinispan-operator/master/operator.html#creating_minimal_clusters-start[Infinispan Operator Guide]. For this procedure, we expect that the Infinispan Server resource is named as `kogito-infinispan`.
+
 .Procedure
 . In a command terminal, enter the following command to install the Infinispan infrastructure for the {PRODUCT} services:
 +
 .Installing Infinispan infrastructure
 [source]
 ----
-$ kogito install infra kogito-infinispan-infra --kind Infinispan --apiVersion infinispan.org/v1
+$ kogito install infra kogito-infinispan-infra --kind Infinispan --apiVersion infinispan.org/v1 --resource-name kogito-infinispan
 ----
 . In the OpenShift web console, use the left menu to navigate to the following windows to verify the installed Infinispan infrastructure:
 
@@ -472,11 +474,11 @@ $ kogito install infra kogito-infinispan-infra --kind Infinispan --apiVersion in
 +
 .{PRODUCT} infrastructure resource for Infinispan
 image::kogito/openshift/kogito-ocp-infra.png[Image of Kogito Infra page in web console]
-* *Operators* -> *Installed Operators* -> *Infinispan* -> *Infinispan Cluster*: A new `kogito-infinispan` custom resource is listed.
+* *Operators* -> *Installed Operators* -> *Infinispan* -> *Infinispan Cluster*: A `kogito-infinispan` custom resource is listed.
 +
 .Infinispan cluster resource
 image::kogito/openshift/kogito-ocp-infinispan-infra.png[Image of Infinispan Cluster page in web console]
-* *Workloads* -> *Stateful Sets*: A new `kogito-infinispan` stateful set is deployed.
+* *Workloads* -> *Stateful Sets*: A `kogito-infinispan` stateful set is deployed.
 +
 .Stateful set for Infinispan
 image::kogito/openshift/kogito-ocp-stateful-sets-infinispan.png[Image of Stateful Sets page in web console]
@@ -489,10 +491,12 @@ image::kogito/openshift/kogito-ocp-stateful-sets-infinispan.png[Image of Statefu
 
 The {PRODUCT} Operator uses the https://strimzi.io/[Strimzi Operator] to deploy and manage the Kafka infrastructure in a {PRODUCT} project. For optimal {PRODUCT} deployment on OpenShift, install the Strimzi Operator and enable Kafka messaging for your {PRODUCT} services. You can install the Kafka infrastructure using the {PRODUCT} Operator page in the OpenShift web console or using the {PRODUCT} CLI.
 
-This example uses the {PRODUCT} CLI to install the Kafka infrastructure and the {PRODUCT} Operator page in the web console to verify that the infrastructure is enabled.
+This example uses the {PRODUCT} CLI to auto-configure an existent Kafka infrastructure and the {PRODUCT} Operator page in the web console to verify that the infrastructure is enabled.
 
 .Prerequisites
 * The https://strimzi.io/[Strimzi Operator] is installed in the same OpenShift namespace as your {PRODUCT} project. You can install the Strimzi Operator using the *Operators* -> *OperatorHub* page in the OpenShift web console or manually as described in the https://strimzi.io/docs/operators/master/quickstart.html[Strimzi Quick Start guide].
+
+* https://strimzi.io/docs/operators/master/overview.html#configuration-points-broker_str[A Kafka Cluster resource] is deployed in the same OpenShift cluster as your {PRODUCT} project. You can try one of their examples as described in the https://strimzi.io/docs/operators/master/quickstart.html#proc-kafka-cluster-str[Strimzi Guide]. For this procedure, we expect that the Kafka Cluster resource is named as `kogito-kafka`.
 
 .Procedure
 . In a command terminal, enter the following command to install the Kafka infrastructure for the {PRODUCT} services:
@@ -500,7 +504,7 @@ This example uses the {PRODUCT} CLI to install the Kafka infrastructure and the 
 .Installing Kafka infrastructure
 [source]
 ----
-$ kogito install infra kogito-kafka-infra --kind Kafka --apiVersion kafka.strimzi.io/v1beta1
+$ kogito install infra kogito-kafka-infra --kind Kafka --apiVersion kafka.strimzi.io/v1beta1 --resource-name kogito-kafka
 ----
 . In the OpenShift web console, use the left menu to navigate to the following windows to verify the installed Kafka infrastructure:
 
@@ -508,11 +512,11 @@ $ kogito install infra kogito-kafka-infra --kind Kafka --apiVersion kafka.strimz
 +
 .Kafka enabled
 image::kogito/openshift/kogito-ocp-infra-kafka.png[Image of Kogito infra details in web console]
-* *Operators* -> *Installed Operators* -> *Strimzi* -> *Kafka*: A new `kogito-kafka` custom resource is listed.
+* *Operators* -> *Installed Operators* -> *Strimzi* -> *Kafka*: A `kogito-kafka` custom resource is listed.
 +
 .Kafka custom resource
 image::kogito/openshift/kogito-ocp-kafka-infra.png[Image of Kafkas page in web console]
-* *Workloads* -> *Stateful Sets*: New `kogito-kafka-kafka` and `kogito-kafka-zookeeper` stateful sets are deployed.
+* *Workloads* -> *Stateful Sets*: `kogito-kafka-kafka` and `kogito-kafka-zookeeper` stateful sets are deployed.
 +
 .Stateful sets for Kafka
 image::kogito/openshift/kogito-ocp-stateful-sets-kafka.png[Image of Stateful Sets page in web console]
@@ -533,8 +537,8 @@ This example uses the {PRODUCT} CLI to install the Data Index Service and the {P
 .Installing Infinispan and Kafka infrastructure components
 [source]
 ----
-$ kogito install infra kogito-infinispan-infra --kind Infinispan --apiVersion infinispan.org/v1
-$ kogito install infra kogito-kafka-infra --kind Kafka --apiVersion kafka.strimzi.io/v1beta1
+$ kogito install infra kogito-infinispan-infra --kind Infinispan --apiVersion infinispan.org/v1 --resource-name kogito-infinispan
+$ kogito install infra kogito-kafka-infra --kind Kafka --apiVersion kafka.strimzi.io/v1beta1 --resource-name kogito-kafka
 ----
 
 .Procedure
@@ -593,8 +597,8 @@ The travel agency example application includes the following key OpenShift resou
 .Installing Infinispan, Kafka, and Data Index Service components
 [source]
 ----
-$ kogito install infra kogito-infinispan-infra --kind Infinispan --apiVersion infinispan.org/v1
-$ kogito install infra kogito-kafka-infra --kind Kafka --apiVersion kafka.strimzi.io/v1beta1
+$ kogito install infra kogito-infinispan-infra --kind Infinispan --apiVersion infinispan.org/v1 --resource-name kogito-infinispan
+$ kogito install infra kogito-kafka-infra --kind Kafka --apiVersion kafka.strimzi.io/v1beta1 --resource-name kogito-kafka
 $ kogito install data-index --infra kogito-infinispan-infra --infra kogito-kafka-infra
 ----
 
@@ -1007,55 +1011,16 @@ The {PRODUCT} Operator uses the following custom resources to deploy {PRODUCT} d
 
 ==== {PRODUCT} Operator dependencies on third-party operators
 
-The {PRODUCT} Operator uses the following third-party operators to deploy {PRODUCT} service infrastructure components:
+The {PRODUCT} Operator uses the following third-party operators to auto-configure {PRODUCT} service infrastructure components:
 
-* *https://github.com/infinispan/infinispan-operator[Infinispan Operator]*: Used to deploy Infinispan Server instances for process data persistence in {PRODUCT} services
-* *https://github.com/strimzi/strimzi-kafka-operator[Strimzi Operator]*: Used to deploy Apache Kafka clusters with Zookeeper for messaging in {PRODUCT} services
-* *https://github.com/keycloak/keycloak-operator[Keycloak Operator]*: Used to deploy Keycloak server instances for security and single sign-on capabilities in {PRODUCT} services
-
-When you enable an infrastructure mechanism through a `KogitoInfra` deployment, the {PRODUCT} Operator uses the relevant third-party operator to create the infrastructure.
-
-For example, the following `kogito-infinispan-infra` custom resource uses the `spec.resource.apiVersion` and `spec.resource.kind` configurations to enable Infinispan persistence for the {PRODUCT} service:
-
-.Example {PRODUCT} infrastructure resource for Infinispan persistence
-[source,yaml]
-----
-apiVersion: app.kiegroup.org/v1beta1
-kind: KogitoInfra
-metadata:
-  name: kogito-infinispan-infra
-spec:
-  resource:
-    apiVersion: infinispan.org/v1
-    kind: Infinispan
-----
-
-In this example, if an Infinispan Server instance named `kogito-infinispan` does not exist, then the {PRODUCT} Operator uses the Infinispan Operator to deploy the Infinispan Server instance for persistence.
-
-Similar to the previous example, the following `kogito-kafka-infra` custom resource uses the `spec.resource.apiVersion` and `spec.resource.kind` configurations to enable Kafka messaging for the {PRODUCT} service:
-
-.Example {PRODUCT} infrastructure resource for Kafka messaging
-[source,yaml]
-----
-apiVersion: app.kiegroup.org/v1beta1
-kind: KogitoInfra
-metadata:
-  name: kogito-kafka-infra
-spec:
-  resource:
-    apiVersion: kafka.strimzi.io/v1beta1
-    kind: Kafka
-----
-
-In this example, if a Kafka cluster named `kogito-kafka` does not exist, then the {PRODUCT} Operator uses the Strimzi Operator to deploy the Kafka cluster for event messaging.
-
-In case the required third-party operators are not available to the {PRODUCT} Operator during {PRODUCT} service runtime, then the {PRODUCT} Operator cannot generate the infrastructure components, and the user must install the operators in the OpenShift or Kubernetes cluster.
-
-You can also define your custom infrastructure resource and link it in the `KogitoInfra`. In addition to the operators supported for third-party operator instance creation, the {PRODUCT} Operator also allows you to interact with created instances using the following operator:
-
+* *https://github.com/infinispan/infinispan-operator[Infinispan Operator]*: Used to interact Infinispan Server instances for process data persistence in {PRODUCT} services
+* *https://github.com/strimzi/strimzi-kafka-operator[Strimzi Operator]*: Used to interact Apache Kafka clusters with Zookeeper for messaging in {PRODUCT} services
+* *https://github.com/keycloak/keycloak-operator[Keycloak Operator]*: Used to interact Keycloak server instances for security and single sign-on capabilities in {PRODUCT} services
 * *https://github.com/mongodb/mongodb-kubernetes-operator[MongoDB Operator]*: Used to interact with MongoDB instances for process data persistence in {PRODUCT} services
 
-You can specify your custom infrastructure resource in the `spec.resource.name` and `spec.resource.namespace` configurations:
+When you enable an infrastructure mechanism through a `KogitoInfra` deployment, the {PRODUCT} Operator uses the relevant third-party operator to configure the infrastructure.
+
+You must define your custom infrastructure resource and link it in the `KogitoInfra`. You can specify your custom infrastructure resource in the `spec.resource.name` and `spec.resource.namespace` configurations:
 
 .Example {PRODUCT} infrastructure resource for custom messaging
 [source,yaml]
@@ -1072,7 +1037,7 @@ spec:
     namespace: my-namespace
 ----
 
-In this example, the `KogitoInfra` custom resource does not deploy a Kafka cluster, but connects to the Kafka cluster named `my-kafka-instance` from the `my-namespace` for event messaging.
+In this example, the `KogitoInfra` custom resource connects to the Kafka cluster named `my-kafka-instance` from the `my-namespace` for event messaging.
 
 Similarly, you can define a `KogitoInfra` resource for MongoDB to allow your processes to connect to it. In this case, you also need to define extra properties into the `KogitoInfra` resource for the {PRODUCT} Operator to interact with the MongoDB instance:
 
@@ -1275,12 +1240,12 @@ The {PRODUCT} command-line interface (CLI) supports the following operations on 
 |`{PRODUCT_INIT} use-project kogito-travel-agency`
 
 |Install the Infinispan infrastructure for process data persistence in {PRODUCT} services.
-|`{PRODUCT_INIT} install infra __INFINISPAN_INFRA_NAME__ --kind Infinispan --apiVersion infinispan.org/v1`
-|`{PRODUCT_INIT} install infra kogito-infinispan-infra --kind Infinispan --apiVersion infinispan.org/v1`
+|`{PRODUCT_INIT} install infra __INFINISPAN_INFRA_NAME__ --kind Infinispan --apiVersion infinispan.org/v1 --resource-name kogito-infinispan`
+|`{PRODUCT_INIT} install infra kogito-infinispan-infra --kind Infinispan --apiVersion infinispan.org/v1 --resource-name kogito-infinispan`
 
 |Install the Apache Kafka infrastructure for messaging in {PRODUCT} services.
-|`{PRODUCT_INIT} install infra __KAFKA_INFRA_NAME__ --kind Kafka --apiVersion kafka.strimzi.io/v1beta1`
-|`{PRODUCT_INIT} install infra kogito-kafka-infra --kind Kafka --apiVersion kafka.strimzi.io/v1beta1`
+|`{PRODUCT_INIT} install infra __KAFKA_INFRA_NAME__ --kind Kafka --apiVersion kafka.strimzi.io/v1beta1 --resource-name kogito-kafka`
+|`{PRODUCT_INIT} install infra kogito-kafka-infra --kind Kafka --apiVersion kafka.strimzi.io/v1beta1 --resource-name kogito-kafka`
 
 |Install the {PRODUCT} Data Index Service for data management in {PRODUCT} services and provision the Data Index Service to connect to the specified Infinispan and Kafka infrastructures.
 |`{PRODUCT_INIT} install data-index --infra __INFINISPAN_INFRA_NAME__ --infra __KAFKA_INFRA_NAME__`
@@ -1313,9 +1278,9 @@ The {PRODUCT} command-line interface (CLI) supports the following operations on 
 
 |`{PRODUCT_INIT} install data-index --infra kogito-infinispan-infra --infra kogito-kafka-infra -p kogito-travel-agency`
 
-`{PRODUCT_INIT} install infra kogito-infinispan-infra --kind Infinispan --apiVersion infinispan.org/v1 -p kogito-travel-agency`
+`{PRODUCT_INIT} install infra kogito-infinispan-infra --kind Infinispan --apiVersion infinispan.org/v1 --resource-name kogito-infinispan -p kogito-travel-agency`
 
-`{PRODUCT_INIT} install infra kogito-kafka-infra --kind Kafka --apiVersion kafka.strimzi.io/v1beta1 -p kogito-travel-agency`
+`{PRODUCT_INIT} install infra kogito-kafka-infra --kind Kafka --apiVersion kafka.strimzi.io/v1beta1 --resource-name kogito-kafka -p kogito-travel-agency`
 
 |Create a {PRODUCT} service definition from a local source or a Git repository and deploy the service. In a local directory source, if the `pom.xml` file is present, then the entire directory is zipped and uploaded to OCP and the build is initiated. However, if the `pom.xml` is not present, then only supported extension files (including `.dmn`, `.drl`, `.bpmn`, `.bpmn2`, `.properties`, `.sw.json`, and `.sw.yaml`) are uploaded from the directory to initiate the build. In a binary build configuration, this command creates the service definition but does not deploy the service.
 |`{PRODUCT_INIT} deploy-service __SERVICE_NAME__`
@@ -1621,12 +1586,12 @@ When the `application.properties` data of the `configMap` is changed, a rolling 
 === {PRODUCT} Operator interaction with Infinispan
 
 [role="_abstract"]
-You can install the Infinispan infrastructure for process data persistence in {PRODUCT} services by using the following {PRODUCT} CLI operation or by providing a `KogitoInfra` custom resource definition:
+You can configure the Infinispan infrastructure for process data persistence in {PRODUCT} services by using the following {PRODUCT} CLI operation or by providing a `KogitoInfra` custom resource definition:
 
 .Enable Infinispan persistence using the {PRODUCT} CLI
 [source,subs="attributes+,+quotes"]
 ----
-$ {PRODUCT_INIT} install infra __INFINISPAN_INFRA_NAME__ --kind Infinispan --apiVersion infinispan.org/v1 -p __PROJECT_NAME__
+$ {PRODUCT_INIT} install infra __INFINISPAN_INFRA_NAME__ --kind Infinispan --apiVersion infinispan.org/v1 --resource-name kogito-infinispan -p __PROJECT_NAME__
 ----
 
 .Enable Infinispan persistence using a custom resource definition
@@ -1640,11 +1605,12 @@ spec:
   resource:
     apiVersion: infinispan.org/v1
     kind: Infinispan
+    name: kogito-infinispan
 ----
 
-When you install the Infinispan infrastructure for your {PRODUCT} project using the {PRODUCT} CLI, the {PRODUCT} Operator creates a `KogitoInfra` custom resource to handle Infinispan deployment for you. This resource is added to your {PRODUCT} project and in the {PRODUCT} Operator page of the *Installed Operators* listed in the OpenShift web console, if applicable.
+When you install the Infinispan infrastructure for your {PRODUCT} project using the {PRODUCT} CLI, the {PRODUCT} Operator creates a `KogitoInfra` custom resource to handle Infinispan configuration for you. This resource is added to your {PRODUCT} project and in the {PRODUCT} Operator page of the *Installed Operators* listed in the OpenShift web console, if applicable.
 
-The `KogitoInfra` resource uses the https://github.com/infinispan/infinispan-operator[Infinispan Operator] to deploy new Infinispan Server instances when needed. Due to this dependency, the Infinispan Operator must be installed in the same namespace where you deployed the custom {PRODUCT} service. For information about Infinispan Operator installation, see the https://infinispan.org/infinispan-operator/master/operator.html[Infinispan Operator Guide].
+The `KogitoInfra` resource uses the https://github.com/infinispan/infinispan-operator[Infinispan Operator] to interact with the Infinispan Server instances when needed. These Infinispan Server instances must be previously deployed. Due to this dependency, the Infinispan Operator must be installed in the same namespace where you deployed the custom {PRODUCT} service. For information about Infinispan Operator installation, see the https://infinispan.org/infinispan-operator/master/operator.html[Infinispan Operator Guide].
 
 The {PRODUCT} Operator does not manage Infinispan instances, but you can edit and manage Infinispan instances as needed. For example, if you want to scale the Infinispan cluster, you can edit the `replicas` field in the https://github.com/infinispan/infinispan-operator/blob/master/pkg/apis/infinispan/v1/infinispan_types.go[`infinispan_types.go`] custom resource to meet your requirements.
 
@@ -1839,7 +1805,7 @@ You can install the Apache Kafka infrastructure for messaging in {PRODUCT} servi
 .Enable Kafka messaging using the {PRODUCT} CLI
 [source,subs="attributes+,+quotes"]
 ----
-$ {PRODUCT_INIT} install infra __KAFKA_INFRA_NAME__ --kind Kafka --apiVersion kafka.strimzi.io/v1beta1 -p __PROJECT_NAME__
+$ {PRODUCT_INIT} install infra __KAFKA_INFRA_NAME__ --kind Kafka --apiVersion kafka.strimzi.io/v1beta1 --resource-name kogito-kafka -p __PROJECT_NAME__
 ----
 
 .Enable Kafka messaging using a custom resource definition
@@ -1853,11 +1819,12 @@ spec:
   resource:
     apiVersion: kafka.strimzi.io/v1beta1
     kind: Kafka
+    name: kogito-kafka
 ----
 
-When you install the Kafka infrastructure for your {PRODUCT} project using the {PRODUCT} CLI, the {PRODUCT} Operator creates a `KogitoInfra` custom resource to handle the Kafka cluster deployment for you. This resource is added to your {PRODUCT} project and in the {PRODUCT} Operator page of the *Installed Operators* listed in the OpenShift web console, if applicable.
+When you install the Kafka infrastructure for your {PRODUCT} project using the {PRODUCT} CLI, the {PRODUCT} Operator creates a `KogitoInfra` custom resource to handle the Kafka cluster interaction for you. This resource is added to your {PRODUCT} project and in the {PRODUCT} Operator page of the *Installed Operators* listed in the OpenShift web console, if applicable.
 
-The {PRODUCT} Operator uses the https://strimzi.io/docs/latest/[Strimzi Operator] to deploy a Kafka cluster with Zookeeper to support sending and receiving messages within a process. Due to this dependency, the Strimzi Operator must be installed in the Kafka cluster. For information about Strimzi Operator installation, see the https://strimzi.io/docs/operators/master/quickstart.html[Strimzi Quick Start guide].
+The {PRODUCT} Operator uses the https://strimzi.io/docs/latest/[Strimzi Operator] to interact with a Kafka cluster with Zookeeper to support sending and receiving messages within a process. Due to this dependency, the Strimzi Operator must be installed and a Kafka cluster must be created. For information about Strimzi Operator installation, see the https://strimzi.io/docs/operators/master/quickstart.html[Strimzi Quick Start guide].
 
 After the Strimzi Operator deploys Kafka instances, you can edit the instances to meet your requirements.
 
@@ -1959,13 +1926,13 @@ If an Infinispan Server instance and an Apache Kafka cluster are not installed i
 .Enable Infinispan persistence
 [source,subs="attributes+,+quotes"]
 ----
-$ {PRODUCT_INIT} install infra __INFINISPAN_INFRA_NAME__ --kind Infinispan --apiVersion infinispan.org/v1 -p __PROJECT_NAME__
+$ {PRODUCT_INIT} install infra __INFINISPAN_INFRA_NAME__ --kind Infinispan --apiVersion infinispan.org/v1 --resource-name kogito-infinispan -p __PROJECT_NAME__
 ----
 
 .Enable Kafka messaging
 [source,subs="attributes+,+quotes"]
 ----
-$ {PRODUCT_INIT} install infra __KAFKA_INFRA_NAME__ --kind Kafka --apiVersion kafka.strimzi.io/v1beta1 -p __PROJECT_NAME__
+$ {PRODUCT_INIT} install infra __KAFKA_INFRA_NAME__ --kind Kafka --apiVersion kafka.strimzi.io/v1beta1 --resource-name kogito-kafka -p __PROJECT_NAME__
 ----
 
 [role="_additional-resources"]
@@ -2053,7 +2020,7 @@ To enable Infinispan persistence for the {PRODUCT} Jobs Service, you install the
 .Example Jobs Service deployment with Infinispan persistence enabled
 [source,subs="attributes+,+quotes"]
 ----
-$ {PRODUCT_INIT} install infra __INFINISPAN_INFRA_NAME__ --kind Infinispan --apiVersion infinispan.org/v1 -p __PROJECT_NAME__
+$ {PRODUCT_INIT} install infra __INFINISPAN_INFRA_NAME__ --kind Infinispan --apiVersion infinispan.org/v1 --resource-name kogito-infinispan -p __PROJECT_NAME__
 $ {PRODUCT_INIT} install jobs-service --infra __INFINISPAN_INFRA_NAME__
 ----
 
@@ -2124,13 +2091,13 @@ If an Infinispan Server instance and an Apache Kafka cluster are not installed i
 .Enable Infinispan persistence
 [source,subs="attributes+,+quotes"]
 ----
-$ {PRODUCT_INIT} install infra __INFINISPAN_INFRA_NAME__ --kind Infinispan --apiVersion infinispan.org/v1 -p __PROJECT_NAME__
+$ {PRODUCT_INIT} install infra __INFINISPAN_INFRA_NAME__ --kind Infinispan --apiVersion infinispan.org/v1 --resource-name kogito-infinispan -p __PROJECT_NAME__
 ----
 
 .Enable Kafka messaging
 [source,subs="attributes+,+quotes"]
 ----
-$ {PRODUCT_INIT} install infra __KAFKA_INFRA_NAME__ --kind Kafka --apiVersion kafka.strimzi.io/v1beta1 -p __PROJECT_NAME__
+$ {PRODUCT_INIT} install infra __KAFKA_INFRA_NAME__ --kind Kafka --apiVersion kafka.strimzi.io/v1beta1 --resource-name kogito-kafka -p __PROJECT_NAME__
 ----
 
 If the {PRODUCT} Explainability Service is enabled, then the Trusty Service also stores the explainability results for all the tracing events.
@@ -2160,7 +2127,7 @@ If an Apache Kafka cluster is not installed in the OpenShift namespace, you must
 .Enable Kafka messaging
 [source,subs="attributes+,+quotes"]
 ----
-$ {PRODUCT_INIT} install infra __KAFKA_INFRA_NAME__ --kind Kafka --apiVersion kafka.strimzi.io/v1beta1 -p __PROJECT_NAME__
+$ {PRODUCT_INIT} install infra __KAFKA_INFRA_NAME__ --kind Kafka --apiVersion kafka.strimzi.io/v1beta1 --resource-name kogito-kafka -p __PROJECT_NAME__
 ----
 
 [role="_additional-resources"]
@@ -2303,7 +2270,7 @@ NOTE: You must be logged in to the relevant Kubernetes cluster using the `kubect
 . If your {PRODUCT} project requires Infinispan or MongoDB persistence and Apache Kafka messaging, install the required Infinispan or MongoDB, and Kafka infrastructure components, including the https://github.com/infinispan/infinispan-operator[Infinispan Operator], https://github.com/mongodb/mongodb-kubernetes-operator/blob/master/README.md[MongoDB Operator] and the https://strimzi.io/docs/latest/[Strimzi Operator] (for Kafka cluster deployment with Zookeeper).
 +
 --
-The {PRODUCT} Operator cannot automatically install these operators for Infinispan or MongoDB persistence, and Kafka messaging, so you must install the components manually if needed.
+The {PRODUCT} Operator cannot automatically install these operators for Infinispan or MongoDB persistence, and Kafka messaging, so you must install the components manually if needed. Also, the specific resources are not created by the {PRODUCT} Operator, so you must create them before deploying the `KogitoInfra` resource.
 
 For information about Infinispan installation and configuration, see the https://infinispan.org/documentation/[Infinispan documentation].
 


### PR DESCRIPTION
Signed-off-by: Ricardo Zanini <zanini@redhat.com>

@hmanwani-rh In this PR we updated the OpenShift section to emphasize that our operator does not create third-party resources anymore. Now users must create them before deploying Kogito services.

See: https://issues.redhat.com/browse/KOGITO-4199