### PR TITLE
[JBPM-9716] Wrong bootstrap servers property in the Kafka Emitter

### DIFF
--- a/doc-content/jbpm-docs/src/main/asciidoc/Kafka/kieserver-kafka-emit-proc.adoc
+++ b/doc-content/jbpm-docs/src/main/asciidoc/Kafka/kieserver-kafka-emit-proc.adoc
@@ -49,7 +49,7 @@ endif::JBPM,DROOLS,OP[]
 ----
 +
 . Configure any of the following system properties for the {KIE_SERVER} as necessary:
-* `org.kie.jbpm.event.emitters.kafka.boopstrap.servers`: The host and port of the Kafka broker. The default value is `localhost:9092`. You can use a comma-separated list of multiple host:port pairs.
+* `org.kie.jbpm.event.emitters.kafka.bootstrap.servers`: The host and port of the Kafka broker. The default value is `localhost:9092`. You can use a comma-separated list of multiple host:port pairs.
 * `org.kie.jbpm.event.emitters.kafka.date_format`: The timestamp format for the `time` field of the messages. The default value is `yyyy-MM-dd'T'HH:mm:ss.SSSZ` .
 * `org.kie.jbpm.event.emitters.kafka.topic.processes`: The topic name for process event messages. The default value is `jbpm-processes-events`. 
 * `org.kie.jbpm.event.emitters.kafka.topic.cases`: The topic name for process event messages. The default value is `jbpm-cases-events`. 


### PR DESCRIPTION
JIRA: [JBPM-9716](https://issues.redhat.com/browse/JBPM-9716)

Depends on https://github.com/kiegroup/jbpm/pull/1925
