### PR TITLE
[KOGITO-4958] Setup Spring Boot/custom probes

### DIFF
--- a/doc-content/kogito-docs/src/main/asciidoc/creating-running/chap-kogito-creating-running.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/creating-running/chap-kogito-creating-running.adoc
@@ -583,20 +583,7 @@ $ mvn archetype:generate \
 mvn io.quarkus:quarkus-maven-plugin:create -DprojectGroupId=com.company -DprojectArtifactId=sample-kogito -Dextensions="kogito"
 ////
 
-.On Spring Boot
-[source,subs="attributes+"]
-----
-$ mvn archetype:generate \
-    -DarchetypeGroupId=org.kie.kogito \
-    -DarchetypeArtifactId=kogito-springboot-archetype \
-    -DgroupId=org.acme -DartifactId=sample-kogito \
-    -DarchetypeVersion={COMMUNITY_VERSION_FINAL} \
-    -Dversion=1.0-SNAPSHOT
-----
-
-This command generates a `sample-kogito` Maven project and imports the {PRODUCT} extension for all required dependencies and configurations to prepare your application for business automation.
-
-On Quarkus, if you plan to run your application on OpenShift or Kubernetes, you must also import the https://quarkus.io/guides/microprofile-health[Quarkus `smallrye-health` extension] for the https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes[liveness and readiness probes], as shown in the following example:
+If you plan to run your Quarkus application on OpenShift or Kubernetes, you must also import the https://quarkus.io/guides/microprofile-health[Quarkus `smallrye-health` extension] for the https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes[liveness, readiness and startup probes], as shown in the following example:
 
 .SmallRye Health extension for Quarkus applications on OpenShift
 [source]
