### PR TITLE
BXMSDOC-8096: Prepare cumulative release notes for Kogito

### DIFF
--- a/doc-content/kogito-docs/src/main/asciidoc/release-notes/ReleaseNotesKogito.1.10.0.Final/ReleaseNotesKogito.1.10.0.Final.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/release-notes/ReleaseNotesKogito.1.10.0.Final/ReleaseNotesKogito.1.10.0.Final.adoc
@@ -1,0 +1,50 @@
+// IMPORTANT: For 1.10 and later, save each version release notes as its own module file in the release folder that this `ReleaseNotesKogito<version>.adoc` file is in, and then include each version release notes file in the chap-kogito-release-notes.adoc after Additional resources of {PRODUCT} deployment on {OPENSHIFT} section, in the following format:
+//include::release-notes/ReleaseNotesKogito<version>.adoc[leveloffset=+2]
+
+[id="ref-kogito-rn-new-features-1.10_{context}"]
+= New features in {PRODUCT} 1.10
+
+[role="_abstract"]
+The following sections describe some of the new features or enhancements in {PRODUCT} 1.10.
+
+== {PRODUCT} runtimes
+
+=== Breaking change on {PRODUCT} PostgreSQL add-on for Quarkus
+
+The usage of `kogito.persistence.postgresql.connection.uri` is discontinued in 1.9.0 when using PostgreSQL add-on for Quarkus. You can use the same configuration using https://quarkus.io/guides/reactive-sql-clients#reactive-datasource[Quarkus reactive datasource].
+
+.Example of how to configure the datasource in the application.properties file:
+[source]
+------
+quarkus.datasource.reactive.url=postgresql://localhost:5432/kogito
+quarkus.datasource.username=kogito-user
+quarkus.datasource.password=kogito-pass
+------
+
+=== Breaking change on {PRODUCT} Management and Task Consoles
+
+The GraphQL endpoint URL now requires the entire path, for example, `http://host-name:port-number/graphql`. You can pass the URL as an environment variable `kogito.dataindex.http.url` to the Quarkus application or image.
+
+=== Persistence script bundle
+
+Persistence setup scripts for {PRODUCT} runtimes and {PRODUCT} runtimes supporting services are now included in the https://repository.jboss.org/org/kie/kogito/kogito-ddl/[kogito-ddl-__VERSION__-db-scripts.zip] artifact.
+
+////
+== {PRODUCT} Operator and CLI
+
+=== Improved/new bla bla
+
+Description
+
+== {PRODUCT} supporting services
+
+=== Improved/new bla bla
+
+Description
+
+== {PRODUCT} tooling
+
+=== Improved/new bla bla
+
+Description
+////

--- a/doc-content/kogito-docs/src/main/asciidoc/release-notes/ReleaseNotesKogito.1.10.0.Final/ReleaseNotesKogito.1.10.0.Final.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/release-notes/ReleaseNotesKogito.1.10.0.Final/ReleaseNotesKogito.1.10.0.Final.adoc
@@ -1,5 +1,5 @@
-// IMPORTANT: For 1.10 and later, save each version release notes as its own module file in the release folder that this `ReleaseNotesKogito<version>.adoc` file is in, and then include each version release notes file in the chap-kogito-release-notes.adoc after Additional resources of {PRODUCT} deployment on {OPENSHIFT} section, in the following format:
-//include::release-notes/ReleaseNotesKogito<version>.adoc[leveloffset=+2]
+// IMPORTANT: For 1.10 and later, save each version release notes as its own module file in the release-notes folder that this `ReleaseNotesKogito<version>.adoc` file is in, and then include each version release notes file in the chap-kogito-release-notes.adoc after Additional resources of {PRODUCT} deployment on {OPENSHIFT} section, in the following format:
+//include::release-notes/ReleaseNotesKogito<version>.adoc[leveloffset=+1]
 
 [id="ref-kogito-rn-new-features-1.10_{context}"]
 = New features in {PRODUCT} 1.10

--- a/doc-content/kogito-docs/src/main/asciidoc/release-notes/ReleaseNotesKogito.1.11.0.Final/ReleaseNotesKogito.1.11.0.Final.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/release-notes/ReleaseNotesKogito.1.11.0.Final/ReleaseNotesKogito.1.11.0.Final.adoc
@@ -1,5 +1,5 @@
-// IMPORTANT: For 1.10 and later, save each version release notes as its own module file in the release folder that this `ReleaseNotesKogito<version>.adoc` file is in, and then include each version release notes file in the chap-kogito-release-notes.adoc after Additional resources of {PRODUCT} deployment on {OPENSHIFT} section, in the following format:
-//include::release-notes/ReleaseNotesKogito<version>.adoc[leveloffset=+2]
+// IMPORTANT: For 1.10 and later, save each version release notes as its own module file in the release-notes folder that this `ReleaseNotesKogito<version>.adoc` file is in, and then include each version release notes file in the chap-kogito-release-notes.adoc after Additional resources of {PRODUCT} deployment on {OPENSHIFT} section, in the following format:
+//include::release-notes/ReleaseNotesKogito<version>.adoc[leveloffset=+1]
 
 [id="ref-kogito-rn-new-features-1.11_{context}"]
 = New features in {PRODUCT} 1.11

