### PR TITLE
Upstream PR: BXMSDOC-7444-master-final to Master Changed instances of seconds to milliseconds per dev confirmation

### DIFF
--- a/doc-content/jbpm-docs/src/main/asciidoc/BPMN2/appe-service-tasks.adoc
+++ b/doc-content/jbpm-docs/src/main/asciidoc/BPMN2/appe-service-tasks.adoc
@@ -295,10 +295,10 @@ Content::
 The data you want to send. This attribute is mandatory for POST and PUT requests. This is an optional parameter. If you want to use it, map it as a data input variable in the *Data I/O* dialogue of the task.
 
 ConnectTimeout::
-The connection timeout. The default value is 60 seconds.
+The connection timeout. The default value is 60000 milliseconds. You must provide the input value in milliseconds.
 
 ReadTimeout::
-The timeout on response. The default value is 60 seconds.
+The timeout on response. The default value is 60000 milliseconds. You must provide the input value in milliseconds.
 +
 Username::
 The user name for authentication. This attribute overrides the handler initialization user name.

--- a/doc-content/jbpm-docs/src/main/asciidoc/BPMN2/con_custom-tasks-overview.adoc
+++ b/doc-content/jbpm-docs/src/main/asciidoc/BPMN2/con_custom-tasks-overview.adoc
@@ -95,8 +95,8 @@ You can click *Assignments* in the *Properties* panel to open the *REST Data I/O
 * *ContentTypeCharset*: Character set for the `ContentType`.
 * *Content*: Data you want to send. This attribute supports backward compatibility, use the *ContentData* attribute instead.
 * *ContentData*: Data you want to send. This attribute is mandatory for `POST` and `PUT` requests.
-* *ConnectTimeout*: Connection timeout (in seconds). The default value is 60 seconds.
-* *ReadTimeout*: Timeout (in seconds) on response. The default value is 60 seconds.
+* *ConnectTimeout*: Connection timeout (in seconds). The default value is 60000 milliseconds. You must provide the input value in milliseconds.
+* *ReadTimeout*: Timeout (in seconds) on response. The default value is 60000 milliseconds. You must provide the input value in milliseconds.
 * *Username*: User name for authentication.
 * *Password*: Password for authentication.
 * *AuthUrl*: URL that is handling authentication.


### PR DESCRIPTION
Modified the following to state milliseconds instead of seconds per reader comment:

ConnectTimeout: Connection timeout. The default value is 60000 milliseconds/60 seconds. The input value must be provided in milliseconds.
ReadTimeout: Timeout on response. The default value is 60000 milliseconds/60 seconds. The input value must be provided in milliseconds.

Original jira: https://issues.redhat.com/browse/BXMSDOC-7444
Rendered output:
jBPM: http://file.rdu.redhat.com/~mhaglund/BXMSDOC-7444_COMM/#con_custom-tasks-overview
PAM: http://file.rdu.redhat.com/~mhaglund/BXMSDOC-7444/#con_custom-tasks-overview