### PR TITLE
KOGITO-4724 sql script bundle note

### DIFF
--- a/doc-content/kogito-docs/src/main/asciidoc/configuration/chap-kogito-configuring.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/configuration/chap-kogito-configuring.adoc
@@ -990,7 +990,7 @@ Runtime persistence is intended primarily for storing data that is required to r
 
 Node instances that are currently active or in wait states are persisted. When a process instance finishes execution but has not reached the end state (completed or aborted), the node instance data is persisted.
 
-Persistence setup scripts for {PRODUCT} runtimes and {PRODUCT} runtimes supporting services are now included in the https://repository.jboss.org/org/kie/kogito/kogito-ddl/[kogito-ddl-__VERSION__-db-scripts.zip] artifact.
+Persistence setup scripts for {PRODUCT} runtimes and {PRODUCT} runtimes supporting services are included in the https://repository.jboss.org/org/kie/kogito/kogito-ddl/[kogito-ddl-__VERSION__-db-scripts.zip] artifact.
 
 === Persistence workflow in {PRODUCT}
 

--- a/doc-content/kogito-docs/src/main/asciidoc/configuration/chap-kogito-configuring.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/configuration/chap-kogito-configuring.adoc
@@ -990,6 +990,8 @@ Runtime persistence is intended primarily for storing data that is required to r
 
 Node instances that are currently active or in wait states are persisted. When a process instance finishes execution but has not reached the end state (completed or aborted), the node instance data is persisted.
 
+Persistence setup scripts both for {PRODUCT} runtimes and supporting services like data index, etc. are bundled as the kogito-ddl-{maven_artifact_version}-db-scripts.zip artifact.
+
 === Persistence workflow in {PRODUCT}
 
 In {PRODUCT}, a process instance is persisted when the process reaches a wait state, where the process does not execute anymore but has not reached the end state (completed or aborted).

--- a/doc-content/kogito-docs/src/main/asciidoc/configuration/chap-kogito-configuring.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/configuration/chap-kogito-configuring.adoc
@@ -990,7 +990,7 @@ Runtime persistence is intended primarily for storing data that is required to r
 
 Node instances that are currently active or in wait states are persisted. When a process instance finishes execution but has not reached the end state (completed or aborted), the node instance data is persisted.
 
-Persistence setup scripts both for {PRODUCT} runtimes and supporting services like data index, etc. are bundled as the kogito-ddl-{maven_artifact_version}-db-scripts.zip artifact.
+Persistence setup scripts for {PRODUCT} runtimes and {PRODUCT} runtimes supporting services are now included in the https://repository.jboss.org/org/kie/kogito/kogito-ddl/[kogito-ddl-__VERSION__-db-scripts.zip] artifact.
 
 === Persistence workflow in {PRODUCT}
 

--- a/doc-content/kogito-docs/src/main/asciidoc/release-notes/chap-kogito-release-notes.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/release-notes/chap-kogito-release-notes.adoc
@@ -113,7 +113,7 @@ quarkus.datasource.password=kogito-pass
 
 ==== Persistence script bundle
 
-Persistence setup scripts both for {PRODUCT} runtimes and supporting services like data index, etc. are bundled as the kogito-ddl-{maven_artifact_version}-db-scripts.zip artifact.
+Persistence setup scripts for {PRODUCT} runtimes and {PRODUCT} runtimes supporting services are now included in the https://repository.jboss.org/org/kie/kogito/kogito-ddl/[kogito-ddl-__VERSION__-db-scripts.zip] artifact.
 
 === {PRODUCT} Operator and CLI
 

--- a/doc-content/kogito-docs/src/main/asciidoc/release-notes/chap-kogito-release-notes.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/release-notes/chap-kogito-release-notes.adoc
@@ -111,6 +111,10 @@ quarkus.datasource.username=kogito-user
 quarkus.datasource.password=kogito-pass
 ------
 
+==== Persistence script bundle
+
+Persistence setup scripts both for {PRODUCT} runtimes and supporting services like data index, etc. are bundled as the kogito-ddl-{maven_artifact_version}-db-scripts.zip artifact.
+
 === {PRODUCT} Operator and CLI
 
 ==== Improved/new bla bla


### PR DESCRIPTION
Mentioned the new artifact that bundles all persistence scripts in the 5.5 persistence section and the release notes section.

Jira https://issues.redhat.com/browse/KOGITO-4724

The task was merged into version 1.10.