### PR TITLE
Add 'rule order' and 'output order' hit policies

### DIFF
--- a/doc-content/drools-docs/src/main/asciidoc/DMN/dmn-decision-tables-hit-policies-con.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/DMN/dmn-decision-tables-hit-policies-con.adoc
@@ -17,4 +17,4 @@ The following decision table hit policies are supported in DMN:
 ** *Collect Max (C>):* Outputs the maximum value among the matches. The resulting values must be comparable, such as numbers, dates or text (lexicographic order).
 ** *Collect Count (C#):* Outputs the number of matching rules.
 ** *Rule Order (R):* Collects output from multiple rules into list ordered according to rules order. It is very similar as 'Collect' without any aggregation function, however order in final list guaranteed.
-** *Output Order (O):* Collects output from multiple rules into list ordered using same sorting mechanism as 'Priority' hit policy.
+** *Output Order (O):* Collects output from multiple rules into list ordered using the same sorting mechanism as 'Priority' hit policy.

--- a/doc-content/drools-docs/src/main/asciidoc/DMN/dmn-decision-tables-hit-policies-con.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/DMN/dmn-decision-tables-hit-policies-con.adoc
@@ -16,3 +16,5 @@ The following decision table hit policies are supported in DMN:
 ** *Collect Min (C<):* Outputs the minimum value among the matches. The resulting values must be comparable, such as numbers, dates, or text (lexicographic order).
 ** *Collect Max (C>):* Outputs the maximum value among the matches. The resulting values must be comparable, such as numbers, dates or text (lexicographic order).
 ** *Collect Count (C#):* Outputs the number of matching rules.
+** *Rule Order (R):* Collects output from multiple rules into list ordered according to rules order. It is very similar as 'Collect' without any aggregation function, however order in final list guaranteed.
+** *Output Order (O):* Collects output from multiple rules into list ordered using same sorting mechanism as 'Priority' hit policy.

--- a/doc-content/drools-docs/src/main/asciidoc/DMN/dmn-decision-tables-hit-policies-con.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/DMN/dmn-decision-tables-hit-policies-con.adoc
@@ -16,5 +16,5 @@ The following decision table hit policies are supported in DMN:
 ** *Collect Min (C<):* Outputs the minimum value among the matches. The resulting values must be comparable, such as numbers, dates, or text (lexicographic order).
 ** *Collect Max (C>):* Outputs the maximum value among the matches. The resulting values must be comparable, such as numbers, dates or text (lexicographic order).
 ** *Collect Count (C#):* Outputs the number of matching rules.
-** *Rule Order (R):* Collects output from multiple rules into list ordered according to rules order. It is very similar as 'Collect' without any aggregation function, however order in final list guaranteed.
+** *Rule Order (R):* Collects output from multiple rules into list ordered according to rules order. It is very similar as 'Collect' without any aggregation function, but with explicit consistent ordering in the final list as defined in the table.
 ** *Output Order (O):* Collects output from multiple rules into list ordered using the same sorting mechanism as 'Priority' hit policy.


### PR DESCRIPTION
**Thank you for submitting this pull request**

This PR is slightly related to changes in kie tooling. That will have 'self-contained' hit policies documentation from now on

* https://github.com/tiagobento/kie-tools/pull/68

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>