@@ -609,11 +596,39 @@ This command generates the following dependency in the `pom.xml` file of your {P
 .SmallRye Heath dependency for Quarkus applications on OpenShift
 [source,xml]
 ----
-<dependency>
-  <groupId>io.quarkus</groupId>
-  <artifactId>quarkus-smallrye-health</artifactId>
-</dependency>
+<dependencies>
+  <dependency>
+    <groupId>io.quarkus</groupId>
+    <artifactId>quarkus-smallrye-health</artifactId>
+  </dependency>
+</dependencies>
 ----
+
+.On Spring Boot
+[source,subs="attributes+"]
+----
+$ mvn archetype:generate \
+    -DarchetypeGroupId=org.kie.kogito \
+    -DarchetypeArtifactId=kogito-springboot-archetype \
+    -DgroupId=org.acme -DartifactId=sample-kogito \
+    -DarchetypeVersion={COMMUNITY_VERSION_FINAL} \
+    -Dversion=1.0-SNAPSHOT
+----
+
+If you plan to run your Spring Boot application on OpenShift or Kubernetes, you must also import the https://docs.spring.io/spring-boot/docs/2.3.0.RELEASE/reference/html/production-ready-features.html[Spring Boot Actuator dependency] for the https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes[liveness, readiness and startup probes], as shown in the following example:
+
+.SmallRye Heath dependency for Quarkus applications on OpenShift
+[source,xml]
+----
+<dependencies>
+  <dependency>
+    <groupId>io.quarkus</groupId>
+    <artifactId>quarkus-smallrye-health</artifactId>
+  </dependency>
+</dependencies>
+----
+
+These commands generate a `sample-kogito` Maven project and imports the {PRODUCT} extension for all required dependencies and configurations to prepare your application for business automation.
 --
 . Open or import the project in your VSCode IDE to view the contents.
 

--- a/doc-content/kogito-docs/src/main/asciidoc/creating-running/chap-kogito-creating-running.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/creating-running/chap-kogito-creating-running.adoc
@@ -583,6 +583,7 @@ $ mvn archetype:generate \
 mvn io.quarkus:quarkus-maven-plugin:create -DprojectGroupId=com.company -DprojectArtifactId=sample-kogito -Dextensions="kogito"
 ////
 
+[id="proc-kogito-creating-project-spring-boot_{context}"]
 .On Spring Boot
 [source,subs="attributes+"]
 ----

--- a/doc-content/kogito-docs/src/main/asciidoc/creating-running/chap-kogito-creating-running.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/creating-running/chap-kogito-creating-running.adoc
@@ -583,9 +583,9 @@ $ mvn archetype:generate \
 mvn io.quarkus:quarkus-maven-plugin:create -DprojectGroupId=com.company -DprojectArtifactId=sample-kogito -Dextensions="kogito"
 ////
 
-If you plan to run your Quarkus application on OpenShift or Kubernetes, you must also import the https://quarkus.io/guides/microprofile-health[Quarkus `smallrye-health` extension] for the https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes[liveness, readiness and startup probes], as shown in the following example:
+If you plan to run your Quarkus application on {OPENSHIFT} or Kubernetes, you must also import the https://quarkus.io/guides/microprofile-health[Quarkus `smallrye-health` extension] for the https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes[liveness, readiness, and startup probes], as shown in the following example:
 
-.SmallRye Health extension for Quarkus applications on OpenShift
+.SmallRye Health extension for Quarkus applications on {OPENSHIFT}
 [source]
 ----
 $ mvn quarkus:add-extension -Dextensions="smallrye-health"
@@ -593,7 +593,7 @@ $ mvn quarkus:add-extension -Dextensions="smallrye-health"
 
 This command generates the following dependency in the `pom.xml` file of your {PRODUCT} project on Quarkus:
 
-.SmallRye Heath dependency for Quarkus applications on OpenShift
+.SmallRye Health dependency for Quarkus applications on {OPENSHIFT}
 [source,xml]
 ----
 <dependencies>
@@ -615,9 +615,9 @@ $ mvn archetype:generate \
     -Dversion=1.0-SNAPSHOT
 ----
 
-If you plan to run your Spring Boot application on OpenShift or Kubernetes, you must also import the https://docs.spring.io/spring-boot/docs/2.3.0.RELEASE/reference/html/production-ready-features.html[Spring Boot Actuator dependency] for the https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes[liveness, readiness and startup probes], as shown in the following example:
+If you plan to run your Spring Boot application on {OPENSHIFT} or Kubernetes, you must also import the https://docs.spring.io/spring-boot/docs/2.3.0.RELEASE/reference/html/production-ready-features.html[Spring Boot Actuator dependency] for the https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes[liveness, readiness, and startup probes], as shown in the following example:
 
-.SmallRye Heath dependency for Quarkus applications on OpenShift
+.SmallRye Health dependency for Quarkus applications on {OPENSHIFT}
 [source,xml]
 ----
 <dependencies>
@@ -628,7 +628,7 @@ If you plan to run your Spring Boot application on OpenShift or Kubernetes, you 
 </dependencies>
 ----
 
-These commands generate a `sample-kogito` Maven project and imports the {PRODUCT} extension for all required dependencies and configurations to prepare your application for business automation.
+These commands generate a `sample-kogito` Maven project and import the {PRODUCT} extension for all required dependencies and configurations to prepare your application for business automation.
 --
 . Open or import the project in your VSCode IDE to view the contents.
 

--- a/doc-content/kogito-docs/src/main/asciidoc/creating-running/chap-kogito-creating-running.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/creating-running/chap-kogito-creating-running.adoc
@@ -583,27 +583,6 @@ $ mvn archetype:generate \
 mvn io.quarkus:quarkus-maven-plugin:create -DprojectGroupId=com.company -DprojectArtifactId=sample-kogito -Dextensions="kogito"
 ////
 
-If you plan to run your Quarkus application on {OPENSHIFT} or Kubernetes, you must also import the https://quarkus.io/guides/microprofile-health[Quarkus `smallrye-health` extension] for the https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes[liveness, readiness, and startup probes], as shown in the following example:
-
-.SmallRye Health extension for Quarkus applications on {OPENSHIFT}
-[source]
-----
-$ mvn quarkus:add-extension -Dextensions="smallrye-health"
-----
-
-This command generates the following dependency in the `pom.xml` file of your {PRODUCT} project on Quarkus:
-
-.SmallRye Health dependency for Quarkus applications on {OPENSHIFT}
-[source,xml]
-----
-<dependencies>
-  <dependency>
-    <groupId>io.quarkus</groupId>
-    <artifactId>quarkus-smallrye-health</artifactId>
-  </dependency>
-</dependencies>
-----
-
 .On Spring Boot
 [source,subs="attributes+"]
 ----
@@ -613,19 +592,6 @@ $ mvn archetype:generate \
     -DgroupId=org.acme -DartifactId=sample-kogito \
     -DarchetypeVersion={COMMUNITY_VERSION_FINAL} \
     -Dversion=1.0-SNAPSHOT
-----
-
-If you plan to run your Spring Boot application on {OPENSHIFT} or Kubernetes, you must also import the https://docs.spring.io/spring-boot/docs/2.3.0.RELEASE/reference/html/production-ready-features.html[Spring Boot Actuator dependency] for the https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes[liveness, readiness, and startup probes], as shown in the following example:
-
-.SmallRye Health dependency for Quarkus applications on {OPENSHIFT}
-[source,xml]
-----
-<dependencies>
-  <dependency>
-    <groupId>io.quarkus</groupId>
-    <artifactId>quarkus-smallrye-health</artifactId>
-  </dependency>
-</dependencies>
 ----
 
 These commands generate a `sample-kogito` Maven project and import the {PRODUCT} extension for all required dependencies and configurations to prepare your application for business automation.

--- a/doc-content/kogito-docs/src/main/asciidoc/openshift/chap-kogito-deploying-on-openshift.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/openshift/chap-kogito-deploying-on-openshift.adoc
@@ -27,14 +27,16 @@ To help you deploy your services on OpenShift, {PRODUCT} provides an operator an
 == Probes for {PRODUCT} services on {OPENSHIFT}
 
 [role="_abstract"]
-On {OPENSHIFT} and Kubernetes, https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes[liveness, readiness, and startup probes] check whether an application is ready and working or needs to be restarted. For {PRODUCT} services on Quarkus and Spring Boot, probes communicate with the application through an HTTP request, defaulting to endpoints exposed by an extension. Therefore, to run your {PRODUCT} services on OpenShift or Kubernetes, you must import the these extensions in order to enable the liveness, readiness and startup probes for your application.
+The probes in {OPENSHFT} and Kubernetes verify that an application is working or it needs to be restarted. For {PRODUCT} services on Quarkus and Spring Boot, probes interact with the application using an HTTP request, defaulting to the endpoints that are exposed by an extension. Therefore, to run your {PRODUCT} services on {OPENSHIFT} or Kubernetes, you must import the extensions to enable the https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes[liveness, readiness, and startup probes] for your application.
 
-=== Enabling probes for Quarkus-based {PRODUCT} services on OpenShift
+=== Enabling probes for Quarkus-based {PRODUCT} services on {OPENSHIFT}
+
+You can enable the probes for the Quarkus-based {PRODUCT} services on {OPENSHIFT}.
 
 .Procedure
-In a command terminal, navigate to the `pom.xml` file of your {PRODUCT} project and add the following dependency for the https://quarkus.io/guides/microprofile-health[Quarkus `smallrye-health`] extension:
+. In a command terminal, navigate to the `pom.xml` file of your {PRODUCT} project and add the following dependency for the https://quarkus.io/guides/microprofile-health[Quarkus `smallrye-health`] extension:
 
-.SmallRye Heath dependency for Quarkus applications on OpenShift
+.SmallRye Health dependency for Quarkus applications on {OPENSHIFT}
 [source,xml]
 ----
 <dependencies>
@@ -45,12 +47,14 @@ In a command terminal, navigate to the `pom.xml` file of your {PRODUCT} project 
 </dependencies>
 ----
 
-=== Enabling probes for Spring Boot-based {PRODUCT} services on OpenShift
+=== Enabling probes for Spring Boot-based {PRODUCT} services on {OPENSHIFT}
+
+You can enable the probes for the Spring Boot-based {PRODUCT} services on {OPENSHIFT}.
 
 .Procedure
-In a command terminal, navigate to the `pom.xml` file of your {PRODUCT} project and add the following https://docs.spring.io/spring-boot/docs/2.3.0.RELEASE/reference/html/production-ready-features.html[Spring Boot Actuator dependency]:
+. In a command terminal, navigate to the `pom.xml` file of your {PRODUCT} project and add the following https://docs.spring.io/spring-boot/docs/2.3.0.RELEASE/reference/html/production-ready-features.html[Spring Boot actuator dependency]:
 
-.Spring Boot Actuator dependency for Quarkus applications on OpenShift
+.Spring Boot Actuator dependency for Quarkus applications on {OPENSHIFT}
 [source,xml]
 ----
 <dependencies>
@@ -61,9 +65,12 @@ In a command terminal, navigate to the `pom.xml` file of your {PRODUCT} project 
 </dependencies>
 ----
 
-=== Setting up custom probes for {PRODUCT} services on OpenShift
+=== Setting custom probes for {PRODUCT} services on {OPENSHIFT}
 
-Alternatively, if you want to configure custom endpoints for the liveness, readiness and startup probes, you can define the probes in the `KogitoRuntime` YAML file of your {PRODUCT} project, as shown in the following example:
+You can also configure the custom endpoints for the liveness, readiness, and startup probes.
+
+.Procedure
+. Define the probes in the `KogitoRuntime` YAML file of your {PRODUCT} project, as shown in the following example:
 
 [source,yaml,subs="attributes+"]
 .Example {PRODUCT} service custom resource with custom probe endpoints
@@ -97,9 +104,9 @@ After you create your {PRODUCT} services as part of a business application, you 
 .Prerequisites
 * The application with your {PRODUCT} services is in a Git repository that is reachable from your OpenShift environment.
 * You have access to the OpenShift web console with `cluster-admin` permissions.
-* (Quarkus only) The `pom.xml` file of your {PRODUCT} project contains the following dependency for the https://quarkus.io/guides/microprofile-health[Quarkus `smallrye-health` extension]. This extension enables the https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes[liveness, readiness and startup probes] that are required for Quarkus-based projects on OpenShift or Kubernetes.
+* (Quarkus only) The `pom.xml` file of your {PRODUCT} project contains the following dependency for the https://quarkus.io/guides/microprofile-health[Quarkus `smallrye-health` extension]. This extension enables the https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes[liveness, readiness, and startup probes] that are required for Quarkus-based projects on {OPENSHIFT} or Kubernetes.
 +
-.SmallRye Heath dependency for Quarkus applications on OpenShift
+.SmallRye Heath dependency for Quarkus applications on {OPENSHIFT}
 [source,xml]
 ----
 <dependencies>
@@ -109,9 +116,9 @@ After you create your {PRODUCT} services as part of a business application, you 
   </dependency>
 </dependencies>
 ----
-* (Spring Boot only) The `pom.xml` file of your {PRODUCT} project contains the following https://docs.spring.io/spring-boot/docs/2.3.0.RELEASE/reference/html/production-ready-features.html[Spring Boot Actuator dependency]. This dependency enables the https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes[liveness, readiness and startup probes] that are required for Spring Boot-based projects on OpenShift or Kubernetes.
+* (Spring Boot only) The `pom.xml` file of your {PRODUCT} project contains the following https://docs.spring.io/spring-boot/docs/2.3.0.RELEASE/reference/html/production-ready-features.html[Spring Boot actuator dependency]. This dependency enables the https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes[liveness, readiness, and startup probes] that are required for Spring Boot-based projects on {OPENSHIFT} or Kubernetes.
 +
-.Spring Boot Actuator dependency for Quarkus applications on OpenShift
+.Spring Boot actuator dependency for Quarkus applications on {OPENSHIFT}
 [source,xml]
 ----
 <dependencies>
@@ -258,9 +265,9 @@ ifdef::KOGITO-COMM[]
 https://docs.openshift.com/container-platform/4.2/cli_reference/openshift_cli/getting-started-cli.html[OpenShift documentation].
 endif::[]
 * You have OpenShift permissions to create resources in a specified namespace.
-* (Quarkus only) The `pom.xml` file of your {PRODUCT} project contains the following dependency for the https://quarkus.io/guides/microprofile-health[Quarkus `smallrye-health` extension]. This extension enables the https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes[liveness, readiness and startup probes] that are required for Quarkus-based projects on OpenShift or Kubernetes.
+* (Quarkus only) The `pom.xml` file of your {PRODUCT} project contains the following dependency for the https://quarkus.io/guides/microprofile-health[Quarkus `smallrye-health` extension]. This extension enables the https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes[liveness, readiness, and startup probes] that are required for Quarkus-based projects on {OPENSHIFT} or Kubernetes.
 +
-.SmallRye Heath dependency for Quarkus applications on OpenShift
+.SmallRye Heath dependency for Quarkus applications on {OPENSHIFT}
 [source,xml]
 ----
 <dependency>
@@ -268,9 +275,9 @@ endif::[]
   <artifactId>quarkus-smallrye-health</artifactId>
 </dependency>
 ----
-* (Spring Boot only) The `pom.xml` file of your {PRODUCT} project contains the following https://docs.spring.io/spring-boot/docs/2.3.0.RELEASE/reference/html/production-ready-features.html[Spring Boot Actuator dependency]. This extension enables the https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes[liveness, readiness and startup probes] that are required for Spring Boot-based projects on OpenShift or Kubernetes.
+* (Spring Boot only) The `pom.xml` file of your {PRODUCT} project contains the following https://docs.spring.io/spring-boot/docs/2.3.0.RELEASE/reference/html/production-ready-features.html[Spring Boot Actuator dependency]. This extension enables the https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes[liveness, readiness, and startup probes] that are required for Spring Boot-based projects on {OPENSHIFT} or Kubernetes.
 +
-.Spring Boot Actuator dependency for Quarkus applications on OpenShift
+.Spring Boot Actuator dependency for Quarkus applications on {OPENSHIFT}
 [source,xml]
 ----
 <dependencies>

--- a/doc-content/kogito-docs/src/main/asciidoc/openshift/chap-kogito-deploying-on-openshift.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/openshift/chap-kogito-deploying-on-openshift.adoc
@@ -24,28 +24,46 @@ To help you deploy your services on OpenShift, {PRODUCT} provides an operator an
 * *{PRODUCT} command-line interface (CLI)*: A CLI tool that enables you to interact with the {PRODUCT} Operator for deployment tasks. The {PRODUCT} CLI also enables you to deploy {PRODUCT} services from source instead of relying on custom resources and YAML files. You can use the {PRODUCT} CLI as a command-line alternative for deploying {PRODUCT} services without the {OPENSHIFT} web console.
 
 [id="proc-kogito-enabling-probes_{context}"]
-== Enabling probes for Quarkus-based {PRODUCT} services on OpenShift
+== Enabling probes for {PRODUCT} services on OpenShift
 
 [role="_abstract"]
-On OpenShift and Kubernetes, https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes[liveness and readiness probes] check whether an application is ready and working or needs to be restarted. For {PRODUCT} services on Spring Boot, probes communicate with the application through a TCP socket, defaulting to port 8080. For {PRODUCT} services on Quarkus, probes communicate with the application through an HTTP request, typically using the endpoint `/q/health`. This endpoint is exposed by the https://quarkus.io/guides/microprofile-health[Quarkus `smallrye-health` extension], which is required for all Quarkus-based {PRODUCT} services on OpenShift or Kubernetes.
+On OpenShift and Kubernetes, https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes[liveness, readiness and startup probes] check whether an application is ready and working or needs to be restarted. For {PRODUCT} services on Quarkus and Spring Boot, probes communicate with the application through an HTTP request, defaulting to endpoints exposed by an extension. Therefore, to run your {PRODUCT} services on OpenShift or Kubernetes, you must import the these extensions in order to enable the liveness, readiness and startup probes for your application.
 
-Therefore, to run your Quarkus-based {PRODUCT} services on OpenShift or Kubernetes, you must import the Quarkus `smallrye-health` extension in order to enable the liveness and readiness probes for your application.
-
-NOTE: The {PRODUCT} Operator currently does not support startup probes.
+=== Enabling probes for Quarkus-based {PRODUCT} services on OpenShift
 
 .Procedure
-In a command terminal, navigate to the `pom.xml` file of your {PRODUCT} project and add the following dependency for the `smallrye-health` extension:
+In a command terminal, navigate to the `pom.xml` file of your {PRODUCT} project and add the following dependency for the https://quarkus.io/guides/microprofile-health[Quarkus `smallrye-health`] extension:
 
 .SmallRye Heath dependency for Quarkus applications on OpenShift
 [source,xml]
 ----
-<dependency>
-  <groupId>io.quarkus</groupId>
-  <artifactId>quarkus-smallrye-health</artifactId>
-</dependency>
+<dependencies>
+  <dependency>
+    <groupId>io.quarkus</groupId>
+    <artifactId>quarkus-smallrye-health</artifactId>
+  </dependency>
+</dependencies>
 ----
 
-Alternatively, if you want to configure custom endpoints for the liveness and readiness probes, you can define the probes in the `KogitoRuntime` YAML file of your {PRODUCT} project, as shown in the following example:
+=== Enabling probes for Spring Boot-based {PRODUCT} services on OpenShift
+
+.Procedure
+In a command terminal, navigate to the `pom.xml` file of your {PRODUCT} project and add the following https://docs.spring.io/spring-boot/docs/2.3.0.RELEASE/reference/html/production-ready-features.html[Spring Boot Actuator dependency]:
+
+.Spring Boot Actuator dependency for Quarkus applications on OpenShift
+[source,xml]
+----
+<dependencies>
+  <dependency>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-actuator</artifactId>
+  </dependency>
+</dependencies>
+----
+
+=== Setting up custom probes for {PRODUCT} services on OpenShift
+
+Alternatively, if you want to configure custom endpoints for the liveness, readiness and startup probes, you can define the probes in the `KogitoRuntime` YAML file of your {PRODUCT} project, as shown in the following example:
 
 [source,yaml,subs="attributes+"]
 .Example {PRODUCT} service custom resource with custom probe endpoints
@@ -65,6 +83,9 @@ spec:
       httpGet:
         path: /probes/ready # Readiness endpoint
         port: 8080
+    startupProbe:
+      tcpSocket:
+        port: 8080
 ----
 
 [id="proc-kogito-deploying-on-ocp-console_{context}"]
@@ -76,15 +97,29 @@ After you create your {PRODUCT} services as part of a business application, you 
 .Prerequisites
 * The application with your {PRODUCT} services is in a Git repository that is reachable from your OpenShift environment.
 * You have access to the OpenShift web console with `cluster-admin` permissions.
-* (Quarkus only) The `pom.xml` file of your {PRODUCT} project contains the following dependency for the https://quarkus.io/guides/microprofile-health[Quarkus `smallrye-health` extension]. This extension enables the https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes[liveness and readiness probes] that are required for Quarkus-based projects on OpenShift or Kubernetes.
+* (Quarkus only) The `pom.xml` file of your {PRODUCT} project contains the following dependency for the https://quarkus.io/guides/microprofile-health[Quarkus `smallrye-health` extension]. This extension enables the https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes[liveness, readiness and startup probes] that are required for Quarkus-based projects on OpenShift or Kubernetes.
 +
 .SmallRye Heath dependency for Quarkus applications on OpenShift
 [source,xml]
 ----
-<dependency>
-  <groupId>io.quarkus</groupId>
-  <artifactId>quarkus-smallrye-health</artifactId>
-</dependency>
+<dependencies>
+  <dependency>
+    <groupId>io.quarkus</groupId>
+    <artifactId>quarkus-smallrye-health</artifactId>
+  </dependency>
+</dependencies>
+----
+* (Spring Boot only) The `pom.xml` file of your {PRODUCT} project contains the following https://docs.spring.io/spring-boot/docs/2.3.0.RELEASE/reference/html/production-ready-features.html[Spring Boot Actuator dependency]. This dependency enables the https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes[liveness, readiness and startup probes] that are required for Spring Boot-based projects on OpenShift or Kubernetes.
++
+.Spring Boot Actuator dependency for Quarkus applications on OpenShift
+[source,xml]
+----
+<dependencies>
+  <dependency>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-actuator</artifactId>
+  </dependency>
+</dependencies>
 ----
 
 .Procedure
@@ -223,7 +258,7 @@ ifdef::KOGITO-COMM[]
 https://docs.openshift.com/container-platform/4.2/cli_reference/openshift_cli/getting-started-cli.html[OpenShift documentation].
 endif::[]
 * You have OpenShift permissions to create resources in a specified namespace.
-* (Quarkus only) The `pom.xml` file of your {PRODUCT} project contains the following dependency for the https://quarkus.io/guides/microprofile-health[Quarkus `smallrye-health` extension]. This extension enables the https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes[liveness and readiness probes] that are required for Quarkus-based projects on OpenShift or Kubernetes.
+* (Quarkus only) The `pom.xml` file of your {PRODUCT} project contains the following dependency for the https://quarkus.io/guides/microprofile-health[Quarkus `smallrye-health` extension]. This extension enables the https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes[liveness, readiness and startup probes] that are required for Quarkus-based projects on OpenShift or Kubernetes.
 +
 .SmallRye Heath dependency for Quarkus applications on OpenShift
 [source,xml]
@@ -232,6 +267,18 @@ endif::[]
   <groupId>io.quarkus</groupId>
   <artifactId>quarkus-smallrye-health</artifactId>
 </dependency>
+----
+* (Spring Boot only) The `pom.xml` file of your {PRODUCT} project contains the following https://docs.spring.io/spring-boot/docs/2.3.0.RELEASE/reference/html/production-ready-features.html[Spring Boot Actuator dependency]. This extension enables the https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes[liveness, readiness and startup probes] that are required for Spring Boot-based projects on OpenShift or Kubernetes.
++
+.Spring Boot Actuator dependency for Quarkus applications on OpenShift
+[source,xml]
+----
+<dependencies>
+  <dependency>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-actuator</artifactId>
+  </dependency>
+</dependencies>
 ----
 
 .Procedure
@@ -353,16 +400,6 @@ endif::[]
 * Git is installed.
 * JDK 11 or later is installed. (https://www.graalvm.org/[GraalVM] is recommended.)
 * Apache Maven 3.6.2 or later is installed.
-* (Quarkus only) The `pom.xml` file of your {PRODUCT} project contains the following dependency for the https://quarkus.io/guides/microprofile-health[Quarkus `smallrye-health` extension]. This extension enables the https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes[liveness and readiness probes] that are required for Quarkus-based projects on OpenShift or Kubernetes.
-+
-.SmallRye Heath dependency for Quarkus applications on OpenShift
-[source,xml]
-----
-<dependency>
-  <groupId>io.quarkus</groupId>
-  <artifactId>quarkus-smallrye-health</artifactId>
-</dependency>
-----
 
 [id="proc-kogito-travel-agency-clone-repo_{context}"]
 === Cloning the {PRODUCT} examples Git repository

--- a/doc-content/kogito-docs/src/main/asciidoc/openshift/chap-kogito-deploying-on-openshift.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/openshift/chap-kogito-deploying-on-openshift.adoc
@@ -24,10 +24,10 @@ To help you deploy your services on OpenShift, {PRODUCT} provides an operator an
 * *{PRODUCT} command-line interface (CLI)*: A CLI tool that enables you to interact with the {PRODUCT} Operator for deployment tasks. The {PRODUCT} CLI also enables you to deploy {PRODUCT} services from source instead of relying on custom resources and YAML files. You can use the {PRODUCT} CLI as a command-line alternative for deploying {PRODUCT} services without the {OPENSHIFT} web console.
 
 [id="proc-kogito-enabling-probes_{context}"]
-== Enabling probes for {PRODUCT} services on OpenShift
+== Probes for {PRODUCT} services on {OPENSHIFT}
 
 [role="_abstract"]
-On OpenShift and Kubernetes, https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes[liveness, readiness and startup probes] check whether an application is ready and working or needs to be restarted. For {PRODUCT} services on Quarkus and Spring Boot, probes communicate with the application through an HTTP request, defaulting to endpoints exposed by an extension. Therefore, to run your {PRODUCT} services on OpenShift or Kubernetes, you must import the these extensions in order to enable the liveness, readiness and startup probes for your application.
+On {OPENSHIFT} and Kubernetes, https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes[liveness, readiness, and startup probes] check whether an application is ready and working or needs to be restarted. For {PRODUCT} services on Quarkus and Spring Boot, probes communicate with the application through an HTTP request, defaulting to endpoints exposed by an extension. Therefore, to run your {PRODUCT} services on OpenShift or Kubernetes, you must import the these extensions in order to enable the liveness, readiness and startup probes for your application.
 
 === Enabling probes for Quarkus-based {PRODUCT} services on OpenShift
 

--- a/doc-content/kogito-docs/src/main/asciidoc/openshift/chap-kogito-deploying-on-openshift.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/openshift/chap-kogito-deploying-on-openshift.adoc
@@ -54,7 +54,7 @@ You can enable the probes for the Spring Boot-based {PRODUCT} services on {OPENS
 .Procedure
 . In a command terminal, navigate to the `pom.xml` file of your {PRODUCT} project and add the following https://docs.spring.io/spring-boot/docs/2.3.0.RELEASE/reference/html/production-ready-features.html[Spring Boot actuator dependency]:
 
-.Spring Boot Actuator dependency for Quarkus applications on {OPENSHIFT}
+.Spring Boot actuator dependency for Spring Boot applications on {OPENSHIFT}
 [source,xml]
 ----
 <dependencies>
@@ -118,7 +118,7 @@ After you create your {PRODUCT} services as part of a business application, you 
 ----
 * (Spring Boot only) The `pom.xml` file of your {PRODUCT} project contains the following https://docs.spring.io/spring-boot/docs/2.3.0.RELEASE/reference/html/production-ready-features.html[Spring Boot actuator dependency]. This dependency enables the https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes[liveness, readiness, and startup probes] that are required for Spring Boot-based projects on {OPENSHIFT} or Kubernetes.
 +
-.Spring Boot actuator dependency for Quarkus applications on {OPENSHIFT}
+.Spring Boot actuator dependency for Spring Boot applications on {OPENSHIFT}
 [source,xml]
 ----
 <dependencies>
@@ -277,7 +277,7 @@ endif::[]
 ----
 * (Spring Boot only) The `pom.xml` file of your {PRODUCT} project contains the following https://docs.spring.io/spring-boot/docs/2.3.0.RELEASE/reference/html/production-ready-features.html[Spring Boot Actuator dependency]. This extension enables the https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes[liveness, readiness, and startup probes] that are required for Spring Boot-based projects on {OPENSHIFT} or Kubernetes.
 +
-.Spring Boot Actuator dependency for Quarkus applications on {OPENSHIFT}
+.Spring Boot actuator dependency for Spring Boot applications on {OPENSHIFT}
 [source,xml]
 ----
 <dependencies>

--- a/doc-content/kogito-docs/src/main/asciidoc/openshift/chap-kogito-deploying-on-openshift.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/openshift/chap-kogito-deploying-on-openshift.adoc
@@ -27,7 +27,7 @@ To help you deploy your services on OpenShift, {PRODUCT} provides an operator an
 == Probes for {PRODUCT} services on {OPENSHIFT}
 
 [role="_abstract"]
-The probes in {OPENSHFT} and Kubernetes verify that an application is working or it needs to be restarted. For {PRODUCT} services on Quarkus and Spring Boot, probes interact with the application using an HTTP request, defaulting to the endpoints that are exposed by an extension. Therefore, to run your {PRODUCT} services on {OPENSHIFT} or Kubernetes, you must import the extensions to enable the https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes[liveness, readiness, and startup probes] for your application.
+The probes in {OPENSHIFT} and Kubernetes verify that an application is working or it needs to be restarted. For {PRODUCT} services on Quarkus and Spring Boot, probes interact with the application using an HTTP request, defaulting to the endpoints that are exposed by an extension. Therefore, to run your {PRODUCT} services on {OPENSHIFT} or Kubernetes, you must import the extensions to enable the https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes[liveness, readiness, and startup probes] for your application.
 
 === Enabling probes for Quarkus-based {PRODUCT} services on {OPENSHIFT}
 

--- a/doc-content/kogito-docs/src/main/asciidoc/release-notes/chap-kogito-release-notes.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/release-notes/chap-kogito-release-notes.adoc
@@ -120,9 +120,9 @@ For more information about the add-on configuration, see {URL_CONFIGURING_KOGITO
 
 The {PRODUCT} operator now uses https://docs.spring.io/spring-boot/docs/2.3.0.RELEASE/reference/html/production-ready-features.html#production-ready-kubernetes-probes[actuator endpoints] for https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes[liveness, readiness, and startup probes] by default. The actuator endpoints provide better information about the application status and possible problems as compared to the TCP sockets, which were previously used for Spring Boot.
 
-When you create a project using the {URL_CONFIGURING_KOGITO}#proc-kogito-creating-project-spring-boot[_Spring Boot Maven archetype generation command_], then it is not required to perform any other step as actuator dependency is added to the Spring Boot archetypes. However, when you have already created a project and deployed the project on {OPENSHIFT} or Kubernetes, and you want to upgrade the {PRODUCT} operator to {PRODUCT_VERSION}, then you must add the following Spring Boot actuator dependency to `pom.xml` file:
+When you create a project using the {URL_CONFIGURING_KOGITO}#proc-kogito-creating-project-spring-boot[_Spring Boot Maven archetype generation command_], then it is not required to perform any other step as the actuator dependency is added to the Spring Boot archetypes. However, when you have already created a project and deployed the project on {OPENSHIFT} or Kubernetes, and you want to upgrade the {PRODUCT} operator to {PRODUCT_VERSION}, then you must add the following Spring Boot actuator dependency to `pom.xml` file:
 
-.Example Spring Boot actuator dependency for Quarkus applications on {OPENSHIFT}
+.Example Spring Boot actuator dependency for Spring Boot applications on {OPENSHIFT}
 [source,xml]
 ----
 <dependencies>

--- a/doc-content/kogito-docs/src/main/asciidoc/release-notes/chap-kogito-release-notes.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/release-notes/chap-kogito-release-notes.adoc
@@ -112,7 +112,7 @@ For more information about PostgreSQL persistence in {PRODUCT}, see {URL_CONFIGU
 
 The Spring Boot projects can now include the {PRODUCT} process SVG add-on that enables the basic REST operations to view the process diagram and execution path of the related process instances.
 
-For more information about the add-on configuration, see {URL_CONFIGURING_KOGITO}#con-bpmn-process-svg-addon[_{PRODUCT} process SVG add-on_].
+For more information about the add-on configuration, see xref:con-bpmn-process-svg-addon_kogito-developing-process-services[_{PRODUCT} process SVG add-on_].
 
 === {PRODUCT} Operator and CLI
 
@@ -120,7 +120,7 @@ For more information about the add-on configuration, see {URL_CONFIGURING_KOGITO
 
 The {PRODUCT} operator now uses https://docs.spring.io/spring-boot/docs/2.3.0.RELEASE/reference/html/production-ready-features.html#production-ready-kubernetes-probes[actuator endpoints] for https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes[liveness, readiness, and startup probes] by default. The actuator endpoints provide better information about the application status and possible problems as compared to the TCP sockets, which were previously used for Spring Boot.
 
-When you create a project using the {URL_CONFIGURING_KOGITO}#proc-kogito-creating-project-spring-boot[_Spring Boot Maven archetype generation command_], then it is not required to perform any other step as the actuator dependency is added to the Spring Boot archetypes. However, when you have already created a project and deployed the project on {OPENSHIFT} or Kubernetes, and you want to upgrade the {PRODUCT} operator to {PRODUCT_VERSION}, then you must add the following Spring Boot actuator dependency to `pom.xml` file:
+When you create a project using the xref:proc-kogito-creating-project-spring-boot_kogito-creating-running[_Spring Boot Maven archetype generation command_], then it is not required to perform any other step as the actuator dependency is added to the Spring Boot archetypes. However, when you have already created a project and deployed the project on {OPENSHIFT} or Kubernetes, and you want to upgrade the {PRODUCT} operator to {PRODUCT_VERSION}, then you must add the following Spring Boot actuator dependency to `pom.xml` file:
 
 .Example Spring Boot actuator dependency for Spring Boot applications on {OPENSHIFT}
 [source,xml]

--- a/doc-content/kogito-docs/src/main/asciidoc/release-notes/chap-kogito-release-notes.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/release-notes/chap-kogito-release-notes.adoc
@@ -116,13 +116,13 @@ For more information about the add-on configuration, see {URL_CONFIGURING_KOGITO
 
 === {PRODUCT} Operator and CLI
 
-==== Spring Boot actuator dependency now required to deploy on {OPENSHIFT}/Kubernetes
+==== Deploy the Spring Boot actuator dependency on {OPENSHIFT} or Kubernetes
 
-By default, the operator now uses https://docs.spring.io/spring-boot/docs/2.3.0.RELEASE/reference/html/production-ready-features.html#production-ready-kubernetes-probes[actuator endpoints] for https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes[liveness, readiness, and startup probes]. These HTTP endpoints are an improvement over the TCP sockets that were previously used for Spring Boot as they provide better information about application status and its possible problems. 
+The {PRODUCT} operator now uses https://docs.spring.io/spring-boot/docs/2.3.0.RELEASE/reference/html/production-ready-features.html#production-ready-kubernetes-probes[actuator endpoints] for https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes[liveness, readiness, and startup probes] by default. The actuator endpoints provide better information about the application status and possible problems as compared to the TCP sockets, which were previously used for Spring Boot.
 
-If you are creating a project from scratch using our {URL_CONFIGURING_KOGITO}#proc-kogito-creating-project-spring-boot[_Spring Boot Maven archetype generation command_], then there is no need to do anything else as this dependency has already been added to our Spring Boot archetypes. If you have created your project already, have it deployed on {OPENSHIFT} or Kubernetes and are planning to upgrade the operator to {PRODUCT_VERSION}, then you must add the following Spring Boot actuator dependency to your `pom.xml`:
+When you create a project using the {URL_CONFIGURING_KOGITO}#proc-kogito-creating-project-spring-boot[_Spring Boot Maven archetype generation command_], then it is not required to perform any other step as actuator dependency is added to the Spring Boot archetypes. However, when you have already created a project and deployed the project on {OPENSHIFT} or Kubernetes, and you want to upgrade the {PRODUCT} operator to {PRODUCT_VERSION}, then you must add the following Spring Boot actuator dependency to `pom.xml` file:
 
-.Spring Boot Actuator dependency for Quarkus applications on {OPENSHIFT}
+.Example Spring Boot actuator dependency for Quarkus applications on {OPENSHIFT}
 [source,xml]
 ----
 <dependencies>

--- a/doc-content/kogito-docs/src/main/asciidoc/release-notes/chap-kogito-release-notes.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/release-notes/chap-kogito-release-notes.adoc
@@ -116,15 +116,22 @@ For more information about the add-on configuration, see {URL_CONFIGURING_KOGITO
 
 === {PRODUCT} Operator and CLI
 
-==== Improved/new bla bla
+==== Spring Boot actuator dependency now required to deploy on {OPENSHIFT}/Kubernetes
 
-Description
+By default, the operator now uses https://docs.spring.io/spring-boot/docs/2.3.0.RELEASE/reference/html/production-ready-features.html#production-ready-kubernetes-probes[actuator endpoints] for https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes[liveness, readiness, and startup probes]. These HTTP endpoints are an improvement over the TCP sockets that were previously used for Spring Boot as they provide better information about application status and its possible problems. 
 
-=== {PRODUCT} Operator and CLI
+If you are creating a project from scratch using our {URL_CONFIGURING_KOGITO}#proc-kogito-creating-project-spring-boot[_Spring Boot Maven archetype generation command_], then there is no need to do anything else as this dependency has already been added to our Spring Boot archetypes. If you have created your project already, have it deployed on {OPENSHIFT} or Kubernetes and are planning to upgrade the operator to {PRODUCT_VERSION}, then you must add the following Spring Boot actuator dependency to your `pom.xml`:
 
-==== Improved/new bla bla
-
-Description
+.Spring Boot Actuator dependency for Quarkus applications on {OPENSHIFT}
+[source,xml]
+----
+<dependencies>
+  <dependency>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-actuator</artifactId>
+  </dependency>
+</dependencies>
+----
 
 === {PRODUCT} supporting services
 

--- a/doc-content/kogito-docs/src/main/asciidoc/release-notes/chap-kogito-release-notes.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/release-notes/chap-kogito-release-notes.adoc
@@ -116,7 +116,7 @@ For more information about the add-on configuration, see {URL_CONFIGURING_KOGITO
 
 === {PRODUCT} Operator and CLI
 
-==== Deploy the Spring Boot actuator dependency on {OPENSHIFT} or Kubernetes
+==== Spring Boot actuator dependency to deploy on {OPENSHIFT} or Kubernetes
 
 The {PRODUCT} operator now uses https://docs.spring.io/spring-boot/docs/2.3.0.RELEASE/reference/html/production-ready-features.html#production-ready-kubernetes-probes[actuator endpoints] for https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes[liveness, readiness, and startup probes] by default. The actuator endpoints provide better information about the application status and possible problems as compared to the TCP sockets, which were previously used for Spring Boot.
 


### PR DESCRIPTION
See: https://issues.redhat.com/browse/KOGITO-4958

## Description
With [this PR](https://github.com/kiegroup/kogito-cloud-operator/pull/841), the operator now expects that Spring Boot applications have the [Spring Boot Actuator dependency](https://docs.spring.io/spring-boot/docs/2.3.0.RELEASE/reference/html/production-ready-features.html) imported. This is now clarified in the docs when setting up an example project and in the OpenShift section.

## Changes
- require Spring Boot Actuator dependency (when deploying on OpenShift/Kubernetes) in following sections:
  - creating Kogito Maven project
  - setting up probes
  - deploying on OpenShift web console
  - deploying with Kogito CLI
- remove note about startup probes not being supported (now implemented with [KOGITO-4322](https://github.com/kiegroup/kogito-operator/pull/826))
  - update probe mentions to include startup
- show how to setup custom probe with TCP socket (not used by default in operator any more)
- remove requiring health extension in travel agency tutorial (added to example's `pom.xml` already)

## Related PR's
- [kogito-operator](https://github.com/kiegroup/kogito-cloud-operator/pull/841): [KOGITO-4898] Set probe defaults based on YAML action values
- [kogito-runtimes](https://github.com/kiegroup/kogito-runtimes/pull/1232): [KOGITO-4958] Add Spring Boot Actuator as default dependency
- [kogito-examples](https://github.com/kiegroup/kogito-examples/pull/660): [KOGITO-4958] Add Spring Boot Actuator dependency
