### PR TITLE
KOGITO-5392:Typo in doc related with the svg addon rest endpoint path

### DIFF
--- a/doc-content/kogito-docs/src/main/asciidoc/bpmn/chap-kogito-developing-process-services.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/bpmn/chap-kogito-developing-process-services.adoc
@@ -3090,7 +3090,7 @@ Use the following endpoint from the process SVG add-on to interact with the proc
 Return the process SVG diagram and highlight the executed path::
 +
 --
-`[GET] /svg/processes/{processId}/instances/{processInstanceId}/nodeInstances`
+`[GET] /svg/processes/{processId}/instances/{processInstanceId}`
 
 .Example REST endpoint
 `\http://localhost:8380/svg/processes/travels/instances/2d115b55-ff30-42f0-ab21-e0651abb4d04`


### PR DESCRIPTION
Fix the typo regarding the available endpoint exposed by the svg addon.