### PR TITLE
Fix links to SW docs

### DIFF
--- a/doc-content/kogito-docs/src/main/asciidoc/release-notes/ReleaseNotesKogito.1.31.0.Final/ReleaseNotesKogito.1.31.0.Final.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/release-notes/ReleaseNotesKogito.1.31.0.Final/ReleaseNotesKogito.1.31.0.Final.adoc
@@ -11,7 +11,7 @@ The following sections describe some of the new features or enhancements in {PRO
 
 === {PRODUCT} Serverless Workflow
 
-https://kiegroup.github.io/kogito-docs/serverlessworkflow/latest/release_notes.html[New features on 1.31].
+https://kiegroup.github.io/kogito-docs/serverlessworkflow/1.31.1.Final/release_notes.html[New features on 1.31].
 
 ==== {PRODUCT} Serverless Workflow Operator
 

--- a/doc-content/kogito-docs/src/main/asciidoc/release-notes/ReleaseNotesKogito.1.31.1.Final/ReleaseNotesKogito.1.31.1.Final.adoc
+++ b/doc-content/kogito-docs/src/main/asciidoc/release-notes/ReleaseNotesKogito.1.31.1.Final/ReleaseNotesKogito.1.31.1.Final.adoc
@@ -11,7 +11,7 @@ The following sections describe some of the new features or enhancements in {PRO
 
 === {PRODUCT} Serverless Workflow
 
-https://kiegroup.github.io/kogito-docs/serverlessworkflow/latest/release_notes.html[New features on 1.31].
+https://kiegroup.github.io/kogito-docs/serverlessworkflow/1.31.1.Final/release_notes.html[New features on 1.31].
 
 == {PRODUCT} supporting services
 


### PR DESCRIPTION
Adding 1.31.1 for both as 1.31.0 doesnt exist aynmore ( 404 )