### PR TITLE
[DROOLS-7195] Modify syntax fails when using executable model, works …

### DIFF
--- a/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes-chapter.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes-chapter.adoc
@@ -6,6 +6,8 @@
 //include::ReleaseNotes/ReleaseNotesDrools.7.24.0.Final/ReleaseNotesDrools.7.24.0.Final-section.adoc[leveloffset=+1]
 //include::{shared-dir}/Workbench/ReleaseNotes/ReleaseNotesWorkbench.7.24.0.Final/ReleaseNotesWorkbench.7.24.0.Final-section.adoc[leveloffset=+1]
 
+include::ReleaseNotes/ReleaseNotesDrools.7.74.0.Final/ReleaseNotesDrools.7.74.0.Final-section.adoc[leveloffset=+1]
+
 include::ReleaseNotes/ReleaseNotesDrools.7.72.0.Final/ReleaseNotesDrools.7.72.0.Final-section.adoc[leveloffset=+1]
 
 include::ReleaseNotes/ReleaseNotesDrools.7.65.0.Final/ReleaseNotesDrools.7.65.0.Final-section.adoc[leveloffset=+1]

--- a/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.7.74.0.Final/ReleaseNotesDrools.7.74.0.Final-section.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.7.74.0.Final/ReleaseNotesDrools.7.74.0.Final-section.adoc
@@ -1,0 +1,5 @@
+[id='drools.releasenotesdrools.7.74.0']
+
+= New and Noteworthy in {PRODUCT} 7.74.0
+
+include::with-statement-is-retired-for-the-executable-model.adoc[leveloffset=+1]

--- a/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.7.74.0.Final/with-statement-is-retired-for-the-executable-model.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.7.74.0.Final/with-statement-is-retired-for-the-executable-model.adoc
@@ -1,0 +1,5 @@
+[id='with-statement-is-retired-for-the-executable-model']
+
+= With statement is retired for the executable model
+
+`with` statement is no longer supported with the executable model. It should be easily rewritten with valid Java syntax.

--- a/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.7.74.0.Final/with-statement-is-retired-for-the-executable-model.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/ReleaseNotes/ReleaseNotesDrools.7.74.0.Final/with-statement-is-retired-for-the-executable-model.adoc
@@ -2,4 +2,4 @@
 
 = With statement is retired for the executable model
 
-`with` statement is no longer supported with the executable model. It should be easily rewritten with valid Java syntax.
+The `with` statement is no longer supported with the executable model. It should be easily rewritten with valid Java syntax.


### PR DESCRIPTION
…with mvel runtime (nested properties)

- As the part of the fix, 'with' statement support is dropped for executable model. So documented in release notes

**JIRA**: 
https://issues.redhat.com/browse/DROOLS-7195

**referenced Pull Requests**: 
https://github.com/kiegroup/drools/pull/4868

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>
