### PR TITLE
KOGITO-4915: Fix docs after setContent fix for standalone editors

### DIFF
--- a/doc-content/shared-kie-docs/src/main/asciidoc/Install/proc-standalone-editors.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/Install/proc-standalone-editors.adoc
@@ -124,7 +124,7 @@ The returned object contains the methods that are required to manipulate the edi
 |`getContent(): Promise<string>`
 |Returns a promise containing the editor content.
 
-|`setContent(content: string): void`
+|`setContent(path:string, content: string): void`
 |Sets the content of the editor.
 
 |`getPreview(): Promise<string>`

--- a/doc-content/shared-kie-docs/src/main/asciidoc/Install/proc-standalone-editors.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/Install/proc-standalone-editors.adoc
@@ -124,7 +124,7 @@ The returned object contains the methods that are required to manipulate the edi
 |`getContent(): Promise<string>`
 |Returns a promise containing the editor content.
 
-|`setContent(path:string, content: string): void`
+|`setContent(path: string, content: string): void`
 |Sets the content of the editor.
 
 |`getPreview(): Promise<string>`


### PR DESCRIPTION
Updates docs to show setContent with path and content in standalone editors doc

cc: @paulovmr @jstastny-cz @sterobin 

https://issues.redhat.com/browse/KOGITO-4915