### PR TITLE
Upstream PR BXMSDOC-7572-master to Master Document timers best practices

### DIFF
--- a/doc-content/jbpm-docs/src/main/asciidoc/BPMN2/con-timer.adoc
+++ b/doc-content/jbpm-docs/src/main/asciidoc/BPMN2/con-timer.adoc
@@ -3,11 +3,26 @@
 
 You can use timers to trigger logic after a certain period or to repeat specific actions at regular intervals. Timers wait for a predefined amount of time before triggering once or repeatedly.
 
-== Configuration of timers with delay and period
+== Supported timers for {PRODUCT} 
+{PRODUCT} supports two types of timers:
+
+* Quartz: Recommended for use with Spring Boot and Tomcat
+* EJB: Recommended for use with {EAP}, both on-premise and {OPENSHIFT}
+
+[NOTE]
+====
+Do not use timers for the following business strategies:
+
+* Do not use timers as your process polling strategy. For example, instead of directly calling the external service and adding a 1 second timer, use {FUSE} to register an asynchronous route. Use the {FUSE} callback to fire an event for the process to move on once the expected response is received. Create a work item handler as part of your business strategy outside of your Business Process Model and Notation (BPMN) process model and move the timer to the work item handler.
+
+* Do not use timers to enforce safe points or commits during process execution. Timers are designed to represent a period of time (duration) in a business process and not for enforcing engine-specific behavior.
+====
+
+== Configuring timers with delay and period
 
 You can set a timer with delay and a certain period. The delay specifies the waiting time after the node activation, and the period defines the time between the subsequent trigger activation. The period value `0` results in a one-shot timer. You can specify the delay and period expression in `[\#d][#h][#m][#s][#[ms]]` form, indicating the number of days, hours, minutes, seconds, and milliseconds (default). For example, the expression `1h` indicates one hour waiting time before triggering the timer again.
 
-== Configuration of timers with ISO-8601 date format
+== Configuring timers with ISO-8601 date format
 
 You can configure timers with ISO-8601 date format that supports both one-shot timers and repeatable timers. You can define timers as date and time representation, time duration, or repeating intervals. For example:
 
@@ -15,7 +30,7 @@ You can configure timers with ISO-8601 date format that supports both one-shot t
 * Duration `PT1S` signifies that timer is triggered once after one second.
 * Repeating intervals `R/PT1S` signifies that timer is triggered every second with any limit. Alternatively, `R5/PT1S` triggers the timer five times every second.
 
-== Configuration of timers with process variables
+== Configuring timers with process variables
 
 You can also specify timers using process variables, consisting of the string representation of delay and period or ISO8601 date format. When you specify `#{variable}`, the engine parses the expression and replaces the expression value with the variable. In a process, you can use timers using the following ways:
 
@@ -23,7 +38,7 @@ You can also specify timers using process variables, consisting of the string re
 
 * Associate timer as a boundary event with a sub-process or task.
 
-== Update timers within running process instance
+== Updating timers in a running process instance
 
 In some cases, the scheduled timer needs to be rescheduled to accommodate the new requirements, such as changing delay, period, or repeat limit. Updating a timer includes many low-level operations, therefore, {PRODUCT} provides the following command to perform the low-level operations related to updating a timer as an atomic operation. The following command ensures that all the operations are performed within the same transaction.
 


### PR DESCRIPTION
Original jira: https://issues.redhat.com/browse/BXMSDOC-7572
Rendered output: http://file.rdu.redhat.com/~mhaglund/BXMSDOC-7572_2/#selecting_the_correct_timer_for_your_environment
Pull request: https://github.com/michelehaglund/kie-docs/pull/192