### PR TITLE
Upstream 7.59.x PR for BXMSDOC-8382: Remove Kogito process related docs updates and limit content updates to traditional components

### DIFF
--- a/assemblies/assembly-deploying-kogito-microservices-on-openshift.adoc
+++ b/assemblies/assembly-deploying-kogito-microservices-on-openshift.adoc
@@ -25,8 +25,8 @@ include::{enterprise-dir}/getting-started-kogito/con-kogito-probes.adoc[leveloff
 include::{enterprise-dir}/getting-started-kogito/proc-kogito-enable-probes-quarkus.adoc[leveloffset=+2]
 include::{enterprise-dir}/getting-started-kogito/proc-kogito-enable-probes-springboot.adoc[leveloffset=+2]
 include::{enterprise-dir}/getting-started-kogito/proc-kogito-set-custom-probes.adoc[leveloffset=+2]
-include::{enterprise-dir}/getting-started-kogito/proc-kogito-prometheus-metrics-monitoring.adoc[leveloffset=+1]
-include::{enterprise-dir}/getting-started-kogito/con-kogito-grafana-dashboards-metrics-monitoring.adoc[leveloffset=+2]
+//include::{enterprise-dir}/getting-started-kogito/proc-kogito-prometheus-metrics-monitoring.adoc[leveloffset=+1] //Commented as per BAPL-2253 (Traditional 7.12 release)
+//include::{enterprise-dir}/getting-started-kogito/con-kogito-grafana-dashboards-metrics-monitoring.adoc[leveloffset=+2] //Commented as per BAPL-2253 (Traditional 7.12 release)
 include::{enterprise-dir}/getting-started-kogito/con-rhpam-kogito-operator-with-prometheus-and-grafana.adoc[leveloffset=+1]
 include::{enterprise-dir}/getting-started-kogito/ref-kogito-microservice-deploy-troubleshooting.adoc[leveloffset=+1]
 

--- a/assemblies/assembly-getting-started-kogito-microservices.adoc
+++ b/assemblies/assembly-getting-started-kogito-microservices.adoc
@@ -23,22 +23,22 @@ include::{shared-dir}/Install/proc-vscode-extension.adoc[leveloffset=+2]
 include::{shared-dir}/Install/proc-standalone-editors.adoc[leveloffset=+2]
 
 include::{enterprise-dir}/getting-started-kogito/proc-kogito-creating-maven-project.adoc[leveloffset=+1]
-include::{enterprise-dir}/getting-started-kogito/proc-kogito-custom-spring-boot-project-creating.adoc[leveloffset=+2]
+//include::{enterprise-dir}/getting-started-kogito/proc-kogito-custom-spring-boot-project-creating.adoc[leveloffset=+2] //Commented as per BAPL-2253 (Traditional 7.12 release)
 
 include::{enterprise-dir}/getting-started-kogito/ref-kogito-microservices-app-examples.adoc[leveloffset=+1]
 
 include::{enterprise-dir}/getting-started-kogito/proc-kogito-designing-app-dmn.adoc[leveloffset=+1]
 include::{enterprise-dir}/getting-started-kogito/proc-kogito-designing-app-drl-unit.adoc[leveloffset=+2]
 
-include::{enterprise-dir}/getting-started-kogito/proc-kogito-bpmn-model-creating.adoc[leveloffset=+1]
+//include::{enterprise-dir}/getting-started-kogito/proc-kogito-bpmn-model-creating.adoc[leveloffset=+1] //Commented as per BAPL-2253 (Traditional 7.12 release)
 
-include::{enterprise-dir}/getting-started-kogito/con-kogito-process-decisions-integration.adoc[leveloffset=+1]
-include::{enterprise-dir}/getting-started-kogito/proc-kogito-embedded-process-decision-integrating.adoc[leveloffset=+2]
-include::{enterprise-dir}/getting-started-kogito/ref-kogito-embedded-process-decision-traffic-example.adoc[leveloffset=+3]
-include::{enterprise-dir}/getting-started-kogito/proc-kogito-remote-process-decision-integrating.adoc[leveloffset=+2]
-include::{enterprise-dir}/getting-started-kogito/ref-kogito-remote-process-decision-traffic-example.adoc[leveloffset=+3]
+//include::{enterprise-dir}/getting-started-kogito/con-kogito-process-decisions-integration.adoc[leveloffset=+1] //Commented as per BAPL-2253 (Traditional 7.12 release)
+//include::{enterprise-dir}/getting-started-kogito/proc-kogito-embedded-process-decision-integrating.adoc[leveloffset=+2] //Commented as per BAPL-2253 (Traditional 7.12 release)
+//include::{enterprise-dir}/getting-started-kogito/ref-kogito-embedded-process-decision-traffic-example.adoc[leveloffset=+3] //Commented as per BAPL-2253 (Traditional 7.12 release)
+//include::{enterprise-dir}/getting-started-kogito/proc-kogito-remote-process-decision-integrating.adoc[leveloffset=+2] //Commented as per BAPL-2253 (Traditional 7.12 release)
+//include::{enterprise-dir}/getting-started-kogito/ref-kogito-remote-process-decision-traffic-example.adoc[leveloffset=+3] //Commented as per BAPL-2253 (Traditional 7.12 release)
 
-include::{enterprise-dir}/getting-started-kogito/proc-kogito-messaging-enabling.adoc[leveloffset=+1]
+//include::{enterprise-dir}/getting-started-kogito/proc-kogito-messaging-enabling.adoc[leveloffset=+1] //Commented as per BAPL-2253 (Traditional 7.12 release)
 
 include::{enterprise-dir}/getting-started-kogito/proc-kogito-microservice-running-app.adoc[leveloffset=+1]
 

--- a/doc-content/enterprise-only/getting-started-kogito/con-kogito-microservices.adoc
+++ b/doc-content/enterprise-only/getting-started-kogito/con-kogito-microservices.adoc
@@ -5,7 +5,7 @@
 
 {KOGITO} in {PRODUCT} is optimized for a hybrid cloud environment and adapts to your domain and tooling needs. The core objective of {KOGITO} microservices is to help you mold a set of decisions into your own domain-specific cloud-native set of services.
 
-IMPORTANT: In {PRODUCT} 7.11 version, {KOGITO} support is limited to decision services, including Decision Model and Notation (DMN), Drools Rule Language (DRL), and Predictive Model Markup Language (PMML). This support will be improved and extended to Business Process Modeling Notation (BPMN) in a future release.
+IMPORTANT: In {PRODUCT} {ENTERPRISE_VERSION} version, {KOGITO} support is limited to decision services, including Decision Model and Notation (DMN), Drools Rule Language (DRL), and Predictive Model Markup Language (PMML). This support will be improved and extended to Business Process Modeling Notation (BPMN) in a future release.
 
 When you use {KOGITO}, you are building a cloud-native application as a set of independent domain-specific microservices to achieve some business value. The decisions that you use to describe the target behavior are executed as part of the microservices that you create. The resulting microservices are highly distributed and scalable with no centralized orchestration service, and the runtime that your microservice uses is optimized for what is required.
 

--- a/doc-content/enterprise-only/getting-started-kogito/con-kogito-modelers.adoc
+++ b/doc-content/enterprise-only/getting-started-kogito/con-kogito-modelers.adoc
@@ -1,12 +1,12 @@
 [id="con-kogito-modelers_{context}"]
-= BPMN and DMN modelers for {KOGITO} microservices
+= DMN modelers for {KOGITO} microservices
 
-{PRODUCT} provides extensions or applications that you can use to design Business Process Model and Notation (BPMN) process models and Decision Model and Notation (DMN) decision models for your {KOGITO} microservices using graphical modelers.
+{PRODUCT} provides extensions or applications that you can use to design Decision Model and Notation (DMN) decision models for your {KOGITO} microservices using graphical modelers.
 
-The following BPMN and DMN modelers are supported:
+The following DMN modelers are supported:
 
-* *VSCode extension*: Enables you to view and design BPMN and DMN models in Visual Studio Code (VSCode). The VSCode extension requires VSCode 1.46.0 or later.
+* *VS Code extension*: Enables you to view and design DMN models in Visual Studio Code (VS Code). The VS Code extension requires VS Code 1.46.0 or later.
 +
-To install the VSCode extension directly in VSCode, select the *Extensions* menu option in VSCode and search for and install the *Red Hat Business Automation Bundle* extension.
+To install the VSCode extension directly in VS Code, select the *Extensions* menu option in VS Code and search for and install the *Red Hat Business Automation Bundle* extension.
 
-* *Business Modeler standalone editors*: Enable you to view and design BPMN and DMN models embedded in your web applications. To download the necessary files, you can either use the NPM artifacts from the https://www.npmjs.com/package/@kogito-tooling/kie-editors-standalone[Kogito tooling repository] or download the JavaScript files directly for the DMN standalone editor library at `https://kiegroup.github.io/kogito-online/standalone/dmn/index.js` and for the BPMN standalone editor library at `https://kiegroup.github.io/kogito-online/standalone/bpmn/index.js`.
+* *Business Modeler standalone editors*: Enable you to view and design DMN models embedded in your web applications. To download the necessary files, you can either use the NPM artifacts from the https://www.npmjs.com/package/@kogito-tooling/kie-editors-standalone[Kogito tooling repository] or download the JavaScript files directly for the DMN standalone editor library at `https://kiegroup.github.io/kogito-online/standalone/dmn/index.js`.

--- a/doc-content/enterprise-only/getting-started-kogito/proc-kogito-creating-maven-project.adoc
+++ b/doc-content/enterprise-only/getting-started-kogito/proc-kogito-creating-maven-project.adoc
@@ -63,4 +63,4 @@ This command generates the following dependency in the `pom.xml` file of your {P
 </dependency>
 ----
 --
-. Open or import the project in your VSCode IDE to view the contents.
+. Open or import the project in your VS Code IDE to view the contents.

--- a/doc-content/enterprise-only/getting-started-kogito/ref-kogito-microservices-app-examples.adoc
+++ b/doc-content/enterprise-only/getting-started-kogito/ref-kogito-microservices-app-examples.adoc
@@ -1,7 +1,7 @@
 [id="ref-kogito-microservices-app-examples_{context}"]
 = Example applications with {KOGITO} microservices
 
-{KOGITO} microservices include example applications in the `{PRODUCT_FILE}-kogito-and-optaplanner-quickstarts.zip` file. These example applications contain various types of services on {QUARKUS} or Spring Boot to help you develop your own applications. The services use one or more Business Process Model and Notation (BPMN) process models, Decision Model and Notation (DMN) decision models, Drools Rule Language (DRL) rule units, Predictive Model Markup Language (PMML) models, or Java classes to define the service logic.
+{KOGITO} microservices include example applications in the `{PRODUCT_FILE}-kogito-and-optaplanner-quickstarts.zip` file. These example applications contain various types of services on {QUARKUS} or Spring Boot to help you develop your own applications. The services use one or more Decision Model and Notation (DMN) decision models, Drools Rule Language (DRL) rule units, Predictive Model Markup Language (PMML) models, or Java classes to define the service logic.
 
 For information about each example application and instructions for using them, see the `README` file in the relevant application folder.
 
@@ -17,6 +17,8 @@ Decision services::
 * `dmn-drools-quarkus-metrics` and `dmn-drools-springboot-metrics`: A decision service (on {QUARKUS} or Spring Boot) that enables and consumes the runtime metrics monitoring feature in {KOGITO}.
 * `pmml-quarkus-example` and `pmml-springboot-example`: A decision service (on {QUARKUS} or Spring Boot) that uses PMML.
 
+////
+Commented as per BAPL-2253 (Traditional 7.12 release)
 Process services::
 * `process-scripts-quarkus` and `process-scripts-springboot`: A process service (on {QUARKUS} and Spring Boot) that invokes scripts within a process.
 * `process-service-calls-quarkus` and `process-service-calls-springboot`: A process service (on {QUARKUS} and Spring Boot) that invokes service calls within a process.
@@ -31,5 +33,6 @@ Process services that use decision services::
 Process services that use Apache Kafka::
 * `process-kafka-quickstart-quarkus` and `process-kafka-quickstart-springboot`: A process service (on {QUARKUS} and Spring Boot) that uses Apache Kafka to manage traveler process containing different rules.
 * `process-kafka-multi-quarkus` and `process-kafka-multi-springboot`:  A process service (on {QUARKUS} and Spring Boot) that uses Apache Kafka to send messages to different topics.
+////
 
-For more information, see {URL_DEVELOPING_PROCESS_SERVICES}#assembly-designing-business-processes[_{DESIGNING_BUSINESS_PROCESSES}_], {URL_DEVELOPING_DECISION_SERVICES}#assembly-dmn-models[_{DMN_MODELS}_], {URL_DEVELOPING_DECISION_SERVICES}#assembly-drl-rules[_{DRL_RULES}_], and {URL_DEVELOPING_DECISION_SERVICES}#assembly-pmml-models[_{PMML_MODELS}_].
+For more information, see {URL_DEVELOPING_DECISION_SERVICES}#assembly-dmn-models[_{DMN_MODELS}_], {URL_DEVELOPING_DECISION_SERVICES}#assembly-drl-rules[_{DRL_RULES}_], and {URL_DEVELOPING_DECISION_SERVICES}#assembly-pmml-models[_{PMML_MODELS}_].

--- a/titles-enterprise/getting-started-kogito/title.adoc
+++ b/titles-enterprise/getting-started-kogito/title.adoc
@@ -6,9 +6,7 @@ include::_artifacts/document-attributes.adoc[]
 :doctype: book
 :imagesdir: _images
 
-As a developer of business decisions
-ifdef::PAM[and processes]
-, you can use {KOGITO} to build cloud-native applications that adapt your business domain and tooling.
+As a developer of business decisions, you can use {KOGITO} to build cloud-native applications that adapt your business domain and tooling.
 
 include::_artifacts/snip-conscious-language.adoc[]
 


### PR DESCRIPTION
See JIRA: https://issues.redhat.com/browse/BXMSDOC-8382
BAPL- https://issues.redhat.com/browse/BAPL-2253

Doc preview:
[Getting started with Red Hat build of Kogito microservices](http://file.pnq.redhat.com/~hmanwani/BXMSDOC-8382-RHPAM-final/#assembly-getting-started-kogito-microservices)