### PR TITLE
Upstream 7.59.x branch PR for BXMSDOC-8373: Remove any references of kogito process management and update the 7.12 release notes

### DIFF
--- a/_artifacts/document-attributes.adoc
+++ b/_artifacts/document-attributes.adoc
@@ -1,5 +1,5 @@
 
-:REBUILT: Friday, January 21, 2022
+:REBUILT: Wednesday, January 26, 2022
 
 
 :ENTERPRISE_VERSION: 7.12

--- a/doc-content/enterprise-only/release-notes/rn-7.12-fixed-issues-ref.adoc
+++ b/doc-content/enterprise-only/release-notes/rn-7.12-fixed-issues-ref.adoc
@@ -80,9 +80,11 @@ endif::[]
 * When you use the JAR installer on {EAP} 7.3.8, the installation fails with the *Cannot start embedded Host Controller* error message [https://issues.redhat.com/browse/RHPAM-3803[RHPAM-3803]]
 * {PRODUCT} now supports {EAP} 7.4.0 [https://issues.redhat.com/browse/RHPAM-3510[RHPAM-3510]]
 
+////
 == {PLANNER_SHORT}
 
 * {PLANNER_SHORT} requires an immutable class for an `@PlanningId` such as Long, long, String or UUID. As of now for version 8.4.0, `ConstraintVerifier` throws an exception if it's not a Long [https://issues.redhat.com/browse/RHDM-1771[RHDM-1771]]
+////
 
 == {OPENSHIFT}
 

--- a/doc-content/enterprise-only/release-notes/rn-7.12-known-issues-ref.adoc
+++ b/doc-content/enterprise-only/release-notes/rn-7.12-known-issues-ref.adoc
@@ -37,6 +37,8 @@ Workaround: None.
 
 endif::PAM[]
 
+////
+
 == {KOGITO}
 
 .Unable to run the tests for {KOGITO} examples with scenario simulations [https://issues.redhat.com/browse/RHPAM-4068[RHPAM-4068]]
@@ -57,6 +59,7 @@ Steps to reproduce:
 
 Workaround: Override the transitive JUnit dependency of `kogito-scenario-simulation` file and use the version `4.13.1.redhat-00001`.
 
+////
 
 == {KIE_SERVER}
 
@@ -91,5 +94,49 @@ Steps to reproduce for {CENTRAL}:
 . Open an existing project or create a new one.
 . Import the `association.dmn` file attached in the [https://issues.redhat.com/browse/RHDM-1856[RHDM-1856]] issue.
 . Build the project and observe the results.
+
+Workaround: None.
+
+== {OPENSHIFT}
+
+.When you set the default role variable as `AUTH_LDAP_DEFAULT_ROLE`, {OPENSHIFT} images ignore the LDAP roles [https://issues.redhat.com/browse/RHPAM-4132[RHPAM-4132]]
+
+Issue: For {OPENSHIFT} images, when you set the LDAP default roles as `AUTH_LDAP_DEFAULT_ROLE`, all the roles from LDAP are ignored and you can not log in to the {CENTRAL} application. But when you do not set the default roles, all the roles from the LDAP are used correctly and you can log in to the {CENTRAL} application.
+
+Steps to reproduce for operator on {OPENSHIFT} 4.x:
+
+. Create a KieApp application and set the default role as follows:
++
+[source]
+----
+spec:
+  auth:
+    ldap:
+      ...
+      defaultRole: guest
+  ...
+----
+. Log in to the {CENTRAL}.
+
+Steps to reproduce for templates on {OPENSHIFT} 3.11:
+
+. Create a template.
+. Set the `AUTH_LDAP_DEFAULT_ROLE` environment variable as `AUTH_LDAP_DEFAULT_ROLE = "guest"`.
+. Log in to the {CENTRAL}.
+
+Workaround for operator on {OPENSHIFT} 4.x: Remove the set `defaultRole: guest` from your KieApp application.
+
+Workaround for templates on {OPENSHIFT} 3.11: Do not set the environment variable as `AUTH_LDAP_DEFAULT_ROLE = "guest"`.
+
+.When the KieApp instance containing one server configuration to pull the image from a given registry, the operator fails to deploy the server and you receive errors [https://issues.redhat.com/browse/RHPAM-3787[RHPAM-3787]]
+
+Issue: When deploying {PRODUCT} on {OPENSHIFT} using the operator, you can not use a docker image for the {KIE_SERVER} by enabling the *Set KIE Server Image* option and setting the *Kind* value to `DockerImage`. To use a docker image for the {KIE_SERVER}, you must set the image Context, name, and image tag fields from the from the custom registry.
+
+Steps to reproduce:
+
+. Install the operator on {OPENSHIFT} platform.
+. Configure one KieApp instance using `DockerImage` image as *Kind* value and provide the image name including the registry name.
+. Click *Set KIE Server image*.
+. Change the *Kind* value to `DockerImage`, and then provide the image name including the registry name, but without the version tag
 
 Workaround: None.

--- a/doc-content/enterprise-only/release-notes/rn-deprecated-issues-ref.adoc
+++ b/doc-content/enterprise-only/release-notes/rn-deprecated-issues-ref.adoc
@@ -20,14 +20,6 @@ The following {PLANNER_SHORT} tooling in {CENTRAL} is part of {PLANNER_SHORT} 7.
 * Guided rule editor actions for {PLANNER_SHORT} score modification
 * Solver assets
 
-ifdef::DM[]
-
-== Unified product deliverable and deprecation of {PRODUCT_DM} distribution files
-
-In {PRODUCT_PAM} 7.13 release, the distribution files for {PRODUCT_DM} will be replaced with {PRODUCT_PAM} files. Note that there will not be any change to the {PRODUCT_DM} subscription and the support entitlements and fees will remain the same. {PRODUCT_DM} is a subset of {PRODUCT_PAM}, and {PRODUCT_DM} subscribers will continue to receive full support for the decision management and optimization capabilities. The business process management (BPM) capabilities are exclusive to {PRODUCT_PAM} and will be available for use by {PRODUCT_DM} subscribers but with development support services only. {PRODUCT_DM} subscribers can upgrade to a full {PRODUCT_PAM} subscription at any time to receive full support for BPM features.
-
-endif::DM[]
-
 == Support for JDK 8
 
 Support for JDK 8 is deprecated in {PRODUCT} and might be removed in a future release.

--- a/doc-content/enterprise-only/release-notes/rn-kogito-productize-features-ref.adoc
+++ b/doc-content/enterprise-only/release-notes/rn-kogito-productize-features-ref.adoc
@@ -5,20 +5,6 @@
 
 This section highlights the {KOGITO} features included with {PRODUCT}.
 
-== Support for BPMN processes in {KOGITO}
-
-{PRODUCT} now provides support for straight-through processes in {KOGITO} to enable you to develop process microservices using Business Process Model and Notation (BPMN) 2.0 models. The supported process services include the following features:
-
-* The ability to create projects using {QUARKUS} and Spring Boot
-* The ability to monitor operational metrics of the process microservices
-* Example applications containing various types of {KOGITO} process microservices on https://access.redhat.com/products/quarkus[{QUARKUS}] or https://access.redhat.com/products/spring-boot[Spring Boot] to help you develop your own applications
-
-For more information, see {URL_GETTING_STARTED_KOGITO_MICROSERVICES}[_{GETTING_STARTED_KOGITO_MICROSERVICES}_].
-
-== Support for processes and decisions integration using {KOGITO}
-
-{PRODUCT} now enables the integration of processes and decisions using {KOGITO}. You can integrate the processes and decisions using an embedded method or a remote method. For more information, see {URL_GETTING_STARTED_KOGITO_MICROSERVICES}[_{GETTING_STARTED_KOGITO_MICROSERVICES}_].
-
 == Ability to migrate {CENTRAL} projects to {KOGITO} microservices projects
 
 You can now migrate your existing {CENTRAL} projects developed using DMN, PMML, or DRL to {KOGITO} microservices projects. For more information, see {URL_GETTING_STARTED_KOGITO_MICROSERVICES}#assembly-getting-started-migration-to-kogito-microservices[_{MIGRATION_KOGITO_SERVICES}_].

--- a/doc-content/enterprise-only/release-notes/rn-tech-preview-ref.adoc
+++ b/doc-content/enterprise-only/release-notes/rn-tech-preview-ref.adoc
@@ -33,6 +33,7 @@ You can perform the following tasks to customize the {CENTRAL} authoring perspec
 * Enhance the pagination.
 * Customize the number of assets present on the project screen.
 
+////
 == {PLANNER} new constraint collectors
 
 In order to provide a full implementation of some pre-existing OptaPlanner examples using the Constraint Streams API, the standard library of constraint collectors has been extended to include the following constraint collectors:
@@ -44,4 +45,5 @@ These new collectors are in technology preview.  Their interfaces, names, and fu
 
 == {KOGITO} and Kafka integration
 
-{KOGITO} decision services integration with managed Kafka by using the `org.kie.kogito:kogito-addons-{quarkus|springboot}-events-decisions` event-driven add-on is now available as technology preview. on {QUARKUS}, you can add the `io.quarkus:quarkus-kubernetes-service-binding` dependency to the application to handle the service binding created by the managed kafka. On Spring boot, you must add `mappings` field to the created service binding which must contain the required environment variables needed by the application. Another solution is to use the custom configuration maps available in the {KOGITO} operator.
+{KOGITO} decision microservices integration with managed Kafka by using the `org.kie.kogito:kogito-addons-{quarkus|springboot}-events-decisions` event-driven add-on is now available as technology preview. on {QUARKUS}, you can add the `io.quarkus:quarkus-kubernetes-service-binding` dependency to the application to handle the service binding created by the managed kafka. On Spring boot, you must add `mappings` field to the created service binding which must contain the required environment variables needed by the application. Another solution is to use the custom configuration maps available in the {KOGITO} operator.
+////

--- a/doc-content/enterprise-only/release-notes/rn-whats-new-con.adoc
+++ b/doc-content/enterprise-only/release-notes/rn-whats-new-con.adoc
@@ -98,6 +98,7 @@ For more information about creating processes that interact with {KAFKA_PRODUCT}
 
 endif::PAM[]
 
+////
 == {PLANNER}
 
 === OptaPlanner quickstarts
@@ -122,6 +123,7 @@ The following quickstarts are included in the  {PRODUCT} {PRODUCT_VERSION_LONG} 
 === Micrometer with OptaPlanner
 
 {PLANNER} exposes metrics through Micrometer, a metrics instrumentation library for Java applications. You can use Micrometer with popular monitoring systems to monitor the OptaPlanner solver. For information about using Micrometer with OptaPlanner, see {URL_DEVELOPING_SOLVERS}[_Developing Solvers with {PRODUCT}_].
+////
 
 == {OPENSHIFT}
 


### PR DESCRIPTION
**JIRAs**
- Epic: https://issues.redhat.com/browse/BXMSDOC-7825
- Dedicated JIRA: https://issues.redhat.com/browse/BXMSDOC-8373

**Doc previews:**
- [Release notes for Red Hat Process Automation Manager 7.12](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-8373-RHPAM-RN-New/)
- [Release notes for Red Hat Decision Manager 7.12](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-8373-RHDM-RN-New/)

**Doc impact:**
- From **Chapter 2**: Removed the references of kogito process management. 
- In RHDM doc Chapter 5. Deprecated components, removed the content related unified product.
- In Chapter 7, added a new known issue related to Openshft.
- Removed section 3.11.1. OptaPlanner quickstarts
- Removed section 3.11.1. OptaPlanner quickstarts
- Removed section 3.11.2. Micrometer with OptaPlanner
- Removed section 6.5. RED HAT BUILD OF OPTAPLANNER NEW CONSTRAINT COLLECTORS
- Removed section 6.6. RED HAT BUILD OF KOGITO AND KAFKA INTEGRATION
- Removed section 7.3. RED HAT BUILD OF KOGITO
- Removed section 8.8. OPTAPLANNER