### PR TITLE
Upstream 7.48.x PR for BXMSDOC-5985: Null fields description for REST API response

### DIFF
--- a/_artifacts/document-attributes.adoc
+++ b/_artifacts/document-attributes.adoc
@@ -1,5 +1,5 @@
 
-:REBUILT: Monday, June 07, 2021
+:REBUILT: Monday, June 14, 2021
 
 
 :ENTERPRISE_VERSION: 7.10

--- a/doc-content/shared-kie-docs/src/main/asciidoc/KieServer/kie-server-rest-api-requests-proc.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/KieServer/kie-server-rest-api-requests-proc.adoc
@@ -84,6 +84,9 @@ For REST client:
 * *HTTP Headers*: Set the following headers:
 ** `Accept`: `application/json`
 ** `Content-Type`: `application/json`
++
+NOTE: When you add `fields=not_null` to `Content-Type`, the null fields are excluded from the REST API response.
+
 * *HTTP method*: Set to `PUT`.
 * *URL*: Enter the {KIE_SERVER} REST API base URL and endpoint, such as `\http://localhost:8080/kie-server/services/rest/server/containers/MyContainer`.
 * *Request body*: Add a JSON request body with the configuration items for the new KIE container:
@@ -131,6 +134,9 @@ For curl utility:
 * `-H`: Set the following headers:
 ** `Accept`: `application/json`
 ** `Content-Type`: `application/json`
++
+NOTE: When you add `fields=not_null` to `Content-Type`, the null fields are excluded from the REST API response.
+
 * `-X`: Set to `PUT`.
 * *URL*: Enter the {KIE_SERVER} REST API base URL and endpoint, such as `\http://localhost:8080/kie-server/services/rest/server/containers/MyContainer`.
 * `-d`: Add a JSON request body or file (`@file.json`) with the configuration items for the new KIE container:


### PR DESCRIPTION
See JIRA: https://issues.redhat.com/browse/BXMSDOC-5985

Added a note for null fields in REST API response in KIE API document

Doc preview
RHPAM - [Interacting with Red Hat Process Automation Manager using KIE APIs](http://file.pnq.redhat.com/~hmanwani/BXMSDOC-5985-7.10-RHPAM/#kie-server-rest-api-requests-proc_kie-apis)