### PR TITLE
Upstream main PR for BXMSDOC-8373: Update the release notes content as per 7.12 (Milestone 2).

### DIFF
--- a/_artifacts/document-attributes.adoc
+++ b/_artifacts/document-attributes.adoc
@@ -1,5 +1,5 @@
 
-:REBUILT: Monday, February 14, 2022
+:REBUILT: Monday, February 21, 2022
 
 
 :ENTERPRISE_VERSION: 7.12

--- a/doc-content/enterprise-only/release-notes/rn-7.12-fixed-issues-ref.adoc
+++ b/doc-content/enterprise-only/release-notes/rn-7.12-fixed-issues-ref.adoc
@@ -15,11 +15,11 @@
 * When you migrate a Git project from version 6.4 to version 7.8.1, you receive an error message [https://issues.redhat.com/browse/RHPAM-3232[RHPAM-3232]]
 * Editing a data object in the guided decision table fails with the null response [https://issues.redhat.com/browse/RHDM-1781[RHDM-1781]]
 * The test scenario tool is unable to execute models using imported inputs and/or decisions nodes and you receive an error message [https://issues.redhat.com/browse/RHDM-1645[RHDM-1645]]
+* When the {KIE_SERVER} is connected to {CENTRAL} using `ws protocol`, you can not stop the KIE container via {CENTRAL} user interface and you receive *Not supported for Web Socket implementation* error [https://issues.redhat.com/browse/RHPAM-3814[RHPAM-3814]]
 
 == Build and assembly
 
-* When a system log contains an attacker controlled string value, remote code execution happens in the Java logging library of Log4j 2.x
-// [https://issues.redhat.com/browse/RHPAM-4077[RHPAM-4077]]
+* When a system log contains an attacker controlled string value, remote code execution happens in the Java logging library of Log4j 2.x [https://issues.redhat.com/browse/RHPAM-4077[RHPAM-4077]]
 * JBoss Java EE 8 with {PRODUCT_BA} now references Jakarta EE 8 dependencies instead of Java EE 8 dependencies [https://issues.redhat.com/browse/RHPAM-3858[RHPAM-3858]]
 
 ifdef::PAM[]
@@ -29,7 +29,7 @@ ifdef::PAM[]
 endif::PAM[]
 
 * In an XStream security framework, by manipulating the processed input stream, a remote attacker can obtain sufficient rights to execute commands. The highest threat from this vulnerability is to data confidentiality, integrity, and system availability
-//[https://issues.redhat.com/browse/RHPAM-3733[RHPAM-3733]]
+[https://issues.redhat.com/browse/RHPAM-3733[RHPAM-3733]]
 * App Fomer Maven integration is not honoring the `nonProxyHosts` property [https://issues.redhat.com/browse/RHPAM-3638[RHPAM-3638]]
 
 == {KIE_SERVER}
@@ -69,7 +69,7 @@ ifdef::PAM[]
 * When you set the *Process Instance Description* with any value, a duplicate row is added in the *Metadata Attributes* [https://issues.redhat.com/browse/RHPAM-3848[RHPAM-3848]]
 * When you are using the singleton runtime strategy initialize listener, the Kafka server fails to publish events to the broker [https://issues.redhat.com/browse/RHPAM-3818[RHPAM-3818]]
 * The sub-process navigation link is not clickable when the boundary event aborts the child process [https://issues.redhat.com/browse/RHPAM-3806[RHPAM-3806]]
-* When you use the {KIE_SERVER} image navigation diagram / (+) button, it must display the last active active sub-process instance [https://issues.redhat.com/browse/RHPAM-3780[3780]]
+* When you use the {KIE_SERVER} image navigation diagram / (+) button, it must display the last active active sub-process instance [https://issues.redhat.com/browse/RHPAM-3780[RHPAM-3780]]
 * The navigation link / (+) button is not working when a sub-process contains boundary event [https://issues.redhat.com/browse/RHPAM-3779[RHPAM-3779]]
 * The BPMN designer fails to parse the work item definition file if the file contains unexpected properties [https://issues.redhat.com/browse/RHPAM-3619[RHPAM-3619]]
 * In the BPMN designer, an unknown custom task causes the diagram explorer to be empty [https://issues.redhat.com/browse/RHPAM-3606[RHPAM-3606]]
@@ -82,11 +82,11 @@ endif::[]
 * When you use the JAR installer on {EAP} 7.3.8, the installation fails with the *Cannot start embedded Host Controller* error message [https://issues.redhat.com/browse/RHPAM-3803[RHPAM-3803]]
 * {PRODUCT} now supports {EAP} 7.4.0 [https://issues.redhat.com/browse/RHPAM-3510[RHPAM-3510]]
 
-////
+
 == {PLANNER_SHORT}
 
 * {PLANNER_SHORT} requires an immutable class for an `@PlanningId` such as Long, long, String or UUID. As of now for version 8.4.0, `ConstraintVerifier` throws an exception if it's not a Long [https://issues.redhat.com/browse/RHDM-1771[RHDM-1771]]
-////
+
 
 == {OPENSHIFT}
 
@@ -99,6 +99,5 @@ endif::[]
 * When a bind variable produced by accumulate function is used in the condition of subsequent accumulate, you receive a compilation error [https://issues.redhat.com/browse/RHDM-1772[RHDM-1772]]
 * When you call `fireAllRules` simultaneously from multiple threads, you receive an exception inside the `MVELConsequence#evaluate` class [https://issues.redhat.com/browse/RHDM-1764[RHDM-1764]]
 * When you are executing `mvn clean compile -DgenerateModel=YES` on a project which contains a rule using the custom accumulate function, the build fails and your receive an error message [https://issues.redhat.com/browse/RHDM-1754[RHDM-1754]]
-* There is a performance difference while using JDK 8 and JDK 11
-//[https://issues.redhat.com/browse/RHDM-1735[RHDM-1735]]
+* There is a performance difference while using JDK 8 and JDK 11 [https://issues.redhat.com/browse/RHDM-1735[RHDM-1735]]
 * Reduce an unnecessary classloading by parent classloader [https://issues.redhat.com/browse/RHDM-1728[RHDM-1728]]

--- a/doc-content/enterprise-only/release-notes/rn-7.12-known-issues-ref.adoc
+++ b/doc-content/enterprise-only/release-notes/rn-7.12-known-issues-ref.adoc
@@ -37,7 +37,7 @@ Workaround: None.
 
 endif::PAM[]
 
-////
+
 
 == {KOGITO}
 
@@ -59,7 +59,7 @@ Steps to reproduce:
 
 Workaround: Override the transitive JUnit dependency of `kogito-scenario-simulation` file and use the version `4.13.1.redhat-00001`.
 
-////
+
 
 == {KIE_SERVER}
 
@@ -140,3 +140,66 @@ Steps to reproduce:
 . Change the *Kind* value to `DockerImage`, and then provide the image name including the registry name, but without the version tag
 
 Workaround: None.
+
+.Authorization fails while using the role mapping [https://issues.redhat.com/browse/RHPAM-4146[RHPAM-4146]]
+
+Issue: When you set the `roleMapper`, authorization fails and it is not specified in the `KIELdapSecurityDomain` security-domain.
+
+Workaround:
+
+. Create the `workaround.cli` script as follows:
++
+[source]
+----
+embed-server --std-out=echo --server-config=standalone-openshift.xml
+batch
+
+/subsystem=elytron/security-domain=KIELdapSecurityDomain:write-attribute(name=realms[0].role-mapper, value=kie-custom-role-mapper)
+
+run-batch
+quit
+----
+
+. Create a empty file as `delayedpostconfigure.sh`.
+. Create the `postconfigure.sh` file and add the following content:
++
+[source]
+----
+echo "trying to execute /opt/eap/bin/jboss-cli.sh --file=/opt/eap/extensions/workaround.cli "
+/opt/eap/bin/jboss-cli.sh --file=/opt/eap/extensions/workaround.cli
+echo "END - cli script executed"
+----
+
+. Create the `config-map` and add the following content:
++
+[source]
+----
+oc create configmap postconfigure \
+  --from-file=workaround.cli=workaround.cli \
+  --from-file=delayedpostconfigure.sh=delayedpostconfigure.sh \
+  --from-file=postconfigure.sh=postconfigure.sh
+----
+
+. To mount the `config-map`, follow the steps mentioned in https://github.com/jboss-container-images/rhpam-7-openshift-image/tree/main/quickstarts/post-configure-example#operator-method[Operator method].
+
+You will receive the following message in the logs during {EAP} startup:
+
+[source]
+----
+trying to execute /opt/eap/bin/jboss-cli.sh --file=/opt/eap/extensions/workaround.cli
+19:15:55,744 INFO  [org.jboss.modules] (CLI command executor) JBoss Modules version 1.11.0.Final-redhat-00001
+...
+The batch executed successfully
+process-state: reload-required
+19:16:04,757 INFO  [org.jboss.as] (MSC service thread 1-1) WFLYSRV0050: JBoss EAP 7.4.1.GA (WildFly Core 15.0.4.Final-redhat-00001) stopped in 18ms
+END - cli script executed
+----
+
+The security domain is also updated as follows:
+
+[source]
+----
+<security-domain name="KIELdapSecurityDomain" default-realm="KIELdapRealm" permission-mapper="default-permission-mapper">
+          <realm name="KIELdapRealm" role-decoder="from-roles-attribute" role-mapper="kie-custom-role-mapper"/>
+        </security-domain>
+----

--- a/doc-content/enterprise-only/release-notes/rn-tech-preview-ref.adoc
+++ b/doc-content/enterprise-only/release-notes/rn-tech-preview-ref.adoc
@@ -33,7 +33,7 @@ You can perform the following tasks to customize the {CENTRAL} authoring perspec
 * Enhance the pagination.
 * Customize the number of assets present on the project screen.
 
-////
+
 == {PLANNER} new constraint collectors
 
 In order to provide a full implementation of some pre-existing OptaPlanner examples using the Constraint Streams API, the standard library of constraint collectors has been extended to include the following constraint collectors:
@@ -46,4 +46,3 @@ These new collectors are in technology preview.  Their interfaces, names, and fu
 == {KOGITO} and Kafka integration
 
 {KOGITO} decision microservices integration with managed Kafka by using the `org.kie.kogito:kogito-addons-{quarkus|springboot}-events-decisions` event-driven add-on is now available as technology preview. on {QUARKUS}, you can add the `io.quarkus:quarkus-kubernetes-service-binding` dependency to the application to handle the service binding created by the managed kafka. On Spring boot, you must add `mappings` field to the created service binding which must contain the required environment variables needed by the application. Another solution is to use the custom configuration maps available in the {KOGITO} operator.
-////

--- a/doc-content/enterprise-only/release-notes/rn-whats-new-con.adoc
+++ b/doc-content/enterprise-only/release-notes/rn-whats-new-con.adoc
@@ -98,7 +98,7 @@ For more information about creating processes that interact with {KAFKA_PRODUCT}
 
 endif::PAM[]
 
-////
+
 == {PLANNER}
 
 === OptaPlanner quickstarts
@@ -123,7 +123,7 @@ The following quickstarts are included in the  {PRODUCT} {PRODUCT_VERSION_LONG} 
 === Micrometer with OptaPlanner
 
 {PLANNER} exposes metrics through Micrometer, a metrics instrumentation library for Java applications. You can use Micrometer with popular monitoring systems to monitor the OptaPlanner solver. For information about using Micrometer with OptaPlanner, see {URL_DEVELOPING_SOLVERS}[_Developing Solvers with {PRODUCT}_].
-////
+
 
 == {OPENSHIFT}
 
@@ -139,7 +139,7 @@ endif::PAM[]
 When you deploy {PRODUCT} on {OPENSHIFT} using the operator installer, by default the deployment uses the `OpenShiftStartupStrategy` setting. You can now switch to the Controller startup strategy in the configuration user interface if necessary.
 
 === Custom hostname routes
-You can now set custom hostnames for external routes by using the `routeHostname` property. 
+You can now set custom hostnames for external routes by using the `routeHostname` property.
 
 === Improved SSL configurability
 You can now enable or disable SSL in the operator and expose the SSL route.


### PR DESCRIPTION
**Tracking JIRA:** https://issues.redhat.com/browse/BXMSDOC-8373

**Doc previews:**
- [Release notes for Red Hat Process Automation Manager 7.12(Milestone 2)](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-8373-7.12-RHPAM-Milestone2/)
- [Release notes for Red Hat Decision Manager 7.12 (Milestone 2)](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-8373-7.12-RHDM-Milestone2)

**Doc impact:**
- Removed Section 2.3. Support for BPMN processes in Red Hat build of Kogito
- Removed Section 2.4. Support for processes and decisions integration using Red Hat build of Kogito
- Added Section 3.11.1. OptaPlanner quickstarts
- Added Section 3.11.2. Micrometer with OptaPlanner
- Added Section 5.2. OptaPlanner 7
- Added Section 5.3. OptaPlanner tooling components in Business Central
- Added Section 6.5. Red Hat build of OptaPlanner new constraint collectors
- Added Section 6.6. Red Hat build of Kogito and Kafka integration
- Added Section 7.3. Red Hat build of Kogito
- Added Section 8.8. OptaPlanner
- Removed Known issue: https://issues.redhat.com/browse/RHPAM-3787 
- Added Known issue: https://issues.redhat.com/browse/RHPAM-4146
- Added Fixed issue: https://issues.redhat.com/browse/RHPAM-3814