### PR TITLE
Upstream 7.59.x PR for BXMSDOC-8062: Removed rule unit section from DRL and decision engine doc

### DIFF
--- a/assemblies/assembly-decision-engine.adoc
+++ b/assemblies/assembly-decision-engine.adoc
@@ -32,7 +32,7 @@ include::{drools-dir}/DecisionEngine/fact-propagation-modes-con.adoc[leveloffset
 
 include::{drools-dir}/DecisionEngine/agenda-filters-con.adoc[leveloffset=+2]
 
-include::{drools-dir}/LanguageReference/drl-rule-units-con.adoc[leveloffset=+2]
+//include::{drools-dir}/LanguageReference/drl-rule-units-con.adoc[leveloffset=+2] (commenting out as rule units are not supported in RHPAM/RHDM)
 
 include::{drools-dir}/DecisionEngine/phreak-algorithm-con.adoc[leveloffset=+1]
 

--- a/assemblies/assembly-drl-rules.adoc
+++ b/assemblies/assembly-drl-rules.adoc
@@ -79,7 +79,7 @@ include::{drools-dir}/LanguageReference/drl-rules-comments-con.adoc[leveloffset=
 
 include::{drools-dir}/LanguageReference/drl-rules-errors-ref.adoc[leveloffset=+2]
 
-include::{drools-dir}/LanguageReference/drl-rule-units-con.adoc[leveloffset=+2]
+//include::{drools-dir}/LanguageReference/drl-rule-units-con.adoc[leveloffset=+2] (Commenting out as rule units are not supported in RHPAM/RHDM)
 
 include::{enterprise-dir}/project-data/data-objects-con.adoc[leveloffset=+1]
 

--- a/doc-content/drools-docs/src/main/asciidoc/DecisionEngine/execution-control-con.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/DecisionEngine/execution-control-con.adoc
@@ -17,7 +17,7 @@ ifdef::DM,PAM[]
 image::HybridReasoning/Two_Phase_enterprise.png[align="center"]
 endif::[]
 
-When multiple rules exist on the agenda, the execution of one rule may cause another rule to be removed from the agenda. To avoid this, you can define how and when rules are executed in the {DECISION_ENGINE}. Some common methods for defining rule execution order are by using rule salience, agenda groups, activation groups, or rule units for DRL rule sets.
+When multiple rules exist on the agenda, the execution of one rule may cause another rule to be removed from the agenda. To avoid this, you can define how and when rules are executed in the {DECISION_ENGINE}. Some common methods for defining rule execution order are by using rule salience, agenda groups, or activation groups.
 
 == Salience for rules
 


### PR DESCRIPTION
See JIRA: https://issues.redhat.com/browse/BXMSDOC-8062

Doc preview:
[Designing a decision service using DRL rules](http://file.pnq.redhat.com/~hmanwani/BXMSDOC-8062-RHPAM/#assembly-drl-rules)
[Decision engine in Red Hat Process Automation Manager](http://file.pnq.redhat.com/~hmanwani/BXMSDOC-8062-RHPAM/#assembly-decision-engine)