### PR TITLE
KOGITO-4915 - SetContent fix for standalone editors

### DIFF
--- a/doc-content/kogito-docs/src/main/asciidoc/creating-running/chap-kogito-creating-running.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/creating-running/chap-kogito-creating-running.adoc
@@ -609,7 +609,7 @@ The returned object contains the methods that are required to manipulate the edi
 |`getContent(): Promise<string>`
 |Returns a promise containing the editor content.
 
-|`setContent(content: string): void`
+|`setContent(path: string, content: string): void`
 |Sets the content of the editor.
 
 |`getPreview(): Promise<string>`


### PR DESCRIPTION
Updates docs to show setContent with path and content in standalone editors doc

related PR: https://github.com/kiegroup/kie-docs/pull/3469