--- a/doc-content/kogito-docs/src/main/asciidoc/release-notes/ReleaseNotesKogito.1.11.0.Final/ReleaseNotesKogito.1.11.0.Final.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/release-notes/ReleaseNotesKogito.1.11.0.Final/ReleaseNotesKogito.1.11.0.Final.adoc
@@ -1,0 +1,103 @@
+// IMPORTANT: For 1.10 and later, save each version release notes as its own module file in the release folder that this `ReleaseNotesKogito<version>.adoc` file is in, and then include each version release notes file in the chap-kogito-release-notes.adoc after Additional resources of {PRODUCT} deployment on {OPENSHIFT} section, in the following format:
+//include::release-notes/ReleaseNotesKogito<version>.adoc[leveloffset=+2]
+
+[id="ref-kogito-rn-new-features-1.11_{context}"]
+= New features in {PRODUCT} 1.11
+
+[role="_abstract"]
+The following sections describe some of the new features or enhancements in {PRODUCT} 1.11.
+
+== {PRODUCT} runtimes
+
+=== Support for {PRODUCT} Spring Boot starters
+
+You can now add {PRODUCT} Spring Boot starters to your Spring Boot project and get started with {PRODUCT} quickly. For more information about {PRODUCT} Spring Boot starters, see {URL_CREATING_RUNNING}#ref-kogito-spring-boot-starter_kogito-creating-running[_Starters for your {PRODUCT} project_].
+
+=== Renamed ArtifactId of {PRODUCT} messaging add-ons
+The following {PRODUCT} messaging add-ons are renamed:
+
+.Quarkus
+|===
+|Old ArtifactId | New ArtifactId
+
+|kogito-addons-quarkus-cloudevents | kogito-addons-quarkus-messaging
+|kogito-addons-quarkus-cloudevents-multi | kogito-addons-quarkus-messaging
+|kogito-addons-quarkus-events-smallrye | kogito-addons-quarkus-events-process
+|===
+
+.Spring Boot
+|===
+|Old ArtifactId | New ArtifactId
+
+| kogito-addons-springboot-cloudevents | kogito-addons-springboot-messaging
+| kogito-addons-springboot-events-kafka | kogito-addons-springboot-events-process-kafka
+|===
+
+=== Renamed ArtifactId of {PRODUCT} Spring Boot archetype
+
+The name of the {PRODUCT} Spring Boot archetype ArtifactId is changed from `kogito-springboot-archetype` to `kogito-spring-boot-archetype`.
+
+To create a new Spring Boot based project using the archetype, see the instructions on {URL_CREATING_RUNNING}#chap-kogito-creating-running[_{CREATING_RUNNING}_].
+
+=== Removed {PRODUCT} Quarkus archetype
+
+The {PRODUCT} Quarkus archetype (`kogito-quarkus-archetype`) is no longer available. To create a new Quarkus based project, please revisit updated instructions on {URL_CREATING_RUNNING}#chap-kogito-creating-running[_{CREATING_RUNNING}_].
+
+=== Breaking change on metrics name provided by {PRODUCT} Prometheus monitoring add-ons
+
+The metrics name provided by {PRODUCT} Prometheus monitoring add-ons (`kogito-addons-quarkus-monitoring-prometheus` or `kogito-addons-springboot-monitoring-prometheus`) are changed as follows:
+
+.Prometheus monitoring add-ons
+|===
+|Add-on
+|Changed to
+
+|`kie_process_instance_started_total`
+|`kogito_process_instance_started_total`
+
+|`kie_process_instance_sla_violated_total`
+|`kogito_process_instance_sla_violated_total`
+
+|`kie_process_instance_completed_total`
+|`kogito_process_instance_completed_total`
+
+|`kie_process_instance_running_total`
+|`kogito_process_instance_running_total`
+
+|`kie_process_instance_duration_seconds`
+|`kogito_process_instance_duration_seconds`
+
+|`kie_work_item_duration_seconds`
+|`kogito_work_item_duration_seconds`
+|===
+
+WARNING: You must review any of your configured tools such as Grafana in which the names of the metrics are used.
+
+For more information about how to use these metrics, see {URL_CONFIGURING_KOGITO}#proc-prometheus-metrics-monitoring_kogito-configuring[_Enabling Prometheus metrics monitoring in Kogito_].
+
+=== Renamed ArtifactId of {PRODUCT} Spring Boot BOM
+
+The name of the {PRODUCT} Spring Boot BOM ArtifactId is changed from `kogito-springboot-bom` to `kogito-spring-boot-bom`.
+For instructions on how to create a new Spring Boot based project, see the instructions on {URL_CREATING_RUNNING}#chap-kogito-creating-running[_{CREATING_RUNNING}_].
+
+== {PRODUCT} Operator and CLI
+
+=== Improved/new bla bla
+
+Description
+
+== {PRODUCT} supporting services
+
+=== Ability to add Metadata Attributes to all nodes and events
+
+You can now add *Metadata Attributes* property to all the nodes and events in the BPMN editor. The *Metadata Attributes* property is a key-value definition that you can use for custom event listeners. For more information about *Metadat Attributes* property, see {URL_PROCESS_SERVICES}#chap-kogito-developing-process-services[_{PROCESS_SERVICES}_].
+
+=== {PRODUCT} Data Index service recommends upgraded version of Infinispan
+
+Starting from {PRODUCT} 1.11.0, you must upgrade the Infinispan version to 12.1.7 or later to prevent the issues regarding results returned in paginated queries.
+
+== {PRODUCT} tooling
+
+=== Improved/new bla bla
+
+Description

