### PR TITLE
Upstream master PR for BXMSDOC-7467: Added sorting capability information in guided decision tables doc

### DIFF
--- a/assemblies/assembly-guided-decision-tables.adoc
+++ b/assemblies/assembly-guided-decision-tables.adoc
@@ -41,6 +41,8 @@ include::{drools-dir}/AuthoringAssets/guided-decision-tables-columns-types-con.a
 
 include::{drools-dir}/AuthoringAssets/guided-decision-tables-rulename-column-view-proc.adoc[leveloffset=+1]
 
+include::{drools-dir}/AuthoringAssets/proc-guided-decision-tables-columns-sort.adoc[leveloffset=+1]
+
 include::{drools-dir}/AuthoringAssets/guided-decision-tables-columns-edit-proc.adoc[leveloffset=+1]
 
 include::{drools-dir}/AuthoringAssets/guided-decision-tables-rows-create-proc.adoc[leveloffset=+1]

--- a/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/GuidedDecisionTableEditor-section.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/GuidedDecisionTableEditor-section.adoc
@@ -15,6 +15,8 @@ include::guided-decision-tables-columns-types-con.adoc[leveloffset=+1]
 
 include::guided-decision-tables-rulename-column-view-proc.adoc[leveloffset=+1]
 
+include::proc-guided-decision-tables-columns-sort.adoc[leveloffset=+1]
+
 include::guided-decision-tables-columns-edit-proc.adoc[leveloffset=+1]
 
 include::guided-decision-tables-rows-create-proc.adoc[leveloffset=+1]

--- a/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/guided-decision-tables-columns-create-proc.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/guided-decision-tables-columns-create-proc.adoc
@@ -27,7 +27,7 @@ image::Workbench/AuthoringAssets/guided-decision-tables-columns-add_1.png[View c
 +
 For descriptions of each column type and required parameters for setup, see xref:guided-decision-tables-columns-types-con[].
 +
-. Click *Finish* to add the configured column.
+. Click *Finish* to add the configured column. 
 
 After all columns are added, you can begin adding rows of rules correlating to your columns to complete the decision table. For details, see xref:guided-decision-tables-rows-create-proc[].
 

--- a/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/proc-guided-decision-tables-columns-sort.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/proc-guided-decision-tables-columns-sort.adoc
@@ -1,0 +1,11 @@
+[id='proc-guided-decision-tables-columns-sort_{context}']
+= Sorting column values in guided decision tables
+
+You can sort the values in columns that you created in a guided decision table.
+
+.Prerequisites
+* You created the required columns in a guided decision table.
+
+.Procedure
+. Double-click a column header that you want to sort in ascending order.
+. To sort the values of the same column in descending order, double-click the column header again.

--- a/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.7.52.0.Final/ReleaseNotesDrools.7.52.0.Final-section.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.7.52.0.Final/ReleaseNotesDrools.7.52.0.Final-section.adoc
@@ -5,3 +5,4 @@
 include::thread-safety-option.adoc[leveloffset=+1]
 include::direct-firing-option.adoc[leveloffset=+1]
 include::optimize-query-payload.adoc[leveloffset=+1]
+include::sort-column-guided-decision-tables.adoc[leveloffset=+1]

--- a/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.7.52.0.Final/sort-column-guided-decision-tables.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.7.52.0.Final/sort-column-guided-decision-tables.adoc
@@ -1,0 +1,5 @@
+[id='sort-column-guided-decision-tables']
+
+= Ability to sort column values in guided decision tables
+
+You can now sort the column values in a guided decision table. To sort a column value in ascending order, double-click the column header. Also, if you double-click the same column header, the column values are sorted in descending order.


### PR DESCRIPTION
See JIRA: https://issues.redhat.com/browse/BXMSDOC-7467
BAPL: https://issues.redhat.com/browse/BAPL-1619
Epic: https://issues.redhat.com/browse/BXMSDOC-7297

Added a new section as **Sorting column values in guided decision tables** in guided decision table doc.

Doc previews:
Enterprise
[32. Sorting column values in guided decision tables](http://file.pnq.redhat.com/~hmanwani/BXMSDOC-7467-RHPAM/#proc-guided-decision-tables-columns-sort_guided-decision-tables) in RHPAM
[32. Sorting column values in guided decision tables](http://file.pnq.redhat.com/~hmanwani/BXMSDOC-7467-RHDM/#proc-guided-decision-tables-columns-sort_guided-decision-tables) in RHDM

Community
[16.4.6. Sorting column values in guided decision tables](http://file.pnq.redhat.com/~hmanwani/BXMSDOC-7467-DROOLS/#proc-guided-decision-tables-columns-sort_kie-apis) in Drools