### PR TITLE
[DROOLS-6063] drools-decisiontables takes "100%" as String even in Pe…

### DIFF
--- a/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/decision-tables-rule-set-entries-ref.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/decision-tables-rule-set-entries-ref.adoc
@@ -31,7 +31,7 @@ The following table lists the supported labels and values for `RuleSet` definiti
 |Optional, at most once. If omitted, quotation marks are escaped.
 
 |`IgnoreNumericFormat`
-|`true` or `false`. If `true`, then the format for numeric values will be ignored (e.g. `Percent`, `Currency`).
+|`true` or `false`. If `true`, then the format for numeric values is ignored, for example, percent and currency.
 |Optional, at most once. If omitted, DRL takes formatted values.
 
 |`Import`

--- a/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/decision-tables-rule-set-entries-ref.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/decision-tables-rule-set-entries-ref.adoc
@@ -30,6 +30,10 @@ The following table lists the supported labels and values for `RuleSet` definiti
 |`true` or `false`. If `true`, then quotation marks are escaped so that they appear literally in the DRL.
 |Optional, at most once. If omitted, quotation marks are escaped.
 
+|`IgnoreNumericFormat`
+|`true` or `false`. If `true`, then the format for numeric values will be ignored (e.g. `Percent`, `Currency`).
+|Optional, at most once. If omitted, DRL takes formatted values.
+
 |`Import`
 |A comma-separated list of Java classes to import from another package.
 |Optional, may be used repeatedly.


### PR DESCRIPTION
…rcent format cell

- Introduced option 'IgnoreNumericFormat'

https://issues.redhat.com/browse/DROOLS-6063