### PR TITLE
KOGITO-6884 Updated links to examples

### DIFF
--- a/doc-content/kogito-docs/src/main/asciidoc/bpmn/chap-kogito-developing-process-services.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/bpmn/chap-kogito-developing-process-services.adoc
@@ -2606,7 +2606,7 @@ image::kogito/bpmn/decisions/process-decisions-embedded-integration.png[Image of
 
 For more information, you can see xref:con-process-decisions-integration-traffic-violation-process-embedded_kogito-developing-process-services[].
 
-You can also use the example applications for Quarkus and Spring Boot, such as https://github.com/kiegroup/kogito-examples/tree/main/process-decisions-quarkus[`process-decisions-quarkus`] and https://github.com/kiegroup/kogito-examples/tree/main/process-decisions-springboot[`process-decisions-springboot`].
+You can also use the example applications for Quarkus and Spring Boot, such as https://github.com/kiegroup/kogito-examples/tree/main/kogito-quarkus-examples/process-decisions-quarkus[`process-decisions-quarkus`] and https://github.com/kiegroup/kogito-examples/tree/main/kogito-springboot-examples/process-decisions-springboot[`process-decisions-springboot`].
 
 The example of a traffic violations project describes how to use decisions within the processes and how to integrate decisions in an embedded way using the business rule tasks, which must be deployed with a process in the same application.
 
@@ -2771,7 +2771,7 @@ In the remote method, it is not required for the process and decision services t
 .Process integration with decisions through REST
 image::kogito/bpmn/decisions/process-decisions-rest-integration.png[Image of Process integration with decisions through REST]
 
-You can also use the example applications for Quarkus and Spring Boot, such as https://github.com/kiegroup/kogito-examples/tree/main/process-decisions-rest-quarkus[`process-decisions-rest-quarkus`] and https://github.com/kiegroup/kogito-examples/tree/main/process-decisions-rest-springboot[`process-decisions-rest-springboot`].
+You can also use the example applications for Quarkus and Spring Boot, such as https://github.com/kiegroup/kogito-examples/tree/main/kogito-quarkus-examples/process-decisions-rest-quarkus[`process-decisions-rest-quarkus`] and https://github.com/kiegroup/kogito-examples/tree/main/kogito-springboot-examples/process-decisions-rest-springboot[`process-decisions-rest-springboot`].
 
 You can define the decisions in different domains or assets, such as DMN and DRL. Here, we can consider the example of traffic violations, which describes how to integrate decisions in a remote environment using REST endpoints. In the REST endpoints, the decisions are deployed from the process service.
 

--- a/doc-content/kogito-docs/src/main/asciidoc/configuration/chap-kogito-configuring.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/configuration/chap-kogito-configuring.adoc
@@ -545,8 +545,8 @@ NOTE: As an alternative to enabling Kafka messaging explicitly in {PRODUCT} serv
 
 For example {PRODUCT} services with Kafka messaging, see the following example applications in GitHub:
 
-* https://github.com/kiegroup/kogito-examples/tree/stable/process-kafka-quickstart-quarkus[`process-kafka-quickstart-quarkus`]: Example on Quarkus
-* https://github.com/kiegroup/kogito-examples/tree/stable/process-kafka-quickstart-springboot[`process-kafka-quickstart-springboot`]: Example on Spring Boot
+* https://github.com/kiegroup/kogito-examples/tree/stable/kogito-quarkus-examples/process-kafka-quickstart-quarkus[`process-kafka-quickstart-quarkus`]: Example on Quarkus
+* https://github.com/kiegroup/kogito-examples/tree/stable/kogito-springboot-examples/process-kafka-quickstart-springboot[`process-kafka-quickstart-springboot`]: Example on Spring Boot
 // end::proc-messaging-enabling[]
 
 [id="proc-events-mongodb-debezium_{context}"]
@@ -671,8 +671,8 @@ In the previous example configuration, replace the server host, port, replica se
 
 You can also use the following example applications for consistency in a {PRODUCT} service using MongoDB and Debezium:
 
-* https://github.com/kiegroup/kogito-examples/tree/stable/process-outbox-mongodb-quarkus[`process-outbox-mongodb-quarkus`]: Example on Quarkus
-* https://github.com/kiegroup/kogito-examples/tree/stable/process-outbox-mongodb-springboot[`process-outbox-mongodb-springboot`]: Example on Spring Boot
+* https://github.com/kiegroup/kogito-examples/tree/stable/kogito-quarkus-examples/process-outbox-mongodb-quarkus[`process-outbox-mongodb-quarkus`]: Example on Quarkus
+* https://github.com/kiegroup/kogito-examples/tree/stable/kogito-springboot-examples/process-outbox-mongodb-springboot[`process-outbox-mongodb-springboot`]: Example on Spring Boot
 
 [id="proc-event-listeners-registering_{context}"]
 === Registering event listeners

--- a/doc-content/kogito-docs/src/main/asciidoc/creating-running/chap-kogito-creating-running.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/creating-running/chap-kogito-creating-running.adoc
@@ -1743,8 +1743,8 @@ The following table lists all the available properties for the Knative Eventing 
 
 For more information about the Knative Eventing add-on, see the following example applications:
 
-* https://github.com/kiegroup/kogito-examples/tree/main/serverless-workflow-order-processing[Serverless Workflow Order Processing]
-* https://github.com/kiegroup/kogito-examples/tree/main/process-knative-quickstart-quarkus[Process Knative Eventing]
+* https://github.com/kiegroup/kogito-examples/tree/main/serverless-workflow-examples/serverless-workflow-order-processing[Serverless Workflow Order Processing]
+* https://github.com/kiegroup/kogito-examples/tree/main/kogito-quarkus-examples/process-knative-quickstart-quarkus[Process Knative Eventing]
 
 === {PRODUCT} mail add-on
 

--- a/doc-content/kogito-docs/src/main/asciidoc/openshift/chap-kogito-deploying-on-openshift.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/openshift/chap-kogito-deploying-on-openshift.adoc
@@ -504,7 +504,7 @@ The {PRODUCT} command-line interface (CLI) supports the following operations on 
 `{PRODUCT_INIT} deploy-service __SERVICE_NAME__ __GIT_REPOSITORY_URL__ --context-dir __PROJECT_DIRECTORY__`
 |`{PRODUCT_INIT} deploy-service travels`
 
-`{PRODUCT_INIT} deploy-service travels \https://github.com/kiegroup/kogito-examples/tree/stable/kogito-travel-agency/extended --context-dir travels`
+`{PRODUCT_INIT} deploy-service travels \https://github.com/kiegroup/kogito-examples/tree/stable/kogito-quarkus-examples/kogito-travel-agency/extended --context-dir travels`
 
 |Enable Infinispan persistence and Apache Kafka messaging for a {PRODUCT} service during deployment. Use this command if you installed the relevant infrastructures using the {PRODUCT} Operator. In a binary build configuration, this command creates the service definition but does not deploy the service.
 |`{PRODUCT_INIT} deploy-service __SERVICE_NAME__ --infra __INFINISPAN_INFRA_NAME__ --infra __KAFKA_INFRA_NAME__`
@@ -512,7 +512,7 @@ The {PRODUCT} command-line interface (CLI) supports the following operations on 
 `{PRODUCT_INIT} deploy-service __SERVICE_NAME__ __GIT_REPOSITORY_URL__ --context-dir __PROJECT_DIRECTORY__ --infra __INFINISPAN_INFRA_NAME__ --infra __KAFKA_INFRA_NAME__`
 |`{PRODUCT_INIT} deploy-service travels --infra kogito-infinispan-infra --infra kogito-kafka-infra`
 
-`{PRODUCT_INIT} deploy-service travels \https://github.com/kiegroup/kogito-examples/tree/stable/kogito-travel-agency/extended --context-dir travels --infra kogito-infinispan-infra --infra kogito-kafka-infra`
+`{PRODUCT_INIT} deploy-service travels \https://github.com/kiegroup/kogito-examples/tree/stable/kogito-quarkus-examples/kogito-travel-agency/extended --context-dir travels --infra kogito-infinispan-infra --infra kogito-kafka-infra`
 
 |Create a {PRODUCT} service definition from a local or Git source and deploy the service using a native build.
 |`{PRODUCT_INIT} deploy-service __SERVICE_NAME__ --native`
@@ -520,18 +520,18 @@ The {PRODUCT} command-line interface (CLI) supports the following operations on 
 `{PRODUCT_INIT} deploy-service __SERVICE_NAME__ __GIT_REPOSITORY_URL__ --context-dir __PROJECT_DIRECTORY__ --native`
 |`{PRODUCT_INIT} deploy-service travels --native`
 
-`{PRODUCT_INIT} deploy-service travels \https://github.com/kiegroup/kogito-examples/tree/stable/kogito-travel-agency/extended --context-dir travels --native`
+`{PRODUCT_INIT} deploy-service travels \https://github.com/kiegroup/kogito-examples/tree/stable/kogito-quarkus-examples/kogito-travel-agency/extended --context-dir travels --native`
 
 |Upload a {PRODUCT} service file, such as a Decision Model and Notation (DMN) or Business Process Model and Notation (BPMN) file, or a file directory with multiple files to an OpenShift Cluster and trigger a new Source-to-Image (S2I) build. For single files, you can specify a local file system path or Git repository URL. For file directories, you can specify a local file system path only.
 |`{PRODUCT_INIT} deploy-service __SERVICE_NAME__ __PATH_TO_FILE_OR_DIR__`
 
 `{PRODUCT_INIT} deploy-service __SERVICE_NAME__ __GIT_FILE_URL__`
 
-|`kogito deploy-service travels /tmp/kogito-examples/kogito-travel-agency/extended/travels/src/main/resources/org/acme/travels/travels.bpmn2`
+|`kogito deploy-service travels /tmp/kogito-examples/kogito-quarkus-examples/kogito-travel-agency/extended/travels/src/main/resources/org/acme/travels/travels.bpmn2`
 
-`kogito deploy-service travels /tmp/kogito-examples/kogito-travel-agency/extended/travels/src/main/resources/org/acme/travels`
+`kogito deploy-service travels /tmp/kogito-examples/kogito-quarkus-examples/kogito-travel-agency/extended/travels/src/main/resources/org/acme/travels`
 
-`kogito deploy-service travels \https://github.com/kiegroup/kogito-examples/blob/stable/kogito-travel-agency/extended/travels/src/main/resources/org/acme/travels/travels.bpmn2`
+`kogito deploy-service travels \https://github.com/kiegroup/kogito-examples/blob/stable/kogito-quarkus-examples/kogito-travel-agency/extended/travels/src/main/resources/org/acme/travels/travels.bpmn2`
 
 |Delete a {PRODUCT} service.
 |`{PRODUCT_INIT} delete-service __SERVICE_NAME__`
@@ -557,7 +557,7 @@ NOTE: For all deployment options, you must be logged in to the relevant OpenShif
 
 === Git source build and deployment
 
-In most use cases, you can use the standard runtime build and deployment method to deploy {PRODUCT} services on OpenShift from a Git repository source, as shown in the following examples. These examples are based on the https://github.com/kiegroup/kogito-examples/tree/stable/kogito-travel-agency/extended[`kogito-travel-agency`] extended example application.
+In most use cases, you can use the standard runtime build and deployment method to deploy {PRODUCT} services on OpenShift from a Git repository source, as shown in the following examples. These examples are based on the https://github.com/kiegroup/kogito-examples/tree/stable/kogito-quarkus-examples/kogito-travel-agency/extended[`kogito-travel-agency`] extended example application.
 
 .Example {PRODUCT} service deployment from existing namespace
 [source,subs="attributes+,+quotes"]
@@ -566,7 +566,7 @@ In most use cases, you can use the standard runtime build and deployment method 
 $ {PRODUCT_INIT} use-project __PROJECT_NAME__
 
 // Deploys a new {PRODUCT} service from a Git source
-$ {PRODUCT_INIT} deploy-service travels https://github.com/kiegroup/kogito-examples/tree/stable/kogito-travel-agency/extended --context-dir travels
+$ {PRODUCT_INIT} deploy-service travels https://github.com/kiegroup/kogito-examples/tree/stable/kogito-quarkus-examples/kogito-travel-agency/extended --context-dir travels
 ----
 
 The {PRODUCT} Operator uses the default branch in the specified Git repository, usually `master`.
@@ -580,7 +580,7 @@ Alternatively, you can generate a new namespace in your cluster during deploymen
 $ {PRODUCT_INIT} new-project __NEW_PROJECT_NAME__
 
 // Deploys a new {PRODUCT} service from a Git source
-$ {PRODUCT_INIT} deploy-service travels https://github.com/kiegroup/kogito-examples/tree/stable/kogito-travel-agency/extended --context-dir travels
+$ {PRODUCT_INIT} deploy-service travels https://github.com/kiegroup/kogito-examples/tree/stable/kogito-quarkus-examples/kogito-travel-agency/extended --context-dir travels
 ----
 
 NOTE: If you are developing or testing your {PRODUCT} service locally, you can use the binary build or file build option to build and deploy from a local source instead of from a Git repository.
@@ -589,7 +589,7 @@ NOTE: If you are developing or testing your {PRODUCT} service locally, you can u
 
 OpenShift builds can require extensive amounts of time. As a faster alternative for building and deploying your {PRODUCT} services on OpenShift, you can use a binary build. In a binary build, you build the application locally and push the built application to an OpenShift `BuildConfig` configuration to be packaged into the runtime container image.
 
-The following example creates a {PRODUCT} service from a local directory, builds the project binaries, and deploys the binary build to OpenShift. This example is based on the https://github.com/kiegroup/kogito-examples/tree/stable/kogito-travel-agency/extended[`kogito-travel-agency`] extended example application.
+The following example creates a {PRODUCT} service from a local directory, builds the project binaries, and deploys the binary build to OpenShift. This example is based on the https://github.com/kiegroup/kogito-examples/tree/stable/kogito-quarkus-examples/kogito-travel-agency/extended[`kogito-travel-agency`] extended example application.
 
 .Example {PRODUCT} service deployment from binary build
 [source,subs="attributes+,+quotes"]
@@ -627,14 +627,14 @@ You can build and deploy your {PRODUCT} services from a single file, such as a D
 
 NOTE: You cannot upload a file directory from a Git repository. The file directory must be in your local file system. However, you can upload single files from either a Git repository or your local file system.
 
-The following examples upload a single BPMN file from a local directory or Git repository to an OpenShift cluster for an S2I build. These examples are based on the https://github.com/kiegroup/kogito-examples/tree/stable/kogito-travel-agency/extended[`kogito-travel-agency`] extended example application.
+The following examples upload a single BPMN file from a local directory or Git repository to an OpenShift cluster for an S2I build. These examples are based on the https://github.com/kiegroup/kogito-examples/tree/stable/kogito-quarkus-examples/kogito-travel-agency/extended[`kogito-travel-agency`] extended example application.
 
 .Example {PRODUCT} service deployment from a local file
 [source,subs="attributes+,+quotes"]
 ----
-$ kogito deploy-service travels /tmp/kogito-examples/kogito-travel-agency/extended/travels/src/main/resources/org/acme/travels/travels.bpmn2
+$ kogito deploy-service travels /tmp/kogito-examples/kogito-quarkus-examples/kogito-travel-agency/extended/travels/src/main/resources/org/acme/travels/travels.bpmn2
 
-File found: /tmp/kogito-examples/kogito-travel-agency/extended/travels/src/main/resources/org/acme/travels/travels.bpmn2.
+File found: /tmp/kogito-examples/kogito-quarkus-examples/kogito-travel-agency/extended/travels/src/main/resources/org/acme/travels/travels.bpmn2.
 ...
 The requested file(s) was successfully uploaded to OpenShift, a build with this file(s) should now be running. To see the logs, run 'oc logs -f bc/kogito-travel-agency-builder -n kogito'
 ----
@@ -642,7 +642,7 @@ The requested file(s) was successfully uploaded to OpenShift, a build with this 
 .Example {PRODUCT} service deployment from a Git repository file
 [source,subs="attributes+,+quotes"]
 ----
-$ kogito deploy-service travels https://github.com/kiegroup/kogito-examples/blob/stable/kogito-travel-agency/extended/travels/src/main/resources/org/acme/travels/travels.bpmn2
+$ kogito deploy-service travels https://github.com/kiegroup/kogito-examples/blob/stable/kogito-quarkus-examples/kogito-travel-agency/extended/travels/src/main/resources/org/acme/travels/travels.bpmn2
 
 Asset found: travels.bpmn2.
 ...
@@ -665,10 +665,10 @@ The following examples upload multiple files within a local directory to an Open
 .Example {PRODUCT} service deployment from multiple files in a local directory
 [source,subs="attributes+,+quotes"]
 ----
-$ kogito deploy-service travels /tmp/kogito-examples/kogito-travel-agency/extended/travels/src/main/resources/org/acme/travels
+$ kogito deploy-service travels /tmp/kogito-examples/kogito-quarkus-examples/kogito-travel-agency/extended/travels/src/main/resources/org/acme/travels
 
 The provided source is a dir, packing files.
-File(s) found: [/tmp/kogito-examples/kogito-travel-agency/extended/travels/src/main/resources/org/acme/travels/flightBooking.bpmn2 /tmp/kogito-examples/kogito-travel-agency/extended/travels/src/main/resources/org/acme/travels/hotelBooking.bpmn2 /tmp/kogito-examples/kogito-travel-agency/extended/travels/src/main/resources/org/acme/travels/travels.bpmn2].
+File(s) found: [/tmp/kogito-examples/kogito-quarkus-examples/kogito-travel-agency/extended/travels/src/main/resources/org/acme/travels/flightBooking.bpmn2 /tmp/kogito-examples/kogito-quarkus-examples/kogito-travel-agency/extended/travels/src/main/resources/org/acme/travels/hotelBooking.bpmn2 /tmp/kogito-examples/kogito-quarkus-examples/kogito-travel-agency/extended/travels/src/main/resources/org/acme/travels/travels.bpmn2].
 ...
 The requested file(s) was successfully uploaded to OpenShift, a build with this file(s) should now be running. To see the logs, run 'oc logs -f bc/travels-builder -n kogito'
 ----
@@ -679,12 +679,12 @@ If you need to update an uploaded file or directory after you create the build, 
 
 .Example command to re-upload a single local file to update the S2I build
 ----
-$ oc start-build kogito-travel-agency-builder --from-file tmp/kogito-examples/kogito-travel-agency/extended/travels/src/main/resources/org/acme/travels/travels.bpmn2
+$ oc start-build kogito-travel-agency-builder --from-file tmp/kogito-examples/kogito-quarkus-examples/kogito-travel-agency/extended/travels/src/main/resources/org/acme/travels/travels.bpmn2
 ----
 
 .Example command to re-upload multiple files from a local directory to update the S2I build
 ----
-$ oc start-build kogito-travel-agency-builder --from-dir tmp/kogito-examples/kogito-travel-agency/extended/travels/src/main/resources/org/acme/travels
+$ oc start-build kogito-travel-agency-builder --from-dir tmp/kogito-examples/kogito-quarkus-examples/kogito-travel-agency/extended/travels/src/main/resources/org/acme/travels
 ----
 
 If a build fails, use the OpenShift environment variable https://docs.openshift.com/container-platform/4.3/builds/basic-build-operations.html#builds-basic-access-build-verbosity_basic-build-operations[`BUILD_LOGLEVEL`] with the desired level as part of your deployment command, as shown in the following example:
@@ -692,7 +692,7 @@ If a build fails, use the OpenShift environment variable https://docs.openshift.
 .Example command to troubleshoot failed build from directory
 [source]
 ----
-$ kogito --verbose deploy-service travels /tmp/kogito-examples/kogito-travel-agency/extended/travels/src/main/resources/org/acme/travels --build-env BUILD_LOGLEVEL=5
+$ kogito --verbose deploy-service travels /tmp/kogito-examples/kogito-quarkus-examples/kogito-travel-agency/extended/travels/src/main/resources/org/acme/travels --build-env BUILD_LOGLEVEL=5
 ----
 
 ifdef::KOGITO-COMM[]
@@ -708,7 +708,7 @@ For more information about native build performance, see the GraalVM https://www
 
 For more information about ahead-of-time (AOT) compilation, see the https://www.graalvm.org/docs/reference-manual/aot-compilation/[GraalVM Native Image] documentation.
 
-The following examples build a {PRODUCT} service on Quarkus in native mode using the `--native` parameter. These examples are based on the https://github.com/kiegroup/kogito-examples/tree/stable/kogito-travel-agency/extended[`kogito-travel-agency`] extended example application.
+The following examples build a {PRODUCT} service on Quarkus in native mode using the `--native` parameter. These examples are based on the https://github.com/kiegroup/kogito-examples/tree/stable/kogito-quarkus-examples/kogito-travel-agency/extended[`kogito-travel-agency`] extended example application.
 
 .Example {PRODUCT} service native build from a local source directory
 [source,subs="attributes+,+quotes"]
@@ -720,7 +720,7 @@ $ {PRODUCT_INIT} deploy-service travels --native
 .Example {PRODUCT} service native build from a Git repository source directory
 [source,subs="attributes+,+quotes"]
 ----
-$ {PRODUCT_INIT} deploy-service travels https://github.com/kiegroup/kogito-examples/tree/stable/kogito-travel-agency/extended --context-dir travels --native
+$ {PRODUCT_INIT} deploy-service travels https://github.com/kiegroup/kogito-examples/tree/stable/kogito-quarkus-examples/kogito-travel-agency/extended --context-dir travels --native
 ----
 
 In {PRODUCT} Operator tests, native builds take approximately 10 minutes and the build pod can consume up to 10GB of RAM and 1.5 CPU cores.
@@ -729,7 +729,7 @@ By default, a {PRODUCT} project does not contain resource requests or limits. As
 
 For more information about OpenShift pod prioritization based on pod requests and limits, see https://docs.okd.io/3.11/dev_guide/compute_resources.html#quality-of-service-tiers[Quality of Service Tiers] in the OpenShift documentation.
 
-The following example is a memory request configuration for the https://github.com/kiegroup/kogito-examples/tree/stable/kogito-travel-agency/extended[`kogito-travel-agency`] extended example application:
+The following example is a memory request configuration for the https://github.com/kiegroup/kogito-examples/tree/stable/kogito-quarkus-examples/kogito-travel-agency/extended[`kogito-travel-agency`] extended example application:
 
 .Example memory request configuration for `kogito-travel-agency`
 [source,yaml]
@@ -751,11 +751,11 @@ spec:
 
 IMPORTANT: Ensure that you have these resources available on your OpenShift nodes when you run native builds. If the resources are not available, the S2I build fails. You can verify currently allocated and total resources of your nodes by using the command `oc describe nodes` invoked with `admin` permission.
 
-You can limit the maximum heap space for the JVM used for a native build. You can apply the limitation by setting the `quarkus.native.native-image-xmx` property in the `application.properties` file of your {PRODUCT} project. In this case, the build pod requires roughly `-Xmx` plus 2 GB of memory. The `-Xmx` value depends on the complexity of the application. For example, for the https://github.com/kiegroup/kogito-examples/tree/stable/process-quarkus-example[`process-quarkus-example`] example application, the `-Xmx` value `2g` is sufficient, resulting in the builder pod consuming up to 4.2 GB of memory.
+You can limit the maximum heap space for the JVM used for a native build. You can apply the limitation by setting the `quarkus.native.native-image-xmx` property in the `application.properties` file of your {PRODUCT} project. In this case, the build pod requires roughly `-Xmx` plus 2 GB of memory. The `-Xmx` value depends on the complexity of the application. For example, for the https://github.com/kiegroup/kogito-examples/tree/stable/kogito-quarkus-examples/process-quarkus-example[`process-quarkus-example`] example application, the `-Xmx` value `2g` is sufficient, resulting in the builder pod consuming up to 4.2 GB of memory.
 
-You can also set resource limits for a native build pod. In the https://github.com/kiegroup/kogito-examples/tree/stable/process-quarkus-example[`process-quarkus-example`] application, 80 percent of the memory limit is used for heap space in the JVM responsible for the native build. If the computed heap space limit for the JVM is less than 1024 MB, then all the memory from resource limits is used.
+You can also set resource limits for a native build pod. In the https://github.com/kiegroup/kogito-examples/tree/stable/kogito-quarkus-examples/process-quarkus-example[`process-quarkus-example`] application, 80 percent of the memory limit is used for heap space in the JVM responsible for the native build. If the computed heap space limit for the JVM is less than 1024 MB, then all the memory from resource limits is used.
 
-The following example is a memory limit configuration for the https://github.com/kiegroup/kogito-examples/tree/stable/process-quarkus-example[`process-quarkus-example`] example application:
+The following example is a memory limit configuration for the https://github.com/kiegroup/kogito-examples/tree/stable/kogito-quarkus-examples/process-quarkus-example[`process-quarkus-example`] example application:
 
 .Example memory request configuration for `process-quarkus-example`
 [source,yaml]
@@ -1378,7 +1378,7 @@ For example, when you deploy the following {PRODUCT} service, the variables `MP_
 .Example {PRODUCT} service deployment with injected Kafka variable values
 [source]
 ----
-$ kogito deploy-service travels https://github.com/kiegroup/kogito-examples/tree/stable/kogito-travel-agency/extended --context-dir travels --infra kogito-kafka-infra \
+$ kogito deploy-service travels https://github.com/kiegroup/kogito-examples/tree/stable/kogito-quarkus-examples/kogito-travel-agency/extended --context-dir travels --infra kogito-kafka-infra \
 --build-env MAVEN_ARGS_APPEND="-Pevents" \
 -e MP_MESSAGING_INCOMING_TRAVELLERS_BOOTSTRAP_SERVERS
 -e MP_MESSAGING_OUTGOING_PROCESSEDTRAVELLERS_BOOTSTRAP_SERVERS
@@ -1597,7 +1597,7 @@ You can use the {PRODUCT} add-on instead of manually configuring definitions of 
 
 To use the {PRODUCT} Knative add-on to generate the needed YAML files for your custom {PRODUCT} service, you add the YAML file to your `pom.xml` configuration file and compile your project using the Knative profile.
 
-https://github.com/kiegroup/kogito-examples/blob/main/kogito-quarkus-examples/serverless-workflow-order-processing/pom.xml#L105-L127[Example ]
+https://github.com/kiegroup/kogito-examples/blob/main/serverless-workflow-examples/serverless-workflow-order-processing/pom.xml#L105-L127[Example ]
 
 .Procedure
 
@@ -1630,7 +1630,7 @@ https://github.com/kiegroup/kogito-examples/blob/main/kogito-quarkus-examples/se
 </profile>
 ----
 +
-For more information, see https://github.com/kiegroup/kogito-examples/blob/main/kogito-quarkus-examples/serverless-workflow-order-processing/pom.xml#L105-L127[pom.xml example] in the _{PRODUCT} examples_ on GitHub.
+For more information, see https://github.com/kiegroup/kogito-examples/blob/main/serverless-workflow-examples/serverless-workflow-order-processing/pom.xml#L105-L127[pom.xml example] in the _{PRODUCT} examples_ on GitHub.
 
 . To create the `knative.yml` and `kogito.yml` YAML files, enter the following:
 +
@@ -2137,7 +2137,7 @@ Several examples are shipped with {KOGITO}. You can review the code for examples
 === Travel agency tutorial for {PRODUCT} services on OpenShift
 
 [role="_abstract"]
-The https://github.com/kiegroup/kogito-examples/tree/stable/kogito-travel-agency/extended[`kogito-travel-agency`] extended example application in GitHub contains {PRODUCT} services related to travel booking. The purpose of this example application is to help you get started with deploying {PRODUCT} services on {OPENSHIFT}.
+The https://github.com/kiegroup/kogito-examples/tree/stable/kogito-quarkus-examples/kogito-travel-agency/extended[`kogito-travel-agency`] extended example application in GitHub contains {PRODUCT} services related to travel booking. The purpose of this example application is to help you get started with deploying {PRODUCT} services on {OPENSHIFT}.
 
 The example application illustrates many of the configuration options you can use whether you are deploying services locally or on {OPENSHIFT}, such as process persistence with Infinispan, messaging with Apache Kafka, and application data indexing with the {PRODUCT} Data Index Service.
 
@@ -2145,8 +2145,8 @@ For more information about this example application, see the `README` file in th
 
 This tutorial demonstrates the following two related services in the `kogito-travel-agency` extended example application:
 
-* https://github.com/kiegroup/kogito-examples/tree/stable/kogito-travel-agency/extended/travels[`travels`]: Service for booking a trip to a specified destination, including flight and hotel
-* https://github.com/kiegroup/kogito-examples/tree/stable/kogito-travel-agency/extended/visas[`visas`]: Service for managing travel visas, if required
+* https://github.com/kiegroup/kogito-examples/tree/stable/kogito-quarkus-examples/kogito-travel-agency/extended/travels[`travels`]: Service for booking a trip to a specified destination, including flight and hotel
+* https://github.com/kiegroup/kogito-examples/tree/stable/kogito-quarkus-examples/kogito-travel-agency/extended/visas[`visas`]: Service for managing travel visas, if required
 
 The following Business Model and Notation (BPMN) 2.0 process models are the core processes in these services:
 
@@ -2212,8 +2212,8 @@ The cloned `{PRODUCT_INIT}-examples` repository contains various types of {PRODU
 
 For this travel agency tutorial, you need the `kogito-travel-agency` extended example application, which contains the following services:
 
-* https://github.com/kiegroup/kogito-examples/tree/stable/kogito-travel-agency/extended/travels[`travels`]: Service for booking a trip to a specified destination, including flight and hotel
-* https://github.com/kiegroup/kogito-examples/tree/stable/kogito-travel-agency/extended/visas[`visas`]: Service for managing travel visas, if required
+* https://github.com/kiegroup/kogito-examples/tree/stable/kogito-quarkus-examples/kogito-travel-agency/extended/travels[`travels`]: Service for booking a trip to a specified destination, including flight and hotel
+* https://github.com/kiegroup/kogito-examples/tree/stable/kogito-quarkus-examples/kogito-travel-agency/extended/visas[`visas`]: Service for managing travel visas, if required
 
 [id="proc-kogito-travel-agency-configure-ocp_{context}"]
 ==== Configuring access to your OpenShift environment
@@ -2247,7 +2247,7 @@ To set up an example application with {PRODUCT} services for deployment on {OPEN
 You can create the project and install the {PRODUCT} Operator using the OpenShift web console or using the {PRODUCT} CLI. This example uses the {PRODUCT} CLI.
 
 .Procedure
-In a command terminal, enter the following command to create an OpenShift project for the https://github.com/kiegroup/kogito-examples/tree/stable/kogito-travel-agency/extended[`kogito-travel-agency`] extended example application using the {PRODUCT} CLI:
+In a command terminal, enter the following command to create an OpenShift project for the https://github.com/kiegroup/kogito-examples/tree/stable/kogito-quarkus-examples/kogito-travel-agency/extended[`kogito-travel-agency`] extended example application using the {PRODUCT} CLI:
 
 .Creating the OpenShift project
 [source]

--- a/doc-content/kogito-docs/src/main/asciidoc/release-notes/ReleaseNotesKogito.1.15.0.Final/ReleaseNotesKogito.1.15.0.Final.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/release-notes/ReleaseNotesKogito.1.15.0.Final/ReleaseNotesKogito.1.15.0.Final.adoc
@@ -29,7 +29,7 @@ Also, you must set the {PRODUCT} Jobs Service properly, as the Jobs Service is r
 
 In {PRODUCT} 1.15.0, the {PRODUCT} runtime support is expanded to the Serverless Workflow specification by implementing support to Workflow Compensation.
 For more details about its usage see the {SERVERLESS_WORKFLOW_REPO_URL_BASE}/blob/{SERVERLESS_WORKFLOW_VERSION_IN_REPO_URL}/specification.md#workflow-compensation[specification].
-You can also explore the new example https://github.com/kiegroup/kogito-examples/tree/stable/serverless-workflow-compensation-quarkus[serverless-workflow-compensation-quarkus] on how to use compensation in your {PRODUCT} project.
+You can also explore the new example https://github.com/kiegroup/kogito-examples/tree/stable/kogito-quarkus-examples/serverless-workflow-compensation-quarkus[serverless-workflow-compensation-quarkus] on how to use compensation in your {PRODUCT} project.
 
 ////
 == {PRODUCT} Operator and CLI

--- a/doc-content/kogito-docs/src/main/asciidoc/serverless/chap-kogito-orchestrating-serverless.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/serverless/chap-kogito-orchestrating-serverless.adoc
@@ -191,7 +191,7 @@ After the execution of the rule service is complete, the event state specifies t
 
 For more {PRODUCT} examples that use Serverless Workflow, see the following example applications in GitHub:
 
-* https://github.com/kiegroup/kogito-examples/tree/stable/serverless-workflow-events-quarkus[`serverless-workflow-events-quarkus`]: A Serverless Workflow service for processing job applicant approvals and that showcases event-driven services
+* https://github.com/kiegroup/kogito-examples/tree/stable/kogito-quarkus-examples/serverless-workflow-events-quarkus[`serverless-workflow-events-quarkus`]: A Serverless Workflow service for processing job applicant approvals and that showcases event-driven services
 * https://github.com/kiegroup/kogito-examples/tree/stable/serverless-workflow-greeting-quarkus[`serverless-workflow-greeting-quarkus`]: A Serverless Workflow greeting service with both JSON and YAML workflow definitions
 * https://github.com/kiegroup/kogito-examples/tree/stable/serverless-workflow-service-calls-quarkus[`serverless-workflow-service-calls-quarkus`]: A Serverless Workflow service for returning country information
 * https://github.com/kiegroup/kogito-examples/tree/stable/serverless-workflow-github-showcase[`serverless-workflow-github-showcase`]: In this example, a GitHub bot application is deployed, which reacts upon a new PR being opened in a given GitHub project. The bot is implemented using a service and event orchestration approach with {PRODUCT} implementation of the Serverless Workflow specification.

--- a/doc-content/kogito-docs/src/main/asciidoc/test-scenarios/chap-kogito-test-scenarios.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/test-scenarios/chap-kogito-test-scenarios.adoc
@@ -280,8 +280,8 @@ To update and re-run a test scenario, ensure that you save the updated `.scesim`
 
 For example {PRODUCT} services with test scenarios, see the following example applications in GitHub:
 
-* https://github.com/kiegroup/kogito-examples/tree/stable/dmn-quarkus-example[`dmn-quarkus-example`]: Example on Quarkus
-* https://github.com/kiegroup/kogito-examples/tree/stable/dmn-springboot-example[`dmn-springboot-example`]: Example on Spring Boot
+* https://github.com/kiegroup/kogito-examples/tree/stable/kogito-quarkus-examples/dmn-quarkus-example[`dmn-quarkus-example`]: Example on Quarkus
+* https://github.com/kiegroup/kogito-examples/tree/stable/kogito-springboot-examples/dmn-springboot-example[`dmn-springboot-example`]: Example on Spring Boot
 
 [id="proc-test-scenarios-collections_{context}"]
 === Defining list values in test scenarios


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/KOGITO-6884

The examples location in kogito-examples has changed. So, we need to review all the links on the KIE blog and in the following repos:

https://github.com/kiegroup/kogito-runtimes
https://github.com/kiegroup/kogito-examples
https://github.com/kiegroup/kie-docs/tree/main-kogito
[https://github.com/kiegroup/kogito-docs](https://github.com/kiegroup/kogito-examples)