### PR TITLE
Upstream 7.59.x PR for BXMSDOC-8435: Update the release notes docs for RHPAM/RHDM 7.12.1

### DIFF
--- a/_artifacts/document-attributes.adoc
+++ b/_artifacts/document-attributes.adoc
@@ -1,5 +1,5 @@
 
-:REBUILT: Monday, February 21, 2022
+:REBUILT: Thursday, March 10, 2022
 
 
 :ENTERPRISE_VERSION: 7.12

--- a/assemblies/assembly-release-notes.adoc
+++ b/assemblies/assembly-release-notes.adoc
@@ -24,7 +24,15 @@ include::{enterprise-dir}/release-notes/rn-tech-preview-ref.adoc[leveloffset=+1]
 
 include::{enterprise-dir}/release-notes/rn-7.12-known-issues-ref.adoc[leveloffset=+1]
 
+ifdef::PAM[]
+
+include::{enterprise-dir}/release-notes/rn-7.12.1-known-issues-ref.adoc[leveloffset=+1]
+
+endif::PAM[]
+
 include::{enterprise-dir}/release-notes/rn-7.12-fixed-issues-ref.adoc[leveloffset=+1]
+
+include::{enterprise-dir}/release-notes/rn-7.12.1-fixed-issues-ref.adoc[leveloffset=+1]
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/doc-content/enterprise-only/release-notes/rn-7.12.1-fixed-issues-ref.adoc
+++ b/doc-content/enterprise-only/release-notes/rn-7.12.1-fixed-issues-ref.adoc
@@ -1,0 +1,64 @@
+[id='rn-7.12.1-fixed-issues-ref']
+= Fixed issues in {PRODUCT} 7.12.1
+
+{PRODUCT} 7.12.1 provides increased stability and fixed issues listed in this section.
+
+== {CENTRAL}
+
+* When you have two data objects, form generation enters into an infinite loop when it reaches the first nested form [https://issues.redhat.com/browse/RHPAM-3366[RHPAM-3366]]
+* An inaccurate alert about duplicate rule name after copying a rule in {CENTRAL} [https://issues.redhat.com/browse/RHPAM-2871[RHPAM-2871]]
+* In the test scenarios designer, `today()` and `now()` functions are not evaluated correctly [https://issues.redhat.com/browse/RHDM-1816[RHDM-1816]]
+* When you delete a column from a guided decision table and try to validate that guided decision table, you receive an error [https://issues.redhat.com/browse/RHDM-1813[RHDM-1813]]
+* When you are converting a guided decision table to XLS, a backslash is added before the double quotes and you receive an error [https://issues.redhat.com/browse/RHDM-1723[RHDM-1723]]
+
+== Build and assembly
+
+* In the Spring framework, versions 5.3.0 - 5.3.10, 5.2.0 - 5.2.17, and an older unsupported versions, it is possible for a user to provide malicious input to cause the insertion of additional log entries [https://issues.redhat.com/browse/RHPAM-4098[RHPAM-4098]]
+
+ifdef::PAM[]
+
+== {PROCESS_ENGINE_CAP}
+
+* Boundary timer is not triggered after a rollback [https://issues.redhat.com/browse/RHPAM-4102[RHPAM-4102]]
+* Incorrect response for REST service when `org.kie.server.bypass.auth.user` system property is used with `JAASUserGroupCallbackImpl` implementation [https://issues.redhat.com/browse/RHPAM-4087[RHPAM-4087]]
+* When you use the `ClusteredJobFailOverListener` method, you receive system errors caused by the `ConcurrentModificationException` exception [https://issues.redhat.com/browse/RHPAM-4069[RHPAM-4069]]
+* Certificate-based authentication is required between {KIE_SERVER} and process instance migration tool [https://issues.redhat.com/browse/RHPAM-4038[RHPAM-4038]]
+* Smart router send requests to a stopped {KIE_SERVER} [https://issues.redhat.com/browse/RHPAM-4035[RHPAM-4035]]
+* The `ProcessServiceImpl.getAvailableSignals` method must obtain process instances in read-only mode to avoid race condition [https://issues.redhat.com/browse/RHPAM-3967[RHPAM-3967]]
+* `OptimisticLockRetryInterceptor` triggers a retry logic when `javax.persistence.OptimisticLockException` or `org.hibernate.exception.ConstraintViolationException` exceptions are thrown. This impacts the pluggable variable persistence when persisting the custom entity classes [https://issues.redhat.com/browse/RHPAM-3948[RHPAM-3948]]
+* All the scheduled notifications are duplicated on restart [https://issues.redhat.com/browse/RHPAM-3946[RHPAM-3946]]
+* Even after the timers are fired, entries from `EJBTimerScheduler.localCache` are not removed [https://issues.redhat.com/browse/RHPAM-3936[RHPAM-3936]]
+* In a setup with multiple {KIE_SERVER} nodes, duplicate EJB timer instances are created [https://issues.redhat.com/browse/RHPAM-3929[RHPAM-3929]]
+* Unable to find the task instance with the ID `xxx` if audit mode is disabled [https://issues.redhat.com/browse/RHPAM-3847[RHPAM-3847]]
+
+== Process Designer
+
+* When you make a rest call to retrieve the task form where a data object contains a `LocalDate` type, it is not displayed on any browsers. An input box displays an empty value [https://issues.redhat.com/browse/RHPAM-4020[RHPAM-4020]]
+* If there are multiple `intermediateCatchEvent` events, you receive an `ExtensibleXmlParser` error due to duplicate ID values [https://issues.redhat.com/browse/RHPAM-3878[RHPAM-3878]]
+
+endif::[]
+
+== DMN Designer
+
+* When the same FEEL object-access invocation is used by two KIE containers, you receive DMN evaluation errors [https://issues.redhat.com/browse/RHDM-1877[RHDM-1877]]
+
+== {OPENSHIFT}
+
+* When you install different versions of the {OPENSHIFT} operator in each namespace on the same {OPENSHIFT} cluster, you receive a validation error and CRD conflict [https://issues.redhat.com/browse/RHPAM-4158[RHPAM-4158]]
+* Authorization fails while using role mapping [https://issues.redhat.com/browse/RHPAM-4146[RHPAM-4146]]
+* When you set the default role variable as `AUTH_LDAP_DEFAULT_ROLE`, {OPENSHIFT} images ignore the LDAP roles [https://issues.redhat.com/browse/RHPAM-4132[RHPAM-4132]]
+* The DockerImage type is not accepted in the business automation operator with JDBC extension images [https://issues.redhat.com/browse/RHPAM-3787[RHPAM-3787]]
+* The `kie_server_container_started_total` counter displays the total number of containers with the status `STARTED` and `DEACTIVATED`, but it counts the `DEACTIVATED` containers as well and gives the wrong count [https://issues.redhat.com/browse/RHPAM-3784[RHPAM-3784]]
+ifdef::PAM[]
+* Increase the `KieExecutorMDB` threads in {PRODUCT} image [https://issues.redhat.com/browse/RHPAM-3528[RHPAM-3528]]
+endif::[]
+
+== Decision engine
+
+* When you use `RuleTerminalNodeLeftTuple`, the delete or insert child facts causes a loop in `PhreakJoinNode.doRightInserts()` function and you receive an `OutOfMemoryError` error [https://issues.redhat.com/browse/RHDM-1865[RHDM-1865]]
+* When you are executing the rules multiple times, you receive a random exception in a specific rule after constraint jitting [https://issues.redhat.com/browse/RHDM-1861[RHDM-1861]]
+* You must define the `allVars` field as `final` in the `org.mvel2.util.VariableSpaceModel` class [https://issues.redhat.com/browse/RHDM-1854[RHDM-1854]]
+* The result type of the `BigDecimal` operation with one or more null value operands must not be a `String` or `Boolean` type value [https://issues.redhat.com/browse/RHDM-1852[RHDM-1852]]
+* Already expired events are remaining forever in a working memory while entering a session [https://issues.redhat.com/browse/RHDM-1843[RHDM-1843]]
+* `NotNode` proceeds with unmatched facts [https://issues.redhat.com/browse/RHDM-1827[RHDM-1827]]
+* An executable model fails to build a rule which contains `&&` constraint with a bind variable on right side [https://issues.redhat.com/browse/RHDM-1820[RHDM-1820]]

--- a/doc-content/enterprise-only/release-notes/rn-7.12.1-known-issues-ref.adoc
+++ b/doc-content/enterprise-only/release-notes/rn-7.12.1-known-issues-ref.adoc
@@ -1,0 +1,46 @@
+[id='rn-7.12.1-known-issues-ref']
+= Known issues in {PRODUCT} 7.12.1
+
+This section lists known issues with {PRODUCT} 7.12.1.
+
+ifdef::PAM[]
+
+== Form modeler
+
+.When you create and open a form in the form modeler, you receive a recursion handling issue [https://issues.redhat.com/browse/RHPAM-4107[RHPAM-4107]]
+
+Issue: In the form modeler, when you try to create and open a form, you receive an error message about a recursion handling issue
+
+Steps to reproduce:
+
+. Create a data object called *A1* and enter the field values as *id:String* and *aField:A1*.
+. Create a custom form as *Form1* for the *A1* data object.
+. Select *aField* and drag it to the canvas and set *Form1* as its nested form.
+. Click *Save*.
+. Reopen the editor.
++
+You receive an error message.
+
+Workaround: None.
+
+== Process Designer
+
+.JavaScript language in an On Entry Action causes an unexpected system error after changing node to Multiple Instance [https://issues.redhat.com/browse/RHPAM-3409[RHPAM-3409]]
+
+Issue: In the *Properties* panel, if the language is set to JavaScript in an *On Entry Action* property and you change the node to *Multiple Instance*, you receive an unexpected system error.
+
+Steps to reproduce:
+
+. Create a new business process.
+. Create a task that contains the *Multiple Instance* property.
+. Enter any string to the *On Entry Action* property.
+. Change the language to JavaScript.
+. Set the value of the *Multiple Instance* property to `true`.
+
+Expected result: No errors occur in the user interface or server log.
+
+Actual result: You receive an unexpected system error.
+
+Workaround: None.
+
+endif::PAM[]

--- a/doc-content/enterprise-only/release-notes/rn-deprecated-issues-ref.adoc
+++ b/doc-content/enterprise-only/release-notes/rn-deprecated-issues-ref.adoc
@@ -4,6 +4,14 @@
 
 The components listed in this section have been deprecated.
 
+ifdef::DM[]
+
+== Unified product deliverable and deprecation of {PRODUCT} distribution files
+
+In Red Hat Process Automation Manager 7.13 release, the distribution files for {PRODUCT} will be replaced with Red Hat Process Automation Manager files. Note that there will not be any change to the {PRODUCT} subscription and the support entitlements and fees will remain the same. {PRODUCT} is a subset of Red Hat Process Automation Manager, and {PRODUCT} subscribers will continue to receive full support for the decision management and optimization capabilities. The business process management (BPM) capabilities are exclusive to Red Hat Process Automation Manager and will be available for use by {PRODUCT} subscribers but with development support services only. {PRODUCT} subscribers can upgrade to a full Red Hat Process Automation Manager subscription at any time to receive full support for BPM features.
+
+endif::DM[]
+
 == Red Hat Enterprise Linux 7
 
 Support for Red Hat Enterprise Linux 7 is deprecated in {PRODUCT} and features and will be removed in a future release.

--- a/doc-content/enterprise-only/release-notes/rn-tech-preview-ref.adoc
+++ b/doc-content/enterprise-only/release-notes/rn-tech-preview-ref.adoc
@@ -22,7 +22,7 @@ endif::PAM[]
 You can deploy a high-availability {PRODUCT} authoring environment on {OPENSHIFT} 4.x using the operator.
 
 == OpenShift operator installer wizard
-An installer wizard is provided in the OpenShift operator for {PRODUCT}. You can use the wizard to deploy a {PRODUCT} environment on {OPENSHIFT} with the operator.
+An installer wizard is provided in the {OPENSHIFT} operator for {PRODUCT}. You can use the wizard to deploy a {PRODUCT} environment on {OPENSHIFT} with the operator.
 
 == Authoring perspective customization
 


### PR DESCRIPTION
**Associated JIRA:** https://issues.redhat.com/browse/BXMSDOC-8435

**Doc previews:** 
- [Release notes for Red Hat Process Automation Manager 7.12](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-8435-7.12.1-RHPAM-RN/)
- [Release notes for Red Hat Decision Manager 7.12](http://file.pnq.redhat.com/~kaldesai/BXMSDOC-8435-RHDM-7.12.1-This/#unified_product_deliverable_and_deprecation_of_red_hat_decision_manager_distribution_files)

**Doc impact:** 
Added fixed issues and known issues for the 7.12.1 release.
