### PR TITLE
RHPAM-3690 local network port conflict, note in the example docs

### DIFF
--- a/doc-content/enterprise-only/getting-started-kogito/ref-kogito-microservices-app-examples.adoc
+++ b/doc-content/enterprise-only/getting-started-kogito/ref-kogito-microservices-app-examples.adoc
@@ -5,7 +5,7 @@
 
 For information about each example application and instructions for using them, see the `README` file in the relevant application folder.
 
-NOTE: In the https://github.com/kiegroup/kogito-examples[`kogito-examples`] repository in GitHub, the example applications in the default `stable` branch use the latest version of {KOGITO}.
+NOTE: In the https://github.com/kiegroup/kogito-examples[`kogito-examples`] repository in GitHub, the example applications in the default `stable` branch use the latest version of {KOGITO}. When you run examples in a local environment, ensure that the environment matches the requirements that are listed in the `README` file of the relevant application folder. Also, this might require making the necessary network ports available, as configured for Quarkus, Spring Boot, and docker-compose where applicable.
 
 The following list describes some of the examples provided with {KOGITO} microservices:
 


### PR DESCRIPTION
"backport" of https://github.com/kiegroup/kie-docs/pull/3567 to main Drools/RHDMN doc content.