### PR TITLE
BXMSDOC-8067 Kogito: do not reference archetypes, use quarkus cli

### DIFF
--- a/doc-content/kogito-docs/src/main/asciidoc/creating-running/chap-kogito-creating-running.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/creating-running/chap-kogito-creating-running.adoc
@@ -655,19 +655,11 @@ Before you can begin developing {PRODUCT} services, you need to create a Maven p
 .On Quarkus
 [source,subs="attributes+"]
 ----
-$ mvn archetype:generate \
-    -DarchetypeGroupId=org.kie.kogito \
-    -DarchetypeArtifactId=kogito-quarkus-archetype \
-    -DgroupId=org.acme -DartifactId=sample-kogito \
-    -DarchetypeVersion={COMMUNITY_VERSION_FINAL} \
-    -Dversion=1.0-SNAPSHOT
+mvn io.quarkus:quarkus-maven-plugin:create \
+  -DprojectGroupId=com.company \
+  -DprojectArtifactId=sample-kogito \
+  -Dextensions="kogito"
 ----
-
-////
-@comment: The following standard command for Quarkus isn't working currently but may be restored for Dev Preview
-
-mvn io.quarkus:quarkus-maven-plugin:create -DprojectGroupId=com.company -DprojectArtifactId=sample-kogito -Dextensions="kogito"
-////
 
 [id="proc-kogito-creating-project-spring-boot_{context}"]
 .On Spring Boot
@@ -706,18 +698,11 @@ NOTE: On Quarkus, disabling code regeneration also disables hot reload of busine
 .On Quarkus
 [source,subs="attributes+"]
 ----
-$ mvn archetype:generate \
-    -DarchetypeGroupId=org.kie.kogito \
-    -DarchetypeArtifactId=kogito-quarkus-archetype \
-    -DgroupId=org.acme -DartifactId=sample-kogito \
-    -DarchetypeVersion={COMMUNITY_VERSION_FINAL} \
-    -Dversion=1.0-SNAPSHOT
+mvn io.quarkus:quarkus-maven-plugin:create \
+  -DprojectGroupId=com.company \
+  -DprojectArtifactId=sample-kogito \
+  -Dextensions="kogito"
 ----
-////
-@comment: The following standard command for Quarkus isn't working currently but may be restored for Dev Preview
-
-mvn io.quarkus:quarkus-maven-plugin:create -DprojectGroupId=com.company -DprojectArtifactId=sample-kogito -Dextensions="kogito"
-////
 
 .On Spring Boot
 [source,subs="attributes+"]


### PR DESCRIPTION
verified manually, the command works as intended. Please do notice that the version number of `-DarchetypeVersion` has disappeared because the Quarkus version now drives the version of Kogito that is used 

It is still possible to add a specific _quarkus_ version number with:

```
mvn io.quarkus:quarkus-maven-plugin:2.1.0.Final:create \
```

where `2.1.0.Final` must obviously be replaced with the corresponding Quarkus version number

also do note that the Quarkus team is advising to use the quarkus cli. In that case, the command just becomes

```
quarkus create -x kogito sample-app
```

with an optional `-S <quarkus-version`; e.g.:

```
quarkus create -S 2.0 -x kogito sample-app
```

see https://quarkus.io/blog/quarkus-2x-platform-quarkiverse-registry/