--- a/doc-content/kogito-docs/src/main/asciidoc/release-notes/ReleaseNotesKogito.1.11.0.Final/ReleaseNotesKogito.1.11.0.Final.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/release-notes/ReleaseNotesKogito.1.11.0.Final/ReleaseNotesKogito.1.11.0.Final.adoc
@@ -49,8 +49,8 @@ The metrics name provided by {PRODUCT} Prometheus monitoring add-ons (`kogito-ad
 
 .Prometheus monitoring add-ons
 |===
-|Add-on
-|Changed to
+|Add-on |Changed to
+
 
 |`kie_process_instance_started_total`
 |`kogito_process_instance_started_total`

--- a/doc-content/kogito-docs/src/main/asciidoc/release-notes/chap-kogito-release-notes.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/release-notes/chap-kogito-release-notes.adoc
@@ -91,116 +91,11 @@ For the complete list of new features, fixed issues, and known issues in {PRODUC
 .Additional resources
 * {URL_DEPLOYING_ON_OPENSHIFT}#chap-kogito-deploying-on-openshift[_{DEPLOYING_ON_OPENSHIFT}_]
 
-[id="ref-kogito-rn-new-features_{context}"]
-== New features in {PRODUCT} {PRODUCT_VERSION}
+//New features section
 
-[role="_abstract"]
-The following sections describe some of the new features or enhancements in {PRODUCT} {PRODUCT_VERSION}.
+include::ReleaseNotesKogito.1.11.0.Final/ReleaseNotesKogito.1.11.0.Final.adoc[leveloffset=+1]
 
-=== {PRODUCT} runtimes
-
-==== Support for {PRODUCT} Spring Boot starters
-
-You can now add {PRODUCT} Spring Boot starters to your Spring Boot project and get started with {PRODUCT} quickly. For more information about {PRODUCT} Spring Boot starters, see {URL_CREATING_RUNNING}#ref-kogito-spring-boot-starter_kogito-creating-running[_Starters for your {PRODUCT} project_].
-
-=== {PRODUCT} Operator and CLI
-
-==== Breaking change on {PRODUCT} PostgreSQL add-on for Quarkus 
-
-The usage of `kogito.persistence.postgresql.connection.uri` is discontinued in 1.9.0 when using PostgreSQL add-on for Quarkus. You can use the same configuration using https://quarkus.io/guides/reactive-sql-clients#reactive-datasource[Quarkus reactive datasource].
-
-.Example of how to configure the datasource in the application.properties file:
-[source]
-------
-quarkus.datasource.reactive.url=postgresql://localhost:5432/kogito
-quarkus.datasource.username=kogito-user
-quarkus.datasource.password=kogito-pass
-------
-
-==== Renamed ArtifactId of {PRODUCT} messaging add-ons
-The following {PRODUCT} messaging add-ons are renamed:
-
-.Quarkus
-|===
-|Old ArtifactId | New ArtifactId
-
-|kogito-addons-quarkus-cloudevents | kogito-addons-quarkus-messaging
-|kogito-addons-quarkus-cloudevents-multi | kogito-addons-quarkus-messaging
-|kogito-addons-quarkus-events-smallrye | kogito-addons-quarkus-events-process
-
-.Spring Boot
-|===
-|Old ArtifactId | New ArtifactId |
-
-| kogito-addons-springboot-cloudevents | kogito-addons-springboot-messaging
-| kogito-addons-springboot-events-kafka | kogito-addons-springboot-events-process-kafka
-
-
-
-=======
-==== Renamed ArtifactId of {PRODUCT} Spring Boot archetype 
-
-The name of the {PRODUCT} Spring Boot archetype ArtifactId has changed from `kogito-springboot-archetype` to `kogito-spring-boot-archetype`.
-To create a new Spring Boot based project using the archetype, see the instructions on {URL_CREATING_RUNNING}#chap-kogito-creating-running[_{CREATING_RUNNING}_].
-
-==== Removed {PRODUCT} Quarkus archetype 
-
-The {PRODUCT} Quarkus archetype (`kogito-quarkus-archetype`) is no longer available. To create a new Quarkus based project, please revisit updated instructions on {URL_CREATING_RUNNING}#chap-kogito-creating-running[_{CREATING_RUNNING}_].
-
-==== Persistence script bundle
-
-Description
-
-==== Breaking change on metrics name provided by {PRODUCT} Prometheus monitoring add-ons
-
-The metrics name provided by {PRODUCT} Prometheus monitoring add-ons (`kogito-addons-quarkus-monitoring-prometheus` or `kogito-addons-springboot-monitoring-prometheus`) have changed from:
-
-- kie_process_instance_started_total
-- kie_process_instance_sla_violated_total
-- kie_process_instance_completed_total
-- kie_process_instance_running_total
-- kie_process_instance_duration_seconds
-- kie_work_item_duration_seconds
-
-To:
-
-- kogito_process_instance_started_total
-- kogito_process_instance_sla_violated_total
-- kogito_process_instance_completed_total
-- kogito_process_instance_running_total
-- kogito_process_instance_duration_seconds
-- kogito_work_item_duration_seconds
-
-WARNING: You must review any of your configured tools such as Grafana in which the names of the metrics are used.
-
-For more details about how to use these metrics, see {URL_CONFIGURING_KOGITO}#proc-prometheus-metrics-monitoring_kogito-configuring[_Enabling Prometheus metrics monitoring in Kogito_].
-
-==== Renamed ArtifactId of {PRODUCT} Spring Boot BOM
-
-The name of the {PRODUCT} Spring Boot BOM ArtifactId has changed from `kogito-springboot-bom` to `kogito-spring-boot-bom`.
-For instructions on how to create a new Spring Boot based project, see the instructions on {URL_CREATING_RUNNING}#chap-kogito-creating-running[_{CREATING_RUNNING}_].
-
-=== {PRODUCT} Operator and CLI
-
-==== Improved/new bla bla
-
-Description
-
-=== {PRODUCT} supporting services
-
-==== Ability to add Metadata Attributes to all nodes and events
-
-You can now add *Metadata Attributes* property to all the nodes and events in the BPMN editor. The *Metadata Attributes* property is a key-value definition that you can use for custom event listeners. For more information about *Metadat Attributes* property, see {URL_PROCESS_SERVICES}#chap-kogito-developing-process-services[_{PROCESS_SERVICES}_].
-
-==== {PRODUCT} Data Index service recommends upgraded version of Infinispan
-
-Starting from {PRODUCT} 1.11.0, you must upgrade the Infinispan version to 12.1.7 or later to prevent the issues regarding results returned in paginated queries.
-
-=== {PRODUCT} tooling
-
-==== Improved/new bla bla
-
-Description
+include::ReleaseNotesKogito.1.10.0.Final/ReleaseNotesKogito.1.10.0.Final.adoc[leveloffset=+1]
 
 [id="ref-kogito-rn-fixed-issues_{context}"]
 == Fixed issues in {PRODUCT} {PRODUCT_VERSION}


### PR DESCRIPTION
This PR is created to have cumulative release notes in Kogito community docs starting from Kogito 1.10. With cumulative release notes, the contributors need to consider the following points:

* The new features file of release notes file for each version needs to be saved as its own module file in the release-notes folder (as updated in this PR)
* The new features file needs to be included in the chap-kogito-release-notes.adoc file as an include (as updated in this PR)
* The {PRODUCT_VERSION} attribute cannot be used in the new features file to avoid the version number updates in the previous version's new features section

Doc preview:
[Kogito 1.11 documentation](http://file.pnq.redhat.com/~hmanwani/BXMSDOC-8096-KOGITO/#chap-kogito-release-notes)