### PR TITLE
[BXMSDOC-8281] Event listeners for decision engine - main

### DIFF
--- a/assemblies/assembly-decision-engine.adoc
+++ b/assemblies/assembly-decision-engine.adoc
@@ -75,8 +75,9 @@ include::{drools-dir}/DecisionEngine/cep-memory-management-con.adoc[leveloffset=
 include::{drools-dir}/DecisionEngine/engine-queries-con.adoc[leveloffset=+1]
 
 include::{drools-dir}/DecisionEngine/engine-event-listeners-con.adoc[leveloffset=+1]
+include::{drools-dir}/DecisionEngine/engine-event-listeners-development-con.adoc[leveloffset=+2]
 
-include::{drools-dir}/DecisionEngine/logging-proc.adoc[leveloffset=+2]
+include::{drools-dir}/DecisionEngine/logging-proc.adoc[leveloffset=+1]
 
 include::{drools-dir}/Examples/decision-examples-IDE-con.adoc[leveloffset=+1]
 

--- a/doc-content/drools-docs/src/main/asciidoc/DecisionEngine-chapter.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/DecisionEngine-chapter.adoc
@@ -68,6 +68,7 @@ include::DecisionEngine/cep-memory-management-con.adoc[leveloffset=+2]
 include::DecisionEngine/engine-queries-con.adoc[leveloffset=+1]
 
 include::DecisionEngine/engine-event-listeners-con.adoc[leveloffset=+1]
+include::DecisionEngine/engine-event-listeners-development-con.adoc[leveloffset=+2]
 
 include::DecisionEngine/logging-proc.adoc[leveloffset=+2]
 

--- a/doc-content/drools-docs/src/main/asciidoc/DecisionEngine/engine-event-listeners-con.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/DecisionEngine/engine-event-listeners-con.adoc
@@ -2,35 +2,53 @@
 
 = {DECISION_ENGINE_CAP} event listeners and debug logging
 
-In {PRODUCT}, you can add or remove listeners for {DECISION_ENGINE} events, such as fact insertions and rule executions. With {DECISION_ENGINE} event listeners, you can be notified of {DECISION_ENGINE} activity and separate your logging and auditing work from the core of your application.
+The {DECISION_ENGINE} generates events when performing activities such as fact insertions and rule executions. If you register event listeners, the {DECISION_ENGINE} calls every listener when an activity is performed.
 
-The {DECISION_ENGINE} supports the following default event listeners for the agenda and working memory:
+Event listeners have methods that correspond to different types of activities. The {DECISION_ENGINE} passes an event object to each method; this object contains information about the specific activity.
 
-* `AgendaEventListener`
-* `WorkingMemoryEventListener`
+Your code can implement custom event listeners and you can also add and remove registered event listeners. In this way, your code can be notified of {DECISION_ENGINE} activity, and you can separate logging and auditing work from the core of your application.
 
-ifdef::DROOLS,JBPM,OP[]
-.WorkingMemoryEventManager
-image::UserGuide/WorkingMemoryEventManager.png[align="center"]
-endif::[]
+The {DECISION_ENGINE} supports the following event listeners with the following methods:
 
-For each event listener, the {DECISION_ENGINE} also supports the following specific events that you can specify to be monitored:
+.Agenda event listener
+[source,java]
+----
+public interface AgendaEventListener
+    extends
+    EventListener {
+    void matchCreated(MatchCreatedEvent event);
+    void matchCancelled(MatchCancelledEvent event);
+    void beforeMatchFired(BeforeMatchFiredEvent event);
+    void afterMatchFired(AfterMatchFiredEvent event);
+    void agendaGroupPopped(AgendaGroupPoppedEvent event);
+    void agendaGroupPushed(AgendaGroupPushedEvent event);
+    void beforeRuleFlowGroupActivated(RuleFlowGroupActivatedEvent event);
+    void afterRuleFlowGroupActivated(RuleFlowGroupActivatedEvent event);
+    void beforeRuleFlowGroupDeactivated(RuleFlowGroupDeactivatedEvent event);
+    void afterRuleFlowGroupDeactivated(RuleFlowGroupDeactivatedEvent event);
+}
+----
 
-* `MatchCreatedEvent`
-* `MatchCancelledEvent`
-* `BeforeMatchFiredEvent`
-* `AfterMatchFiredEvent`
-* `AgendaGroupPushedEvent`
-* `AgendaGroupPoppedEvent`
-* `ObjectInsertEvent`
-* `ObjectDeletedEvent`
-* `ObjectUpdatedEvent`
-* `ProcessCompletedEvent`
-* `ProcessNodeLeftEvent`
-* `ProcessNodeTriggeredEvent`
-* `ProcessStartEvent`
+.Rule runtime event listener
+[source,java]
+----
+public interface RuleRuntimeEventListener extends EventListener {
+    void objectInserted(ObjectInsertedEvent event);
+    void objectUpdated(ObjectUpdatedEvent event);
+    void objectDeleted(ObjectDeletedEvent event);
+}
+----
 
-For example, the following code uses a `DefaultAgendaEventListener` listener attached to a KIE session and specifies the `AfterMatchFiredEvent` event to be monitored. The code prints pattern matches after the rules are executed (fired):
+For the definitions of event classes, see the https://github.com/kiegroup/drools/tree/{COMMUNITY_VERSION_FINAL}/drools-core/src/main/java/org/drools/core/event[GitHub repository].
+
+//ifdef::DROOLS,JBPM,OP[]
+//.WorkingMemoryEventManager
+//image::UserGuide/WorkingMemoryEventManager.png[align="center"]
+//endif::[]
+
+{PRODUCT} includes default implementations of these listeners: `DefaultAgendaEventListener` and `DefaultRuleRuntimeEventListener`. You can extend each of these implementations to monitor specific events.
+
+For example, the following code extends `DefaultAgendaEventListener` to monitor the  `AfterMatchFiredEvent` event and attaches this listener to a KIE session. The code prints pattern matches when rules are executed (fired):
 
 .Example code to monitor and print `AfterMatchFiredEvent` events in the agenda
 [source,java]
@@ -43,14 +61,14 @@ ksession.addEventListener( new DefaultAgendaEventListener() {
 });
 ----
 
-The {DECISION_ENGINE} also supports the following agenda and working memory event listeners for debug logging:
+{PRODUCT} also includes the following {DECISION_ENGINE} agenda and rule runtime event listeners for debug logging:
 
 * `DebugAgendaEventListener`
 * `DebugRuleRuntimeEventListener`
 
-These event listeners implement the same supported event-listener methods and include a debug print statement by default. You can add a specific supported event to be monitored and documented, or monitor all agenda or working memory activity.
+These event listeners implement the same supported event-listener methods and include a debug print statement by default. You can add additional monitoring code for a specific supported event.
 
-For example, the following code uses the `DebugRuleRuntimeEventListener` event listener to monitor and print all working memory events:
+For example, the following code uses the `DebugRuleRuntimeEventListener` event listener to monitor and print all working memory (rule runtime) events:
 
 .Example code to monitor and print all working memory events
 [source,java]

--- a/doc-content/drools-docs/src/main/asciidoc/DecisionEngine/engine-event-listeners-development-con.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/DecisionEngine/engine-event-listeners-development-con.adoc
@@ -1,0 +1,12 @@
+[id='engine-event-listeners-development-con_{context}']
+= Practices for development of event listeners
+
+The {DECISION_ENGINE} calls event listeners during rule processing. The calls block the execution of the {DECISION_ENGINE}. Therefore, the event listener can affect the performance of the {DECISION_ENGINE}.
+
+To ensure minimal disruption, follow the following guidelines:
+
+* Any action must be as short as possible.
+* A listener class must not have a state. The {DECISION_ENGINE} can destroy and re-create a listener class at any time.
+* Do not use logic that relies on the order of execution of different event listeners.
+* Do not include interactions with different entities outside the {DECISION_ENGINE} within a listener. For example, do not include REST calls for notification of events. An exception is the output of logging information; however, a logging listener must be as simple as possible.
+* You can use a listener to modify the state of the {DECISION_ENGINE}, for example, to change the values of variables.

--- a/doc-content/jbpm-docs/src/main/asciidoc/CoreEngine/event-listeners-development-con.adoc
+++ b/doc-content/jbpm-docs/src/main/asciidoc/CoreEngine/event-listeners-development-con.adoc
@@ -3,7 +3,7 @@
 
 The {PROCESS_ENGINE} calls event listeners during processing of events or tasks. The calls happen within {PROCESS_ENGINE} transactions and block execution. Therefore, the event listener can affect the logic and performance of the {PROCESS_ENGINE}.
 
-To ensure minimal disruption, observe the following practices:
+To ensure minimal disruption, follow the following guidelines:
 
 * Any action must be as short as possible.
 * A listener class must not have a state. The {PROCESS_ENGINE} can destroy and re-create a listener class at any time.
@@ -12,6 +12,6 @@ To ensure minimal disruption, observe the following practices:
 Database-related resources provided by {EAP} are always enlisted in the current transaction. In other cases, check the JTA information for the runtime environment that you are using.
 +
 * Do not use logic that relies on the order of execution of different event listeners.
-* Do not include interaction with different entities outside the {PROCESS_ENGINE} within a listener. For example, do not include REST calls for notification of events. Instead, use process nodes to complete such calls. An excepting is output of logging information; however, a logging listener must be as simple as possible.
+* Do not include interactions with different entities outside the {PROCESS_ENGINE} within a listener. For example, do not include REST calls for notification of events. Instead, use process nodes to complete such calls. An exception is the output of logging information; however, a logging listener must be as simple as possible.
 * You can use a listener to modify the state of the process or task that is involved in the event, for example, to change its variables.
 * You can use a listener to interact with the {PROCESS_ENGINE}, for example, to send signals or to interact with process instances that are not involved in the event.


### PR DESCRIPTION
* Improved documentation for decision engine event listeners

* Link to definitions of event classes

* Update doc-content/drools-docs/src/main/asciidoc/DecisionEngine/engine-event-listeners-con.adoc

Co-authored-by: Heena Manwani <59050394+hmanwani-rh@users.noreply.github.com>

* SME/peer review

* Peer review 2

Co-authored-by: Heena Manwani <59050394+hmanwani-rh@users.noreply.github.com>