### PR TITLE
Upstream 7.52.x PR for BXMSDOC-7527: [DDF] Add a note about DMN based test scenarios.

### DIFF
--- a/_artifacts/document-attributes.adoc
+++ b/_artifacts/document-attributes.adoc
@@ -1,5 +1,5 @@
 
-:REBUILT: Thursday, June 17, 2021
+:REBUILT: Friday, June 25, 2021
 
 
 :ENTERPRISE_VERSION: 7.11

--- a/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/test-designer-expressions-syntax-dmn-based-ref.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/test-designer-expressions-syntax-dmn-based-ref.adoc
@@ -1,5 +1,5 @@
 [id='test-designer-expressions-syntax-dmn-based-ref']
-= Expression syntax in DMN-based scenarios
+= Expression syntax in DMN-based test scenarios
 The following data types are supported by the DMN-based test scenarios in the test scenarios designer:
 
 .Data types supported by DMN-based scenarios
@@ -17,7 +17,7 @@ The following data types are supported by the DMN-based test scenarios in the te
 |For example, `date("2019-05-13")` or `time("14:10:00+02:00")`.
 
 |functions
-|Supports built-in math functions, for example, `avg`, `max`. 
+|Supports built-in math functions, for example, `avg`, `max`.
 
 |contexts
 |For example, `{x : 5, y : 3}`.
@@ -29,5 +29,7 @@ The following data types are supported by the DMN-based test scenarios in the te
 
 [NOTE]
 ====
-You can refer to the supported commands and syntax in the *Scenario Cheatsheet* tab on the right of the DMN-based test scenarios designer.
+When evaluating a DMN-based test scenario, an empty cell is skipped from the evaluation. To define an empty string in DMN-based test scenarios, use `" "` and to define a null value, use `null`.
 ====
+
+You can refer to the supported commands and syntax in the *Scenario Cheatsheet* tab on the right of the DMN-based test scenarios designer.

--- a/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/test-designer-expressions-syntax-rule-based-ref.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/AuthoringAssets/test-designer-expressions-syntax-rule-based-ref.adoc
@@ -55,7 +55,7 @@ The following rule-based test scenario definition expressions are supported by t
 
 [NOTE]
 ====
-An empty cell is skipped from evaluation. To define an empty string, use `=`,`[]`, or `;`. To define a null value, use `null`.
+When evaluating a rule-based test scenario, an empty cell is skipped from the evaluation. To define an empty string, use `=`,`[]`, or `;` and to define a null value, use `null`.
 ====
 
 .Example expressions
@@ -88,7 +88,4 @@ An empty cell is skipped from evaluation. To define an empty string, use `=`,`[]
 |The actual value is neither less than 0 nor equal to 0 but is greater than or equal to 1.
 |===
 
-[NOTE]
-====
 You can refer to the supported commands and syntax in the *Scenario Cheatsheet* tab on the right of the rule-based test scenarios designer.
-====


### PR DESCRIPTION
**DDF JIRA:** https://issues.redhat.com/browse/BXMSDOC-7527

**Doc previews:**
- [RHPAM-Testing a decision service using test scenarios](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-7527-TS-RHPAM/#test-designer-expressions-syntax-dmn-based-ref)
- [RHDM-Testing a decision service using test scenarios](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-7527-TS-RHDM/#test-designer-expressions-syntax-dmn-based-ref)

**Doc impact:** Check **70.2. Expression syntax in DMN-based test scenarios** in RHPAM doc. I have added a note about empty cells in DMN based test scenarios. 