### PR TITLE
[BXMSDOC-8087] Startup strategy configuration in OpenShift Operator - 7.59.x

### DIFF
--- a/doc-content/enterprise-only/openshift/operator-deploy-basic-proc.adoc
+++ b/doc-content/enterprise-only/openshift/operator-deploy-basic-proc.adoc
@@ -37,7 +37,7 @@ endif::DM[]
 +
 You cannot remove any service from the pod or add any new service to the pod. If you want to use another version of a service or to modify the configuration in any other way, deploy a new server image to replace the old one. You can use any container-based integration workflows to manage the pods.
 +
-When configuring this environment, in the *KIE Servers* tab you must customize {KIE_SERVER} and either click the *Set immutable server configuration* button or set the `KIE_SERVER_CONTAINER_DEPLOYMENT` environment variable. For instructions about configuring {KIE_SERVER}, see xref:operator-deploy-kieserver-proc_{context}[]. 
+When configuring this environment, in the *KIE Servers* tab you must customize {KIE_SERVER} and either click the *Set immutable server configuration* button or set the `KIE_SERVER_CONTAINER_DEPLOYMENT` environment variable. For instructions about configuring {KIE_SERVER}, see xref:operator-deploy-kieserver-proc_{context}[].
 ifdef::PAM[]
 +
 Optionally, you can also use the *Console* tab to include {CENTRAL} Monitoring in this environment to monitor, stop, and restart the execution of process services. For instructions about configuring {CENTRAL} Monitoring, see xref:operator-deploy-central-proc_{context}[].
@@ -59,7 +59,16 @@ Disable automatic updates if you want to use a custom image for any component of
 ====
 If you use RH-SSO or LDAP authentication, the same user must be configured in your authentication system with the `kie-server,rest-all,admin` roles for {PRODUCT}.
 ====
-. If you want to use a custom version tag for images, complete the following steps:
+. Optional: Select the startup strategy. The `OpenShiftStartupStrategy` setting is enabled by default.
++
+In some authoring environments, you might need to ensure that several users can deploy services on the same {KIE_SERVER} at the same time. By default, after deploying a service onto a {KIE_SERVER} using {CENTRAL}, the user must wait a few seconds before more services can be deployed. The `OpenShiftStartupStrategy` setting is enabled by default and causes this limitation. To remove the limitation, select the `ControllerBasedStartupStrategy` setting from the *Startup Strategy* list.
++
+[NOTE]
+====
+Do not enable the controller-based startup strategy in an environment with a high-availability {CENTRAL}. 
+====
++
+. Optional: If you want to use a custom version tag for images, complete the following steps:
 .. Click *Next* to access the *Security* tab.
 .. Scroll to the bottom of the window.
 .. Enter the image tag in the *Image tag* field.

--- a/doc-content/enterprise-only/openshift/operator-deploy-central-proc.adoc
+++ b/doc-content/enterprise-only/openshift/operator-deploy-central-proc.adoc
@@ -71,18 +71,6 @@ If your authoring environment uses a built-in {CENTRAL} Maven repository, change
 To enable persistence for the Maven repository cache, set the `KIE_PERSIST_MAVEN_REPO` environment variable to `true`.
 +
 If you set `KIE_PERSIST_MAVEN_REPO` to `true`, you can optionally set a custom path for the cache using the `KIE_M2_REPO_DIR` variable. The default path is `/opt/kie/data/m2`. Files in the `/opt/kie/data` directory tree are persisted.
-+
-** In some authoring environments, you might need to ensure that several users can deploy services on the same {KIE_SERVER} at the same time. By default, after deploying a service onto a {KIE_SERVER} using {CENTRAL}, the user needs to wait for some seconds before more services can be deployed. The `OpenShiftStartupStrategy` setting is enabled by default and causes this limitation. To remove the limitation, you can configure an `{PRODUCT_INIT}-authoring` environment to use the _controller strategy_. Do not make this change unless a specific need for it exists; if you decide to enable controller strategy, make this change on {CENTRAL} and on all {KIE_SERVERS} in the same environment.
-+
-[NOTE]
-====
-Do not enable the controller strategy in an environment with a high-availability {CENTRAL}. In such environments the controller strategy does not function correctly.
-====
-+
-To enable the controller strategy on {CENTRAL}, set the  `KIE_SERVER_CONTROLLER_OPENSHIFT_ENABLED` environment variable to `false`.
-
-//** In an authoring environment, to configure a Git hooks directory, set the following variable:
-//*** `GIT_HOOKS_DIR`: The fully qualified path to a Git hooks directory, for example, `/opt/eap/standalone/data/kie/git/hooks`. You must provide the content of this directory and mount it at the specified path. For instructions about providing and mounting the Git hooks directory, see <<githooks-proc_{context}>>.
 
 .Next steps
 

--- a/doc-content/enterprise-only/openshift/operator-deploy-kieserver-proc.adoc
+++ b/doc-content/enterprise-only/openshift/operator-deploy-kieserver-proc.adoc
@@ -147,14 +147,6 @@ If your authoring environment uses a built-in {CENTRAL} Maven repository, change
 * To use CORS with the default configuration, ensure *Default configuration* is selected from the *CORS Filters configuration* list and select *Enable CORS with Default values*.
 +
 * To use CORS with a custom configuration, select *Custom configuration* from the *CORS Filters configuration* list and enter the relevant values for the CORS filters.
-** In some authoring environments, you might need to ensure that several users can deploy services on the same {KIE_SERVER} at the same time. By default, after deploying a service onto a {KIE_SERVER} using {CENTRAL}, the user needs to wait for some seconds before more services can be deployed. The `OpenShiftStartupStrategy` setting is enabled by default and causes this limitation. To remove the limitation, you can configure an `{PRODUCT_INIT}-authoring` environment to use the _controller strategy_. Do not make this change unless a specific need for it exists; if you decide to enable controller strategy, make this change on {CENTRAL} and on all {KIE_SERVERS} in the same environment.
-+
-[NOTE]
-====
-Do not enable the controller strategy in an environment with a high-availability {CENTRAL}. In such environments the controller strategy does not function correctly.
-====
-+
-To enable controller strategy on a {KIE_SERVER}, set the  `KIE_SERVER_STARTUP_STRATEGY` environment variable to `ControllerBasedStartupStrategy` and the `KIE_SERVER_CONTROLLER_OPENSHIFT_ENABLED` environment variable to `false`.
 
 .Next steps
 To configure additional {KIE_SERVERS}, click *Add new KIE Server* again and repeat the procedure for the new server configuration.


### PR DESCRIPTION
* Startup strategy configuration in OpenShift Operator

* Update doc-content/enterprise-only/openshift/operator-deploy-basic-proc.adoc

Co-authored-by: emmurphy1 <30830712+emmurphy1@users.noreply.github.com>

Co-authored-by: emmurphy1 <30830712+emmurphy1@users.noreply.github.com>