### PR TITLE
[DROOLS-6886] KIE Server asynchronous deployment does not work

### DIFF
--- a/doc-content/shared-kie-docs/src/main/asciidoc/KieServer/kie-server-system-properties-ref.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/KieServer/kie-server-system-properties-ref.adoc
@@ -371,7 +371,7 @@ endif::[]
 |`false`
 |A property that instructs {KIE_SERVER} to hold the deployment until the {CONTROLLER} provides the container deployment configuration. This property only affects servers running in managed mode. The following options are available:
 
-* `false`: The connection to the {CONTROLLER} is asynchronous. The application starts, connects to the {CONTROLLER}, and once successful, deploys the containers. The application accepts requests even before the containers are available. Note that asynchronous deployment is applicable only with Java EE server environment. With web containers, for example Tomcat, deployment is synchronous if the {CONTROLLER} is available.
+* `false`: The connection to the {CONTROLLER} is asynchronous. The application starts, connects to the {CONTROLLER}, and once successful, deploys the containers. The application accepts requests even before the containers are available. Note that an asynchronous deployment applies only to the Java EE server environment. With web containers, for example, Tomcat, deployment is synchronous if the {CONTROLLER} is available.
 * `true`: The deployment of the server application joins the {CONTROLLER} connection thread with the main deployment and awaits its completion. This option can lead to a potential deadlock in case more applications are on the same server. Use only one application on one server instance.
 
 |`org.kie.server.startup.strategy`

--- a/doc-content/shared-kie-docs/src/main/asciidoc/KieServer/kie-server-system-properties-ref.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/KieServer/kie-server-system-properties-ref.adoc
@@ -371,7 +371,7 @@ endif::[]
 |`false`
 |A property that instructs {KIE_SERVER} to hold the deployment until the {CONTROLLER} provides the container deployment configuration. This property only affects servers running in managed mode. The following options are available:
 
-* `false`: The connection to the {CONTROLLER} is asynchronous. The application starts, connects to the {CONTROLLER}, and once successful, deploys the containers. The application accepts requests even before the containers are available.
+* `false`: The connection to the {CONTROLLER} is asynchronous. The application starts, connects to the {CONTROLLER}, and once successful, deploys the containers. The application accepts requests even before the containers are available. Note that asynchronous deployment is applicable only with Java EE server environment. With web containers, for example Tomcat, deployment is synchronous if the {CONTROLLER} is available.
 * `true`: The deployment of the server application joins the {CONTROLLER} connection thread with the main deployment and awaits its completion. This option can lead to a potential deadlock in case more applications are on the same server. Use only one application on one server instance.
 
 |`org.kie.server.startup.strategy`


### PR DESCRIPTION
- As a limitation, asynchronous deployment does not work in Tomcat because it doesn't have ContainerManagerEJB. Clarifying it in the doc.

Explained in the JIRA:
https://issues.redhat.com/browse/DROOLS-6886
