### PR TITLE
KOGITO-8061 Fix kogito-spring-boot-archetype name

### DIFF
--- a/doc-content/enterprise-only/getting-started-kogito/proc-kogito-custom-spring-boot-project-creating.adoc
+++ b/doc-content/enterprise-only/getting-started-kogito/proc-kogito-custom-spring-boot-project-creating.adoc
@@ -93,7 +93,7 @@ $ mvn archetype:generate \
     -DgroupId=org.acme -DartifactId=sample-kogito \
     -DarchetypeVersion={KOGITO_VERSION_LONG} \
     -Dversion=1.0-SNAPSHOT
-    -Dstarters=descisions
+    -Dstarters=decisions
     -Daddons=monitoring-prometheus,persistence-infinispan
 ----
 

--- a/doc-content/enterprise-only/getting-started-kogito/proc-kogito-custom-spring-boot-project-creating.adoc
+++ b/doc-content/enterprise-only/getting-started-kogito/proc-kogito-custom-spring-boot-project-creating.adoc
@@ -73,7 +73,7 @@ Starter for providing DRL support to your Spring Boot project. The following is 
 ----
 $ mvn archetype:generate \
     -DarchetypeGroupId=org.kie.kogito \
-    -DarchetypeArtifactId=kogito-springboot-archetype \
+    -DarchetypeArtifactId=kogito-spring-boot-archetype \
     -DgroupId=org.acme -DartifactId=sample-kogito \
     -DarchetypeVersion={KOGITO_VERSION_LONG} \
     -Dversion=1.0-SNAPSHOT
@@ -89,7 +89,7 @@ The new project includes the dependencies required to run the decision microserv
 ----
 $ mvn archetype:generate \
     -DarchetypeGroupId=org.kie.kogito \
-    -DarchetypeArtifactId=kogito-springboot-archetype \
+    -DarchetypeArtifactId=kogito-spring-boot-archetype \
     -DgroupId=org.acme -DartifactId=sample-kogito \
     -DarchetypeVersion={KOGITO_VERSION_LONG} \
     -Dversion=1.0-SNAPSHOT


### PR DESCRIPTION
The archetype was renamed in the past, so the example doesn't work with the old name anymore. 