### PR TITLE
Removed misleading message on Lambda externalisation

### DIFF
--- a/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.7.33.0.Final/lambda-externalisation.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.7.33.0.Final/lambda-externalisation.adoc
@@ -16,4 +16,4 @@ Lambda externalization optimization provides the following advantages for your p
 
     Once the rete or phreak is instantiated from an executable model, it becomes garbage collectible.
 
-The above advantages provide optimized memory performance, however, it can also lead to `OutOfMemory` error.
+The above advantages provide optimized memory performance.


### PR DESCRIPTION
@hmanwani-rh discussing with users we realised that saying "optimized memory performance" and "lead to `OutOfMemory` error" in the same phrase is misleading. Also OOM errors are not really known in latest version so let's remove this