### PR TITLE
synced to main SNAPSHOT version

### DIFF
--- a/doc-content/kogito-docs/pom.xml
+++ b/doc-content/kogito-docs/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-docs-guides</artifactId>
-    <version>7.72.0-SNAPSHOT</version>
+    <version>7.73.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.kie.kogito</groupId>

--- a/doc-content/pom.xml
+++ b/doc-content/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-docs</artifactId>
-    <version>7.72.0-SNAPSHOT</version>
+    <version>7.73.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-parent</artifactId>
-    <version>7.72.0-SNAPSHOT</version>
+    <version>7.73.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-docs</artifactId>


### PR DESCRIPTION
now the versions are synced with the main branch. Each time the job for updating the kie-docs is executed the version will be updated too. Until now the problem was, that this SNAPSHOT version was always one version behind.