### PR TITLE
Upstream 7.48.x PR for BXMSDOC-7303: Include "New wrapper modules" section to 7.10 RHPAM/RHDM release notes.

### DIFF
--- a/_artifacts/document-attributes.adoc
+++ b/_artifacts/document-attributes.adoc
@@ -1,6 +1,5 @@
 
-:REBUILT: Monday, March 01, 2021
-
+:REBUILT: Wednesday, March 24, 2021
 
 
 :ENTERPRISE_VERSION: 7.10

--- a/doc-content/enterprise-only/release-notes/rn-whats-new-con.adoc
+++ b/doc-content/enterprise-only/release-notes/rn-whats-new-con.adoc
@@ -122,6 +122,19 @@ The {PROCESS_ENGINE} now supports the singleton timer start node in a process wi
 
 endif::PAM[]
 
+== New wrapper modules
+
+{PRODUCT} {ENTERPRISE_VERSION} now includes wrapper modules that you can use to reduce overhead and improve the maintenance of Drools engine. There is an ongoing effort to refactor Drools engine by identifying and descoping optional features that are unrelated to the internal algorithm of the engine. Drools engine uses MVEL for DRL parsing, constraints evaluation, and templates generation. Usages of MVEL are isolated in a new `drools-mvel` module. Drools engine implements KieSessions serialization with `protobuf` to ensure better backward compatibility. This serialization feature is isolated in the `drools-serialization-protobuf` module.
+
+You can add `drools-mvel` and `drools-serialization-protobuf` modules to your project classpath.
+
+{PRODUCT} now provides the following new wrapper modules:
+
+* *drools-engine*: Contains `drools-core`, `drools-compiler`, and `drools-model-compiler` dependencies
+* *drools-engine-classic*: Contains `drools-core`, `drools-compiler`, and `drools-mvel` dependencies
+
+To use the Drools engine with the executable model, you must include the `drools-engine` wrapper module in your project dependencies. To use the Drools engine without the executable model, you must import your dependencies to the `drools-engine-classic` wrapper module.
+
 == Integration
 
 ifdef::PAM[]


### PR DESCRIPTION
**Associated JIRA:** https://issues.redhat.com/browse/BXMSDOC-7303

**Doc preview links:** 
- [Release notes for Red Hat Process Automation Manager 7.10](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-7303-RN-WrapperModules-RHPAM/#new_wrapper_modules)
- [Release notes for Red Hat Decision Manager 7.10](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-7303-RN-WrapperModules-RHDM/#new_wrapper_modules)

**Doc impact:**
- Please check section **3.6. New wrapper modules** in the **RHPAM** document. 
- Please check section **3.4. New wrapper modules** in the **RHDM** document. (Same as RHPAM)
 