### PR TITLE
[DROOLS-7276] Fix document : drl functions in a different package can…

### DIFF
--- a/doc-content/drools-docs/src/main/asciidoc/LanguageReference/drl-functions-con.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/LanguageReference/drl-functions-con.adoc
@@ -8,7 +8,7 @@ endif::[]
 
 Functions in DRL files put semantic code in your rule source file instead of in Java classes. Functions are especially useful if an action (`then`) part of a rule is used repeatedly and only the parameters differ for each rule. Above the rules in the DRL file, you can declare the function or import a static method from a helper class as a function, and then use the function by name in an action (`then`) part of the rule.
 
-The following examples illustrate a function that is either declared or imported in a DRL file:
+The following examples illustrate a function that is either declared or an imported static method in a DRL file:
 
 .Example function declaration with a rule (option 1)
 [source]
@@ -25,10 +25,22 @@ rule "Using a function"
 end
 ----
 
-.Example function import with a rule (option 2)
+.Example import a static method of a Java class (option 2)
+[source,java]
+----
+package org.example.applicant;
+
+public class MyFunctions {
+
+    public static String hello(String applicantName) {
+        return "Hello " + applicantName + "!";
+    }
+}
+----
+
 [source]
 ----
-import function my.package.applicant.hello;
+import static org.example.applicant.MyFunctions.hello;
 
 rule "Using a function"
   when
@@ -37,3 +49,8 @@ rule "Using a function"
     System.out.println( hello( "James" ) );
 end
 ----
+
+[NOTE]
+====
+A function declared in a DRL file cannot be imported to a rule in a different package while a Java static method in a different package can be imported.
+====


### PR DESCRIPTION
…not be imported

**JIRA**: 
https://issues.redhat.com/browse/DROOLS-7276

for main -> https://github.com/kiegroup/drools/pull/4926


<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>
