### PR TITLE
BXMSDOC-8312: Add note to enable user and group management (#12)

### DIFF
--- a/doc-content/enterprise-only/installation/run-dc-standalone-proc.adoc
+++ b/doc-content/enterprise-only/installation/run-dc-standalone-proc.adoc
@@ -39,7 +39,7 @@ java -jar {PRODUCT_FILE}-{URL_COMPONENT_CENTRAL}-standalone.jar --cli-script=app
 +
 [source,subs="attributes+"]
 ----
-java -jar {PRODUCT_FILE}-{URL_COMPONENT_CENTRAL}-standalone.jar  --cli-script=application-script.cli -D<PROPERTY>=<VALUE> -D<PROPERTY>=<VALUE>
+java -jar {PRODUCT_FILE}-{URL_COMPONENT_CENTRAL}-standalone.jar --cli-script=application-script.cli -D<PROPERTY>=<VALUE> -D<PROPERTY>=<VALUE>
 ----
 +
 For example, to run {CENTRAL} and connect to {KIE_SERVER} as the user `controllerUser`, enter:
@@ -54,3 +54,8 @@ java -jar {PRODUCT_FILE}-{URL_COMPONENT_CENTRAL}-standalone.jar \
 +
 Doing this enables you to deploy containers to {KIE_SERVER}.
 See <<business-central-system-properties-ref_install-on-eap>> for more information.
++
+[NOTE]
+====
+To enable user and group management in {CENTRAL}, set the value of the `org.uberfire.ext.security.management.wildfly.cli.folderPath` property to `kie-fs-realm-users`.
+====


### PR DESCRIPTION
* BXMSDOC-8312 Adds note to enable user and group management

* Fixes typo

* Update doc-content/enterprise-only/installation/run-dc-standalone-proc.adoc

Incorporating peer review suggestion.

Co-authored-by: emmurphy1 <30830712+emmurphy1@users.noreply.github.com>

Co-authored-by: emmurphy1 <30830712+emmurphy1@users.noreply.github.com>