### PR TITLE
BXMSDOC-8590: Partially revert PR 4320 as the additional module does not fix RHPAM-4223

### DIFF
--- a/doc-content/enterprise-only/installation/clustering-kie-server-failover-proc.adoc
+++ b/doc-content/enterprise-only/installation/clustering-kie-server-failover-proc.adoc
@@ -98,7 +98,6 @@ You can configure your cluster to include jobs in the `RUNNING` state, to be req
 ----
     <module name="org.infinispan" services="export"/>
     <module name="org.jgroups" />
-    <module name="org.wildfly.clustering.infinispan.spi" />
 ----
 .. Download the JAR file.
 ... Navigate to the https://access.redhat.com/jbossnetwork/restricted/listSoftware.html[Software Downloads] page in the Red Hat Customer Portal (login required), and select the product and version from the drop-down options:

--- a/doc-content/enterprise-only/installation/clustering-kie-server-failover-proc.adoc
+++ b/doc-content/enterprise-only/installation/clustering-kie-server-failover-proc.adoc
@@ -17,7 +17,7 @@ You can configure your cluster to include jobs in the `RUNNING` state, to be req
 <extension module="org.jboss.as.clustering.infinispan"/>
 <extension module="org.jboss.as.clustering.jgroups"/>
 ----
-.. In the `standalone.xml` file, locate the `<subsystem xmlns="urn:jboss:domain:infinispan:9.0">` subsystem and create a cached container entry named `jbpm` that includes a cache named `nodes` and a cache named `jobs` as shown in the following example:
+.. In the `standalone.xml` file, locate the `<subsystem xmlns="urn:jboss:domain:infinispan:12.0">` subsystem and create a cached container entry named `jbpm` that includes a cache named `nodes` and a cache named `jobs` as shown in the following example:
 +
 [source, xml]
 ----
@@ -35,7 +35,7 @@ You can configure your cluster to include jobs in the `RUNNING` state, to be req
 +
 [source, xml]
 ----
-<subsystem xmlns="urn:jboss:domain:jgroups:7.0">
+<subsystem xmlns="urn:jboss:domain:jgroups:8.0">
     <channels default="ee">
         <channel name="ee" stack="udp" cluster="ejb"/>
     </channels>
@@ -98,6 +98,7 @@ You can configure your cluster to include jobs in the `RUNNING` state, to be req
 ----
     <module name="org.infinispan" services="export"/>
     <module name="org.jgroups" />
+    <module name="org.wildfly.clustering.infinispan.spi" />
 ----
 .. Download the JAR file.
 ... Navigate to the https://access.redhat.com/jbossnetwork/restricted/listSoftware.html[Software Downloads] page in the Red Hat Customer Portal (login required), and select the product and version from the drop-down options:


### PR DESCRIPTION
Note: This only reverts the additional module added to the docs, but I left the other changes related to the subsystem versions as these are still valid.