### PR TITLE
Kogito 6699- Drop Spring Boot support from Serverless Workflow

### DIFF
--- a/doc-content/kogito-docs/src/main/asciidoc/serverless/chap-kogito-orchestrating-serverless.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/serverless/chap-kogito-orchestrating-serverless.adoc
@@ -190,8 +190,8 @@ After the execution of the rule service is complete, the event state specifies t
 For more {PRODUCT} examples that use Serverless Workflow, see the following example applications in GitHub:
 
 * https://github.com/kiegroup/kogito-examples/tree/stable/serverless-workflow-events-quarkus[`serverless-workflow-events-quarkus`]: A Serverless Workflow service for processing job applicant approvals and that showcases event-driven services
-* https://github.com/kiegroup/kogito-examples/tree/stable/serverless-workflow-greeting-quarkus[`serverless-workflow-greeting-quarkus`] and https://github.com/kiegroup/kogito-examples/tree/stable/serverless-workflow-greeting-springboot[`serverless-workflow-greeting-springboot`]: A Serverless Workflow greeting service with both JSON and YAML workflow definitions
-* https://github.com/kiegroup/kogito-examples/tree/stable/serverless-workflow-service-calls-quarkus[`serverless-workflow-service-calls-quarkus`] and https://github.com/kiegroup/kogito-examples/tree/stable/serverless-workflow-service-calls-springboot[`serverless-workflow-service-calls-springboot`]: A Serverless Workflow service for returning country information
+* https://github.com/kiegroup/kogito-examples/tree/stable/serverless-workflow-greeting-quarkus[`serverless-workflow-greeting-quarkus`]: A Serverless Workflow greeting service with both JSON and YAML workflow definitions
+* https://github.com/kiegroup/kogito-examples/tree/stable/serverless-workflow-service-calls-quarkus[`serverless-workflow-service-calls-quarkus`]: A Serverless Workflow service for returning country information
 * https://github.com/kiegroup/kogito-examples/tree/stable/serverless-workflow-github-showcase[`serverless-workflow-github-showcase`]: In this example, a GitHub bot application is deployed, which reacts upon a new PR being opened in a given GitHub project. The bot is implemented using a service and event orchestration approach with {PRODUCT} implementation of the Serverless Workflow specification.
 
 [id="proc-serverless-workflow-definitions_{context}"]

--- a/doc-content/kogito-docs/src/main/asciidoc/serverless/chap-kogito-orchestrating-serverless.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/serverless/chap-kogito-orchestrating-serverless.adoc
@@ -9,6 +9,8 @@ As a microservices developer or architect, you can use the {SERVERLESS_WORKFLOW_
 
 The target users of Serverless Workflow orchestration are mostly developers and architects who want to define logical steps of execution declaratively (no code) for cloud-native services. Although you can orchestrate your services using process diagrams in https://www.omg.org/spec/BPMN/2.0/About-BPMN[Business Process Model and Notation (BPMN)], the Serverless Workflow has less focus on business definition and more focus on function-level steps of execution. Serverless Workflow is also designed specifically for microservice orchestration and therefore has a smaller scope than BPMN. Serverless Workflow also enables you to write workflows in formats (JSON or YAML) that might be better suited for developing and deploying serverless applications in cloud or container environments.
 
+ ⚠️ Quarkus is the only supported runtime for Serverless Workflow.
+ 
 Ultimately, the choice of which specification to use for orchestrating event-driven microservices depends on your environment needs, development goals, and personal preference.
 
 The Serverless Workflow `functions`, `events`, and `states` are the core constructs for defining the orchestration behavior for your services. You can use one or all of these three constructs in your workflow definitions.


### PR DESCRIPTION
Jira - https://github.com/VaniHaripriya/kie-docs/pull/new/KOGITO-6699

Removed references of Spring boot from Serverless documentation.