### PR TITLE
[KOGITO-4882] Removing SmallRye HTTP Connector references from our docs

### DIFF
--- a/doc-content/kogito-docs/src/main/asciidoc/bpmn/chap-kogito-developing-process-services.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/bpmn/chap-kogito-developing-process-services.adoc
@@ -1767,22 +1767,14 @@ NOTE: Knative Eventing is currently supported for {PRODUCT} services on Quarkus 
 [source,xml,subs="attributes+,+quotes"]
 ----
 <dependencies>
-  <dependency>
-    <groupId>org.kie.kogito</groupId>
-    <artifactId>knative-eventing-addon</artifactId>
-  </dependency>
-  <dependency>
-    <groupId>org.kie.kogito</groupId>
-    <artifactId>kogito-cloudevents-quarkus-addon</artifactId>
-  </dependency>
-  <dependency>
-    <groupId>io.quarkus</groupId>
-    <artifactId>quarkus-smallrye-reactive-messaging</artifactId>
-  </dependency>
-  <dependency>
-    <groupId>io.smallrye.reactive</groupId>
-    <artifactId>smallrye-reactive-messaging-http</artifactId>
-  </dependency>
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-cloudevents-quarkus-addon</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-reactive-messaging-http</artifactId>
+    </dependency>
 </dependencies>
 ----
 
@@ -1812,12 +1804,11 @@ image::kogito/bpmn/kogito-knative-set-node-name.png[Image of a message node prop
 .Required application properties for publishing
 [source,subs="attributes+,+quotes"]
 ----
-mp.messaging.incoming.kogito_incoming_stream.connector=smallrye-http
-mp.messaging.outgoing.kogito_outgoing_stream.connector=smallrye-http
+mp.messaging.outgoing.kogito_outgoing_stream.connector=quarkus-http
 mp.messaging.outgoing.kogito_outgoing_stream.url=${K_SINK}
 ----
 
-The `smallrye-http` property defines the HTTP endpoint for the published messages. The `${K_SINK}` property is an environment variable injected by Knative Eventing when you deploy a {PRODUCT} service that references a Knative Eventing https://knative.dev/docs/eventing/samples/sinkbinding/[`SinkBinding`] object.
+The `quarkus-http` property defines the HTTP endpoint for the published messages. The `${K_SINK}` property is an environment variable injected by Knative Eventing when you deploy a {PRODUCT} service that references a Knative Eventing https://knative.dev/docs/eventing/samples/sinkbinding/[`SinkBinding`] object.
 --
 . Build your {PRODUCT} project locally using your usual method, such as `mvn clean package`, and navigate to the `target/generated-sources/kogito` directory in your project and verify the following contents:
 +


### PR DESCRIPTION
Signed-off-by: Ricardo Zanini <zanini@redhat.com>

See: https://issues.redhat.com/browse/KOGITO-4882

Small update to the docs to remove any reference from the old connector.