### PR TITLE
BXMSDOC-7682: fixing typo on openshift documentation

### DIFF
--- a/doc-content/enterprise-only/openshift/operator-deploy-kieserver-proc.adoc
+++ b/doc-content/enterprise-only/openshift/operator-deploy-kieserver-proc.adoc
@@ -30,7 +30,7 @@ For instructions about creating custom images, see xref:customimage-con_{context
 +
 [IMPORTANT]
 ====
-If you want to configure an immutable {KIE_SERVER} that pulls services from the Maven repository, do not click *Set Immutable server configuration* and do not complete these steps. Instead, set the `KIE_SERVER_CONTAINER_REPLOYMENT` environment variable.
+If you want to configure an immutable {KIE_SERVER} that pulls services from the Maven repository, do not click *Set Immutable server configuration* and do not complete these steps. Instead, set the `KIE_SERVER_CONTAINER_DEPLOYMENT` environment variable.
 ====
 +
 .. Click *Set Immutable server configuration*.


### PR DESCRIPTION
Fixing typo on "DEPLOYING RED HAT PROCESS AUTOMATION MANAGER ON RED HAT OPENSHIFT CONTAINER PLATFORM" documentation v7.10.

https://issues.redhat.com/browse/BXMSDOC-7682