### PR TITLE
disabled windows-latest for github action martix builds

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -9,7 +9,7 @@ jobs:
       cancel-in-progress: true
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
         java-version: [8, 11]
         maven-version: ['3.8.1']
       fail-fast: false

--- a/.github/workflows/pull_request_no_chain.yml
+++ b/.github/workflows/pull_request_no_chain.yml
@@ -9,7 +9,7 @@ jobs:
       cancel-in-progress: true
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
         java: [8, 11]
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
erased windows-latest github action jobs since they seem to be not needed in kiegroup/kie-docs