### PR TITLE
[7.52.x] [DROOLS-5910] Enable range index for JoinNode (#3606)

### DIFF
--- a/doc-content/drools-docs/src/main/asciidoc/DecisionEngine/performance-tuning-decision-engine-ref.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/DecisionEngine/performance-tuning-decision-engine-ref.adoc
@@ -59,3 +59,20 @@ Configure alpha node range index threshold::
 Alpha node range index is used to evaluate the rule constraint. You can configure the threshold of the alpha node range index using the `drools.alphaNodeRangeIndexThreshold` system property. The default value of the threshold is `9`, indicating that the alpha node range index is enabled when a precedent node contains more than nine alpha nodes with inequality constraints. For example, when you have nine rules similar to `Person(age > 10)`, `Person(age > 20)`, ..., `Person(age > 90)`, then you can have similar nine alpha nodes.
 +
 The default value of the threshold is based on the related advantages and overhead. However, if you configure a smaller value for the threshold, then the performance can be improved depending on your rules. For example, you can configure the `drools.alphaNodeRangeIndexThreshold` value to `6`, enabling the alpha node range index when you have more than six alpha nodes for a precedent node. You can set a suitable value for the threshold based on the performance test results of your rules.
+
+Enable join node range index::
+The join node range index feature improves the performance only when there is a large number of facts to be joined, for example, 256*16 combinations. When your application inserts a large number of facts, you can enable the join node range index and evaluate the performance improvement. By default, the join node range index is disabled. 
++
+--
+.Example `kmodule.xml` file
+[source,xml]
+----
+<kbase name="KBase1" betaRangeIndex="enabled">
+----
+
+.System property for `BetaRangeIndexOption`
+[source,java]
+----
+drools.betaNodeRangeIndexEnabled=true
+----
+--

--- a/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes-chapter.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes-chapter.adoc
@@ -8,6 +8,8 @@
 
 include::ReleaseNotes/ReleaseNotesDrools.7.52.0.Final/ReleaseNotesDrools.7.52.0.Final-section.adoc[leveloffset=+1]
 
+include::ReleaseNotes/ReleaseNotesDrools.7.50.0.Final/ReleaseNotesDrools.7.50.0.Final-section.adoc[leveloffset=+1]
+
 include::ReleaseNotes/ReleaseNotesDrools.7.49.0.Final/ReleaseNotesDrools.7.49.0.Final-section.adoc[leveloffset=+1]
 
 include::ReleaseNotes/ReleaseNotesDrools.7.48.0.Final/ReleaseNotesDrools.7.48.0.Final-section.adoc[leveloffset=+1]

--- a/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.7.50.0.Final/ReleaseNotesDrools.7.50.0.Final-section.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.7.50.0.Final/ReleaseNotesDrools.7.50.0.Final-section.adoc
@@ -1,0 +1,5 @@
+[id='drools.releasenotesdrools.7.50.0']
+
+= New and Noteworthy in {PRODUCT} 7.50.0
+
+include::join-node-range-index.adoc[leveloffset=+1]

--- a/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.7.50.0.Final/join-node-range-index.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.7.50.0.Final/join-node-range-index.adoc
@@ -1,0 +1,7 @@
+[id='join-node-range-index']
+
+= Join node range index for join evaluations
+
+The join node range index improves the performance of join evaluations when there is a large number of facts to be joined. By default, the join node range index is disabled.
+
+For more information about join node range index, see xref:performance-tuning-decision-engine-ref_decision-engine[].


### PR DESCRIPTION
Backport https://github.com/kiegroup/kie-docs/commit/98aedaf7ea9114651be962fc632888c436e3b315 to 7.52.x