### PR TITLE
BXMSDOC-8600 Changes for OpenShift 4 and remove CodeReady in Designing your DM architecture - 7.67.x

### DIFF
--- a/doc-content/shared-kie-docs/src/main/asciidoc/KIE/Overview/architecture-scenarios-ref.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/KIE/Overview/architecture-scenarios-ref.adoc
@@ -4,10 +4,10 @@
 The following scenarios illustrate common variations of {PRODUCT} installation, asset authoring, project storage, project deployment, and asset execution in a decision management architecture. Each section summarizes the methods and tools used and the advantages for the given architecture. The examples are basic and are only a few of the many combinations you might consider, depending on your specific goals and needs with {PRODUCT}.
 
 ifdef::DM,PAM[]
-{PRODUCT} authoring and managed server environments on OpenShift with {CENTRAL} and {KIE_SERVER}::
+{PRODUCT} environments on OpenShift with {CENTRAL} and {KIE_SERVER}::
 +
 --
-* *Installation environment*: {PRODUCT} on {OPENSHIFT}, using the `{PRODUCT_INIT}{ENTERPRISE_VERSION_SHORT}-authoring.yaml` and `{PRODUCT_INIT}{ENTERPRISE_VERSION_SHORT}-kieserver.yaml` template files
+* *Installation environment*: {PRODUCT} on {OPENSHIFT}, using the operator to deploy an `{PRODUCT_INIT}-authoring` environment and other types of environment as necessary.
 * *Project storage and build environment*: External Git repository for project versioning synchronized with the {CENTRAL} Git repository using Git hooks, and external Maven repository for project management and building configured with {KIE_SERVER}
 * *Asset-authoring tool*: {CENTRAL}
 * *Main asset types*: Decision Model and Notation (DMN) models for decisions
@@ -72,10 +72,7 @@ endif::[]
 ifdef::DM,PAM[{EAP_LONG}]
 ifdef::DROOLS,JBPM,OP[Wildfly]
 * *Project storage and build environment*: External Git repository for project versioning (not synchronized with {CENTRAL}) and external Maven repository for project management and building configured with {KIE_SERVER}
-* *Asset-authoring tools*: Integrated development environment (IDE), such as
-ifdef::DM,PAM[Red Hat CodeReady Studio,]
-ifdef::DROOLS,JBPM,OP[Eclipse,]
-and a spreadsheet editor or a Decision Model and Notation (DMN) modeling tool for other decision formats
+* *Asset-authoring tools*: Integrated development environment (IDE), such as VSCode, and a spreadsheet editor or a Decision Model and Notation (DMN) modeling tool for other decision formats
 * *Main asset types*:
 ifdef::DM,DROOLS[Drools Rule Language (DRL) rules, spreadsheet decision tables, and Decision Model and Notation (DMN) models for decisions]
 ifdef::PAM,JBPM[Drools Rule Language (DRL) rules, spreadsheet decision tables, and Decision Model and Notation (DMN) models for decisions, and Business Process Model and Notation (BPMN) models for processes]
@@ -100,10 +97,7 @@ endif::[]
 --
 * *Installation environment*: {PRODUCT} libraries embedded within a custom application
 * *Project storage and build environment*: External Git repository for project versioning (not synchronized with {CENTRAL}) and external Maven repository for project management and building configured with your embedded Java application (not configured with {KIE_SERVER})
-* *Asset-authoring tools*: Integrated development environment (IDE), such as
-ifdef::DM,PAM[Red Hat CodeReady Studio,]
-ifdef::DROOLS,JBPM,OP[Eclipse,]
-and a spreadsheet editor or a Decision Model and Notation (DMN) modeling tool for other decision formats
+* *Asset-authoring tools*: Integrated development environment (IDE), such as VSCode, and a spreadsheet editor or a Decision Model and Notation (DMN) modeling tool for other decision formats
 * *Main asset types*:
 ifdef::DM,DROOLS[Drools Rule Language (DRL) rules, spreadsheet decision tables, and Decision Model and Notation (DMN) models for decisions]
 ifdef::PAM,JBPM[Drools Rule Language (DRL) rules, spreadsheet decision tables, and Decision Model and Notation (DMN) models for decisions, and Business Process Model and Notation (BPMN) models for processes]

--- a/doc-content/shared-kie-docs/src/main/asciidoc/KIE/Overview/project-storage-version-build-options-ref.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/KIE/Overview/project-storage-version-build-options-ref.adoc
@@ -103,8 +103,12 @@ endif::[]
 ifdef::DM,PAM[]
 |S2I in OpenShift (container image)
 |If you use {PRODUCT} on {OPENSHIFT}, you can build your {PRODUCT} projects as KJAR files in the typical way or use Source-to-Image (S2I) to build your projects as container images. S2I is a framework and a tool that allows you to write images that use the application source code as an input and produce a new image that runs the assembled application as an output. The main advantage of using the S2I tool for building reproducible container images is the ease of use for developers.
-a|
-https://access.redhat.com/documentation/en-us/openshift_container_platform/3.3/html/creating_images/creating-images-s2i[_Creating Images in OpenShift_]
+
+The {PRODUCT} images build the KJAR files as S2I automatically, using the source from a Git repository that you can specify. You do not need to create scripts or manage an S2I build.
+|
+For the S2I concept: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.10/html/images/creating-images#images-create-s2i_create-images[_Images_] in the {OPENSHIFT} product documentation.
+
+For the operator-based deployment process: {URL_DEPLOYING_ON_OPENSHIFT}#operator-environment-deploy-assy_openshift-operator[_{DEPLOYING_OPENSHIFT_OPERATOR}_]. In the {KIE_SERVER} settings, add a {KIE_SERVER} instance and then click *Set Immutable server configuration* to configure the source Git repository for an S2I deployment.
 endif::[]
 |===
 


### PR DESCRIPTION
* Changes for OpenShift 4 in Decisiong your DM architecture doc

* Clarified S2I

* Replaced CodeReady with VSCode

* Update doc-content/shared-kie-docs/src/main/asciidoc/KIE/Overview/architecture-scenarios-ref.adoc

Co-authored-by: emmurphy1 <30830712+emmurphy1@users.noreply.github.com>

Co-authored-by: emmurphy1 <30830712+emmurphy1@users.noreply.github.com>